### PR TITLE
add node resources filters to farms list

### DIFF
--- a/grid-proxy/docs/docs.go
+++ b/grid-proxy/docs/docs.go
@@ -229,6 +229,24 @@ const docTemplate = `{
                         "description": "farm stellar_address",
                         "name": "stellar_address",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Min free reservable mru for at least a single node that belongs to the farm, in bytes",
+                        "name": "node_free_mru",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Min free reservable hru for at least a single node that belongs to the farm, in bytes",
+                        "name": "node_free_hru",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Min free reservable sru for at least a single node that belongs to the farm, in bytes",
+                        "name": "node_free_sru",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/grid-proxy/docs/swagger.json
+++ b/grid-proxy/docs/swagger.json
@@ -221,6 +221,24 @@
                         "description": "farm stellar_address",
                         "name": "stellar_address",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Min free reservable mru for at least a single node that belongs to the farm, in bytes",
+                        "name": "node_free_mru",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Min free reservable hru for at least a single node that belongs to the farm, in bytes",
+                        "name": "node_free_hru",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Min free reservable sru for at least a single node that belongs to the farm, in bytes",
+                        "name": "node_free_sru",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/grid-proxy/docs/swagger.yaml
+++ b/grid-proxy/docs/swagger.yaml
@@ -400,6 +400,21 @@ paths:
         in: query
         name: stellar_address
         type: string
+      - description: Min free reservable mru for at least a single node that belongs
+          to the farm, in bytes
+        in: query
+        name: node_free_mru
+        type: integer
+      - description: Min free reservable hru for at least a single node that belongs
+          to the farm, in bytes
+        in: query
+        name: node_free_hru
+        type: integer
+      - description: Min free reservable sru for at least a single node that belongs
+          to the farm, in bytes
+        in: query
+        name: node_free_sru
+        type: integer
       produces:
       - application/json
       responses:

--- a/grid-proxy/internal/explorer/helpers.go
+++ b/grid-proxy/internal/explorer/helpers.go
@@ -186,6 +186,9 @@ func (a *App) handleFarmRequestsQueryParams(r *http.Request) (types.FarmFilter, 
 		"pricing_policy_id": &filter.PricingPolicyID,
 		"farm_id":           &filter.FarmID,
 		"twin_id":           &filter.TwinID,
+		"node_free_mru":     &filter.NodeFreeMRU,
+		"node_free_hru":     &filter.NodeFreeHRU,
+		"node_free_sru":     &filter.NodeFreeSRU,
 	}
 	strs := map[string]**string{
 		"name":               &filter.Name,

--- a/grid-proxy/internal/explorer/server.go
+++ b/grid-proxy/internal/explorer/server.go
@@ -45,6 +45,9 @@ const (
 // @Param certification_type query string false "certificate type Diy or Certified"
 // @Param dedicated query bool false "farm is dedicated"
 // @Param stellar_address query string false "farm stellar_address"
+// @Param node_free_mru query int false "Min free reservable mru for at least a single node that belongs to the farm, in bytes"
+// @Param node_free_hru query int false "Min free reservable hru for at least a single node that belongs to the farm, in bytes"
+// @Param node_free_sru query int false "Min free reservable sru for at least a single node that belongs to the farm, in bytes"
 // @Success 200 {object} []types.Farm
 // @Failure 400 {object} string
 // @Failure 500 {object} string

--- a/grid-proxy/pkg/client/utils.go
+++ b/grid-proxy/pkg/client/utils.go
@@ -166,6 +166,15 @@ func farmParams(filter types.FarmFilter, limit types.Limit) string {
 	if limit.Randomize {
 		fmt.Fprintf(&builder, "randomize=true&")
 	}
+	if filter.NodeFreeMRU != nil && *filter.NodeFreeMRU != 0 {
+		fmt.Fprintf(&builder, "node_free_mru=%d&", *filter.NodeFreeMRU)
+	}
+	if filter.NodeFreeHRU != nil && *filter.NodeFreeHRU != 0 {
+		fmt.Fprintf(&builder, "node_free_hru=%d&", *filter.NodeFreeHRU)
+	}
+	if filter.NodeFreeSRU != nil && *filter.NodeFreeSRU != 0 {
+		fmt.Fprintf(&builder, "node_free_sru=%d&", *filter.NodeFreeSRU)
+	}
 
 	res := builder.String()
 	// pop the extra ? or &

--- a/grid-proxy/pkg/types/types.go
+++ b/grid-proxy/pkg/types/types.go
@@ -123,6 +123,9 @@ type FarmFilter struct {
 	NameContains      *string
 	CertificationType *string
 	Dedicated         *bool
+	NodeFreeMRU       *uint64
+	NodeFreeHRU       *uint64
+	NodeFreeSRU       *uint64
 }
 
 // TwinFilter twin filters

--- a/grid-proxy/tests/queries/farm_test.go
+++ b/grid-proxy/tests/queries/farm_test.go
@@ -89,6 +89,43 @@ func TestFarm(t *testing.T) {
 			assert.NoError(t, err, serializeFarmsFilter(f))
 		}
 	})
+	t.Run("farms list node free hru", func(t *testing.T) {
+		aggNode := calcNodesAggregates(&data)
+		l := proxytypes.Limit{
+			Size:     999999999999,
+			Page:     1,
+			RetCount: false,
+		}
+		filter := proxytypes.FarmFilter{
+			NodeFreeHRU: &aggNode.maxFreeHRU,
+		}
+		localFarms, _, err := localClient.Farms(filter, l)
+		assert.NoError(t, err)
+		remoteFarms, _, err := proxyClient.Farms(filter, l)
+		assert.NoError(t, err)
+
+		err = validateFarmsResults(localFarms, remoteFarms)
+		assert.NoError(t, err, serializeFarmsFilter(filter))
+	})
+	t.Run("farms list node free hru, mru", func(t *testing.T) {
+		aggNode := calcNodesAggregates(&data)
+		l := proxytypes.Limit{
+			Size:     999999999999,
+			Page:     1,
+			RetCount: false,
+		}
+		filter := proxytypes.FarmFilter{
+			NodeFreeHRU: &aggNode.maxFreeHRU,
+			NodeFreeMRU: &aggNode.maxFreeMRU,
+		}
+		localFarms, _, err := localClient.Farms(filter, l)
+		assert.NoError(t, err)
+		remoteFarms, _, err := proxyClient.Farms(filter, l)
+		assert.NoError(t, err)
+
+		err = validateFarmsResults(localFarms, remoteFarms)
+		assert.NoError(t, err, serializeFarmsFilter(filter))
+	})
 }
 
 func calcFarmsAggregates(data *DBData) (res FarmsAggregate) {

--- a/grid-proxy/tests/queries/local_client.go
+++ b/grid-proxy/tests/queries/local_client.go
@@ -498,7 +498,34 @@ func farmSatisfies(data *DBData, farm farm, f proxytypes.FarmFilter) bool {
 	if f.Dedicated != nil && *f.Dedicated != farm.dedicated_farm {
 		return false
 	}
+	if f.NodeFreeHRU != nil || f.NodeFreeMRU != nil || f.NodeFreeSRU != nil {
+		if !satisfyFarmResourceFilter(farm, data, f) {
+			return false
+		}
+	}
 	return true
+}
+
+func satisfyFarmResourceFilter(farm farm, data *DBData, f proxytypes.FarmFilter) bool {
+	for _, val := range data.nodes {
+		if val.farm_id != farm.farm_id {
+			continue
+		}
+		total := data.nodeTotalResources[val.node_id]
+		used := data.nodeUsedResources[val.node_id]
+		free := calcFreeResources(total, used)
+		if f.NodeFreeHRU != nil && free.hru < *f.NodeFreeHRU {
+			continue
+		}
+		if f.NodeFreeMRU != nil && free.mru < *f.NodeFreeMRU {
+			continue
+		}
+		if f.NodeFreeSRU != nil && free.sru < *f.NodeFreeSRU {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func rentContractsSatisfies(contract rent_contract, f proxytypes.ContractFilter) bool {


### PR DESCRIPTION
### Description

Add filters to allow filtering farms based on the free resources of the nodes in that farm.
Original PR: https://github.com/threefoldtech/tfgridclient_proxy/pull/321


### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-go/issues/41

### Checklist

- [x] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
