### PR TITLE
Fixing Makefile's start script

### DIFF
--- a/grid-proxy/Makefile
+++ b/grid-proxy/Makefile
@@ -42,7 +42,7 @@ db-stop: ## Stop the database container if running
 		docker stop postgres; \
 	fi
 
-start: ## Start the proxy server
+server-start: ## Start the proxy server			(Args: `m=<MNEMONICS>`)
 	@go run cmds/proxy_server/main.go \
 		-no-cert \
 		--address :8080 \
@@ -50,9 +50,10 @@ start: ## Start the proxy server
 		--postgres-host $(PQ_HOST) \
 		--postgres-db tfgrid-graphql \
 		--postgres-password postgres \
-		--postgres-user postgres
+		--postgres-user postgres \
+		--mnemonics "$(m)" ;
 
-restart: db-stop db-start sleep db-fill start ## Full start of the database and the server
+all-start: db-stop db-start sleep db-fill server-start ## Full start of the database and the server (Args: `m=<MNEMONICS>`)
 
 sleep:
 	@sleep 5

--- a/grid-proxy/README.md
+++ b/grid-proxy/README.md
@@ -83,7 +83,7 @@ To start the services for development or testing make sure first you have all th
 - For a quick test explorer server.
   
   ```bash
-   make restart
+   make all-start e=<MNEMONICS>
   ```
 
   Now you can access the server at [:8080](http://loaclhost:8080)


### PR DESCRIPTION
### Description

Fixing issue #86 

### Changes

- Add arg for mnemonics to start script
- Rename target `start` -> `server-start`
- Rename target `restart` -> `all-start`
- Update README.md

### Related Issues

- #86 

