### PR TITLE
Changing image/chart name and version

### DIFF
--- a/.github/workflows/gridproxy-release.yml
+++ b/.github/workflows/gridproxy-release.yml
@@ -35,7 +35,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/threefoldtech/grid-proxy
+          images: ghcr.io/threefoldtech/tfgridproxy
           tags: |
             type=semver,pattern={{raw}}
 

--- a/grid-proxy/charts/gridproxy/Chart.yaml
+++ b/grid-proxy/charts/gridproxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: gridproxy
+name: tfgridproxy
 description: A Helm chart for grid proxy server
 
 # A chart can be either an 'application' or a 'library' chart.
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v1.8.0-rc3
+appVersion: v0.3.0

--- a/grid-proxy/charts/gridproxy/values.yaml
+++ b/grid-proxy/charts/gridproxy/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/threefoldtech/gridproxy
+  repository: ghcr.io/threefoldtech/tfgridproxy
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   # the image tag is the same as `appVersion` in Chart.yaml


### PR DESCRIPTION
### Description

- change image name to `tfgridproxy`
- change chart name to `tfgridproxy`
- appVersion to `v0.3.0`
- change gridproxy release workflow to push image to `ghcr.io/threefoldtech/tfgridproxy`