### PR TITLE
Fixing (would clobber existing tag) workflow error

### DIFF
--- a/.github/workflows/gridproxy-release.yml
+++ b/.github/workflows/gridproxy-release.yml
@@ -18,12 +18,6 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v3.5.2
 
-      - name: "Get Previous tag"
-        id: previoustag
-        uses: actions-ecosystem/action-get-latest-tag@v1
-        with:
-          fallback: latest # Optional fallback tag to use when no tag can be found
-
       - name: Log in to the Container registry
         uses: docker/login-action@v2.1.0
         with:

--- a/.github/workflows/gridproxy-release.yml
+++ b/.github/workflows/gridproxy-release.yml
@@ -41,4 +41,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            version=${{ steps.previoustag.outputs.tag }}
+            version=${{ steps.meta.outputs.tags }}

--- a/.github/workflows/gridproxy-release.yml
+++ b/.github/workflows/gridproxy-release.yml
@@ -41,4 +41,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            version=${{ steps.meta.outputs.tags }}
+            version=${{ steps.meta.outputs.tags[0] }}
+      - name: Debugging
+        run: echo ${{ steps.meta.outputs.tags[0] }}


### PR DESCRIPTION
### Description

- Remove the get-latest-tag-action from the workflow as it was causing an error when the workflow trigger.
- this step output wasn't used anyway in the workflow.

### Issues

- https://github.com/threefoldtech/tfgrid-sdk-go/issues/114

