### PR TITLE
Get the release tag from github context

### DIFF
--- a/.github/workflows/gridproxy-release.yml
+++ b/.github/workflows/gridproxy-release.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
-          context: "grid-proxy"
+          context: .
+          file: ./grid-proxy/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/gridproxy-release.yml
+++ b/.github/workflows/gridproxy-release.yml
@@ -40,7 +40,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          #  For workflows triggered by release, `github.ref_name` is the short name for the release tag created.
           build-args: |
-            version=${{ steps.meta.outputs.tags[0] }}
-      - name: Debugging
-        run: echo ${{ steps.meta.outputs.tags[0] }}
+            version=${{ github.ref_name	 }}

--- a/.github/workflows/gridproxy-release.yml
+++ b/.github/workflows/gridproxy-release.yml
@@ -1,6 +1,7 @@
 name: proxy release Create and publish a Docker image
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/grid-proxy/Dockerfile
+++ b/grid-proxy/Dockerfile
@@ -4,8 +4,8 @@ ENV CGO_ENABLED=0
 
 WORKDIR /src
 
-ADD . /src
-
+ADD grid-proxy /src
+ADD rmb-sdk-go /rmb-sdk-go
 ARG version
 
 RUN cd /src/cmds/proxy_server &&\
@@ -19,7 +19,7 @@ COPY --from=builder /src/cmds/proxy_server/gridrest /usr/bin/gridrest
 RUN wget https://github.com/threefoldtech/zinit/releases/download/v0.2.10/zinit -O /sbin/zinit \
     && chmod +x /sbin/zinit
 
-COPY rootfs /
+COPY grid-proxy/rootfs /
 
 ENV SERVER_PORT=":443"
 ENV POSTGRES_HOST="postgres"


### PR DESCRIPTION
### Description

- Fixing the release workflow for GridProxy and getting the release tag from [GitHub context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) 
- Fixing issue #74 
 
