### PR TITLE
gridproxy: add `standby` node status

### DIFF
--- a/grid-proxy/cmds/proxy_server/main.go
+++ b/grid-proxy/cmds/proxy_server/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/explorer"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/explorer/db"
 	logging "github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg"
-	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go"
+	rmb "github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go"
 	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go/direct"
 )
 

--- a/grid-proxy/internal/explorer/converters.go
+++ b/grid-proxy/internal/explorer/converters.go
@@ -10,12 +10,16 @@ import (
 	"github.com/threefoldtech/zos/pkg/gridtypes"
 )
 
+const (
+	nodeUpInterval = -3 * time.Hour
+)
+
 func decideNodeStatus(power types.NodePower, updatedAt int64) string {
 	if power.Target == "Down" { // off or powering off
 		return "standby"
 	} else if power.Target == "Up" && power.State == "Down" { // powering on
 		return "down"
-	} else if updatedAt >= time.Now().Add(-3*time.Hour).Unix() {
+	} else if updatedAt >= time.Now().Add(nodeUpInterval).Unix() {
 		return "up"
 	} else {
 		return "down"

--- a/grid-proxy/internal/explorer/converters.go
+++ b/grid-proxy/internal/explorer/converters.go
@@ -10,6 +10,18 @@ import (
 	"github.com/threefoldtech/zos/pkg/gridtypes"
 )
 
+func decideNodeStatus(power types.NodePower, updatedAt int64) string {
+	if power.Target == "Down" { // off or powering off
+		return "standby"
+	} else if power.Target == "Up" && power.State == "Down" { // powering on
+		return "down"
+	} else if updatedAt >= time.Now().Add(-3*time.Hour).Unix() {
+		return "up"
+	} else {
+		return "down"
+	}
+}
+
 func nodeFromDBNode(info db.Node) types.Node {
 	node := types.Node{
 		ID:              info.ID,
@@ -53,12 +65,9 @@ func nodeFromDBNode(info db.Node) types.Node {
 		RentContractID:    uint(info.RentContractID),
 		RentedByTwinID:    uint(info.RentedByTwinID),
 		SerialNumber:      info.SerialNumber,
+		Power:             types.NodePower(info.Power),
 	}
-	if node.UpdatedAt >= time.Now().Add(-3*time.Hour).Unix() {
-		node.Status = "up"
-	} else {
-		node.Status = "down"
-	}
+	node.Status = decideNodeStatus(node.Power, node.UpdatedAt)
 	return node
 }
 
@@ -125,12 +134,9 @@ func nodeWithNestedCapacityFromDBNode(info db.Node) types.NodeWithNestedCapacity
 		RentContractID:    uint(info.RentContractID),
 		RentedByTwinID:    uint(info.RentedByTwinID),
 		SerialNumber:      info.SerialNumber,
+		Power:             types.NodePower(info.Power),
 	}
-	if node.UpdatedAt >= time.Now().Add(-3*time.Hour).Unix() {
-		node.Status = "up"
-	} else {
-		node.Status = "down"
-	}
+	node.Status = decideNodeStatus(node.Power, node.UpdatedAt)
 	return node
 }
 

--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -238,7 +238,7 @@ func (d *PostgresDatabase) GetCounters(filter types.StatsFilter) (types.Counters
 	return counters, nil
 }
 
-// custom decoding for jsonb filed. executed while scanning the node.
+// Scan is a custom decoder for jsonb filed. executed while scanning the node.
 func (np *NodePower) Scan(value interface{}) error {
 	if value == nil {
 		return nil

--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -154,7 +154,7 @@ func decideNodeStatusCondition(status *string) string {
 				OR node.updated_at IS NULL
 				OR node.power->> 'target' = 'Up' AND node.power->> 'state' = 'Down'`, nodeUpInterval)
 		} else if *status == "standby" {
-			condition = fmt.Sprintf(`node.power->> 'target' = 'Down'`)
+			condition = fmt.Sprint(`node.power->> 'target' = 'Down'`)
 		}
 	}
 	return condition

--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -154,7 +154,7 @@ func decideNodeStatusCondition(status *string) string {
 				OR node.updated_at IS NULL
 				OR node.power->> 'target' = 'Up' AND node.power->> 'state' = 'Down'`, nodeUpInterval)
 		} else if *status == "standby" {
-			condition = fmt.Sprint(`node.power->> 'target' = 'Down'`)
+			condition = `node.power->> 'target' = 'Down'`
 		}
 	}
 	return condition

--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -141,6 +142,24 @@ func (d *PostgresDatabase) initialize() error {
 	return res.Error
 }
 
+func decideNodeStatusCondition(status *string) string {
+	condition := "TRUE"
+	if status != nil {
+		nodeUpInterval := time.Now().Unix() - nodeStateFactor*int64(reportInterval.Seconds())
+
+		if *status == "up" {
+			condition = fmt.Sprintf(`node.updated_at >= %d`, nodeUpInterval)
+		} else if *status == "down" {
+			condition = fmt.Sprintf(`node.updated_at < %d 
+				OR node.updated_at IS NULL
+				OR node.power->> 'target' = 'Up' AND node.power->> 'state' = 'Down'`, nodeUpInterval)
+		} else if *status == "standby" {
+			condition = fmt.Sprintf(`node.power->> 'target' = 'Down'`)
+		}
+	}
+	return condition
+}
+
 // GetCounters returns aggregate info about the grid
 func (d *PostgresDatabase) GetCounters(filter types.StatsFilter) (types.Counters, error) {
 	var counters types.Counters
@@ -167,15 +186,7 @@ func (d *PostgresDatabase) GetCounters(filter types.StatsFilter) (types.Counters
 		return counters, errors.Wrap(res.Error, "couldn't get farm count")
 	}
 
-	condition := "TRUE"
-	if filter.Status != nil {
-		nodeUpInterval := time.Now().Unix() - nodeStateFactor*int64(reportInterval.Seconds())
-		if *filter.Status == "up" {
-			condition = fmt.Sprintf(`node.updated_at >= %d`, nodeUpInterval)
-		} else if *filter.Status == "down" {
-			condition = fmt.Sprintf(`node.updated_at < %d`, nodeUpInterval)
-		}
-	}
+	condition := decideNodeStatusCondition(filter.Status)
 
 	if res := d.gormDB.
 		Table("node").
@@ -223,6 +234,17 @@ func (d *PostgresDatabase) GetCounters(filter types.StatsFilter) (types.Counters
 	}
 	counters.NodesDistribution = nodesDistribution
 	return counters, nil
+}
+
+func (np *NodePower) Scan(value interface{}) error {
+	// custom decoding for jsonb filed. executed while scanning the node.
+	if value == nil {
+		return nil
+	}
+	if data, ok := value.([]byte); ok {
+		return json.Unmarshal(data, np)
+	}
+	return fmt.Errorf("failed to unmarshal NodePower")
 }
 
 // GetNode returns node info
@@ -342,6 +364,7 @@ func (d *PostgresDatabase) nodeTableQuery() *gorm.DB {
 			"node.serial_number",
 			"convert_to_decimal(location.longitude) as longitude",
 			"convert_to_decimal(location.latitude) as latitude",
+			"node.power",
 		).
 		Joins(
 			"LEFT JOIN nodes_resources_view ON node.node_id = nodes_resources_view.node_id",
@@ -364,15 +387,10 @@ func (d *PostgresDatabase) nodeTableQuery() *gorm.DB {
 func (d *PostgresDatabase) GetNodes(filter types.NodeFilter, limit types.Limit) ([]Node, uint, error) {
 	q := d.nodeTableQuery()
 	q = q.Session(&gorm.Session{Logger: logger.Default.LogMode(logger.Silent)})
-	if filter.Status != nil {
-		// TODO: this shouldn't be in db
-		threshold := time.Now().Unix() - nodeStateFactor*int64(reportInterval.Seconds())
-		if *filter.Status == "down" {
-			q = q.Where("node.updated_at < ? OR node.updated_at IS NULL", threshold)
-		} else {
-			q = q.Where("node.updated_at >= ?", threshold)
-		}
-	}
+
+	condition := decideNodeStatusCondition(filter.Status)
+	q = q.Where(condition)
+
 	if filter.FreeMRU != nil {
 		q = q.Where("nodes_resources_view.free_mru >= ?", *filter.FreeMRU)
 	}

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -63,6 +63,12 @@ type Node struct {
 	SerialNumber    string
 	Longitude       *float64
 	Latitude        *float64
+	Power           NodePower `gorm:"column:power;type:jsonb"`
+}
+
+type NodePower struct {
+	State  string `json:"state"`
+	Target string `json:"target"`
 }
 
 // Farm data about a farm which is calculated from the chain

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -63,9 +63,10 @@ type Node struct {
 	SerialNumber    string
 	Longitude       *float64
 	Latitude        *float64
-	Power           NodePower `gorm:"column:power;type:jsonb"`
+	Power           NodePower
 }
 
+// NodePower is the farmerbot status for the node
 type NodePower struct {
 	State  string `json:"state"`
 	Target string `json:"target"`

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -66,7 +66,7 @@ type Node struct {
 	Power           NodePower `gorm:"type:jsonb"`
 }
 
-// NodePower is the farmerbot status for the node
+// NodePower struct is the farmerbot report for node status
 type NodePower struct {
 	State  string `json:"state"`
 	Target string `json:"target"`

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -63,7 +63,7 @@ type Node struct {
 	SerialNumber    string
 	Longitude       *float64
 	Latitude        *float64
-	Power           NodePower
+	Power           NodePower `gorm:"type:jsonb"`
 }
 
 // NodePower is the farmerbot status for the node

--- a/grid-proxy/internal/explorer/models.go
+++ b/grid-proxy/internal/explorer/models.go
@@ -3,11 +3,11 @@ package explorer
 import (
 	"encoding/json"
 
-	"github.com/patrickmn/go-cache"
+	cache "github.com/patrickmn/go-cache"
 	"github.com/pkg/errors"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/explorer/db"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
-	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go"
+	rmb "github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go"
 )
 
 // ErrNodeNotFound creates new error type to define node existence or server problem

--- a/grid-proxy/internal/explorer/server.go
+++ b/grid-proxy/internal/explorer/server.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/patrickmn/go-cache"
+	cache "github.com/patrickmn/go-cache"
 	"github.com/rs/zerolog/log"
 	httpSwagger "github.com/swaggo/http-swagger"
 
@@ -17,7 +17,7 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/explorer/db"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/explorer/mw"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
-	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go"
+	rmb "github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go"
 )
 
 const (

--- a/grid-proxy/pkg/client/retrying_grid_client.go
+++ b/grid-proxy/pkg/client/retrying_grid_client.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/cenkalti/backoff/v3"
+	backoff "github.com/cenkalti/backoff/v3"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
 )
 

--- a/grid-proxy/pkg/types/types.go
+++ b/grid-proxy/pkg/types/types.go
@@ -156,6 +156,11 @@ type Location struct {
 	Latitude  *float64 `json:"latitude"`
 }
 
+type NodePower struct {
+	State  string `json:"state"`
+	Target string `json:"target"`
+}
+
 // Node is a struct holding the data for a Node for the nodes view
 type Node struct {
 	ID                string       `json:"id"`
@@ -179,6 +184,7 @@ type Node struct {
 	RentContractID    uint         `json:"rentContractId"`
 	RentedByTwinID    uint         `json:"rentedByTwinId"`
 	SerialNumber      string       `json:"serialNumber"`
+	Power             NodePower    `json:"power"`
 }
 
 // CapacityResult is the NodeData capacity results to unmarshal json in it
@@ -209,6 +215,7 @@ type NodeWithNestedCapacity struct {
 	RentContractID    uint           `json:"rentContractId"`
 	RentedByTwinID    uint           `json:"rentedByTwinId"`
 	SerialNumber      string         `json:"serialNumber"`
+	Power             NodePower      `json:"power"`
 }
 
 type Twin struct {

--- a/grid-proxy/pkg/types/types.go
+++ b/grid-proxy/pkg/types/types.go
@@ -156,6 +156,7 @@ type Location struct {
 	Latitude  *float64 `json:"latitude"`
 }
 
+// NodePower is the farmerbot status for the node
 type NodePower struct {
 	State  string `json:"state"`
 	Target string `json:"target"`

--- a/grid-proxy/pkg/types/types.go
+++ b/grid-proxy/pkg/types/types.go
@@ -156,7 +156,7 @@ type Location struct {
 	Latitude  *float64 `json:"latitude"`
 }
 
-// NodePower is the farmerbot status for the node
+// NodePower struct is the farmerbot report for node status
 type NodePower struct {
 	State  string `json:"state"`
 	Target string `json:"target"`

--- a/grid-proxy/tests/queries/loader.go
+++ b/grid-proxy/tests/queries/loader.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"database/sql"
-	"fmt"
 	"math"
 
 	"github.com/threefoldtech/zos/pkg/gridtypes"
@@ -35,7 +34,7 @@ type DBData struct {
 func loadNodes(db *sql.DB, data *DBData) error {
 	rows, err := db.Query(`
 	SELECT
-		id,
+		COALESCE(id, ''),
 		COALESCE(grid_version, 0),
 		COALESCE(node_id, 0),
 		COALESCE(farm_id, 0),
@@ -82,15 +81,6 @@ func loadNodes(db *sql.DB, data *DBData) error {
 		); err != nil {
 			return err
 		}
-		if &node.id == nil {
-			node.id = ""
-		}
-		// if node.power == (nodePower{}) {
-		// 	node.power = nodePower{
-		// 		state: "Down",
-		// 		target: "Down",
-		// 	}
-		// }
 		data.nodes[node.node_id] = node
 		data.nodeIDMap[node.id] = node.node_id
 	}
@@ -502,7 +492,6 @@ func load(db *sql.DB) (DBData, error) {
 		db:                  db,
 	}
 	if err := loadNodes(db, &data); err != nil {
-		fmt.Println("Err loading nodes")
 		return data, err
 	}
 	if err := loadFarms(db, &data); err != nil {

--- a/grid-proxy/tests/queries/local_client.go
+++ b/grid-proxy/tests/queries/local_client.go
@@ -3,6 +3,7 @@ package main
 import (
 	"sort"
 	"strings"
+	"time"
 
 	proxyclient "github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/client"
 	proxytypes "github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
@@ -25,6 +26,18 @@ func (g *GridProxyClientimpl) Ping() error {
 	return nil
 }
 
+func decideNodeStatus(power nodePower, updatedAt uint64) string {
+	if power.Target == "Down" { // off or powering off
+		return "standby"
+	} else if power.Target == "Up" && power.State == "Down" { // powering on
+		return "down"
+	} else if int64(updatedAt) >= time.Now().Add(-3*time.Hour).Unix() {
+		return "up"
+	} else {
+		return "down"
+	}
+}
+
 // Nodes returns nodes with the given filters and pagination parameters
 func (g *GridProxyClientimpl) Nodes(filter proxytypes.NodeFilter, limit proxytypes.Limit) (res []proxytypes.Node, totalCount int, err error) {
 	if limit.Page == 0 {
@@ -35,10 +48,7 @@ func (g *GridProxyClientimpl) Nodes(filter proxytypes.NodeFilter, limit proxytyp
 	}
 	for _, node := range g.data.nodes {
 		if nodeSatisfies(&g.data, node, filter) {
-			status := STATUS_DOWN
-			if isUp(node.updated_at) {
-				status = STATUS_UP
-			}
+			status := decideNodeStatus(node.power, node.updated_at)
 			res = append(res, proxytypes.Node{
 				ID:              node.id,
 				NodeID:          int(node.node_id),
@@ -80,6 +90,10 @@ func (g *GridProxyClientimpl) Nodes(filter proxytypes.NodeFilter, limit proxytyp
 				RentedByTwinID:    uint(g.data.nodeRentedBy[node.node_id]),
 				RentContractID:    uint(g.data.nodeRentContractID[node.node_id]),
 				SerialNumber:      node.serial_number,
+				Power: proxytypes.NodePower{
+					State:  node.power.State,
+					Target: node.power.Target,
+				},
 			})
 		}
 	}
@@ -277,10 +291,7 @@ func (g *GridProxyClientimpl) Twins(filter proxytypes.TwinFilter, limit proxytyp
 }
 func (g *GridProxyClientimpl) Node(nodeID uint32) (res proxytypes.NodeWithNestedCapacity, err error) {
 	node := g.data.nodes[uint64(nodeID)]
-	status := STATUS_DOWN
-	if isUp(node.updated_at) {
-		status = STATUS_UP
-	}
+	status := decideNodeStatus(node.power, node.updated_at)
 	res = proxytypes.NodeWithNestedCapacity{
 		ID:              node.id,
 		NodeID:          int(node.node_id),
@@ -324,16 +335,17 @@ func (g *GridProxyClientimpl) Node(nodeID uint32) (res proxytypes.NodeWithNested
 		RentedByTwinID:    uint(g.data.nodeRentedBy[node.node_id]),
 		RentContractID:    uint(g.data.nodeRentContractID[node.node_id]),
 		SerialNumber:      node.serial_number,
+		Power: proxytypes.NodePower{
+			State:  node.power.State,
+			Target: node.power.Target,
+		},
 	}
 	return
 }
 
 func (g *GridProxyClientimpl) NodeStatus(nodeID uint32) (res proxytypes.NodeStatus, err error) {
 	node := g.data.nodes[uint64(nodeID)]
-	res.Status = STATUS_DOWN
-	if isUp(node.updated_at) {
-		res.Status = STATUS_UP
-	}
+	res.Status = decideNodeStatus(node.power, node.updated_at)
 	return
 }
 

--- a/grid-proxy/tests/queries/local_client.go
+++ b/grid-proxy/tests/queries/local_client.go
@@ -10,6 +10,10 @@ import (
 	"github.com/threefoldtech/zos/pkg/gridtypes"
 )
 
+const (
+	nodeUpInterval = -3 * time.Hour
+)
+
 // GridProxyClientimpl client that returns data directly from the db
 type GridProxyClientimpl struct {
 	data DBData
@@ -31,7 +35,7 @@ func decideNodeStatus(power nodePower, updatedAt uint64) string {
 		return "standby"
 	} else if power.Target == "Up" && power.State == "Down" { // powering on
 		return "down"
-	} else if int64(updatedAt) >= time.Now().Add(-3*time.Hour).Unix() {
+	} else if int64(updatedAt) >= time.Now().Add(nodeUpInterval).Unix() {
 		return "up"
 	} else {
 		return "down"

--- a/grid-proxy/tests/queries/types.go
+++ b/grid-proxy/tests/queries/types.go
@@ -1,6 +1,11 @@
 // nolint
 package main
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // TODO: the one in tools/db/types.go is unexported but it's the same file
 
 var (
@@ -53,7 +58,25 @@ type node struct {
 	created_at        uint64
 	updated_at        uint64
 	location_id       string
+	power             nodePower `gorm:"column:power;type:json"`
 }
+
+type nodePower struct {
+	State  string `json:"state"`
+	Target string `json:"target"`
+}
+
+func (np *nodePower) Scan(value interface{}) error {
+	// custom decoding for jsonb filed. executed while scanning the node.
+	if value == nil {
+		return nil
+	}
+	if data, ok := value.([]byte); ok {
+		return json.Unmarshal(data, np)
+	}
+	return fmt.Errorf("failed to unmarshal NodePower")
+}
+
 type twin struct {
 	id           string
 	grid_version uint64

--- a/grid-proxy/tests/queries/types.go
+++ b/grid-proxy/tests/queries/types.go
@@ -66,7 +66,7 @@ type nodePower struct {
 	Target string `json:"target"`
 }
 
-// custom decoding for jsonb filed. executed while scanning the node.
+// Scan is a custom decoder for jsonb filed. executed while scanning the node.
 func (np *nodePower) Scan(value interface{}) error {
 	if value == nil {
 		return nil

--- a/grid-proxy/tests/queries/types.go
+++ b/grid-proxy/tests/queries/types.go
@@ -58,7 +58,7 @@ type node struct {
 	created_at        uint64
 	updated_at        uint64
 	location_id       string
-	power             nodePower `gorm:"column:power;type:json"`
+	power             nodePower
 }
 
 type nodePower struct {
@@ -66,8 +66,8 @@ type nodePower struct {
 	Target string `json:"target"`
 }
 
+// custom decoding for jsonb filed. executed while scanning the node.
 func (np *nodePower) Scan(value interface{}) error {
-	// custom decoding for jsonb filed. executed while scanning the node.
 	if value == nil {
 		return nil
 	}

--- a/grid-proxy/tests/queries/types.go
+++ b/grid-proxy/tests/queries/types.go
@@ -58,7 +58,7 @@ type node struct {
 	created_at        uint64
 	updated_at        uint64
 	location_id       string
-	power             nodePower
+	power             nodePower `gorm:"type:jsonb"`
 }
 
 type nodePower struct {

--- a/grid-proxy/tools/db/generate.go
+++ b/grid-proxy/tools/db/generate.go
@@ -3,6 +3,7 @@ package main
 import (
 	"database/sql"
 	"fmt"
+	"math/rand"
 	"os"
 	"time"
 
@@ -303,6 +304,7 @@ func generateRentContracts(db *sql.DB) error {
 
 func generateNodes(db *sql.DB) error {
 	const NodeCount = 1000
+	powerState := []string{"Up", "Down"}
 	for i := uint64(1); i <= NodeCount; i++ {
 		mru := rnd(4, 256) * 1024 * 1024 * 1024
 		hru := rnd(100, 30*1024) * 1024 * 1024 * 1024 // 100GB -> 30TB
@@ -340,6 +342,10 @@ func generateNodes(db *sql.DB) error {
 			secure:            false,
 			virtualized:       false,
 			serial_number:     "",
+			power: nodePower{
+				State:  powerState[rand.Intn(len(powerState))],
+				Target: powerState[rand.Intn(len(powerState))],
+			},
 		}
 		total_resources := node_resources_total{
 			id:      fmt.Sprintf("total-resources-%d", i),

--- a/grid-proxy/tools/db/schema.sql
+++ b/grid-proxy/tools/db/schema.sql
@@ -328,7 +328,8 @@ CREATE TABLE public.node (
     updated_at numeric NOT NULL,
     location_id character varying NOT NULL,
     certification character varying(9),
-    connection_price integer
+    connection_price integer,
+    power jsonb
 );
 
 

--- a/grid-proxy/tools/db/types.go
+++ b/grid-proxy/tools/db/types.go
@@ -38,6 +38,12 @@ type node struct {
 	created_at        uint64
 	updated_at        uint64
 	location_id       string
+	power             nodePower `gorm:"column:power;type:json"`
+}
+
+type nodePower struct {
+	State  string `json:"state"`
+	Target string `json:"target"`
 }
 type twin struct {
 	id           string

--- a/grid-proxy/tools/db/types.go
+++ b/grid-proxy/tools/db/types.go
@@ -38,7 +38,7 @@ type node struct {
 	created_at        uint64
 	updated_at        uint64
 	location_id       string
-	power             nodePower `gorm:"column:power;type:json"`
+	power             nodePower
 }
 
 type nodePower struct {

--- a/grid-proxy/tools/db/types.go
+++ b/grid-proxy/tools/db/types.go
@@ -38,7 +38,7 @@ type node struct {
 	created_at        uint64
 	updated_at        uint64
 	location_id       string
-	power             nodePower
+	power             nodePower `gorm:"type:jsonb"`
 }
 
 type nodePower struct {

--- a/grid-proxy/tools/db/utils.go
+++ b/grid-proxy/tools/db/utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net"
@@ -64,6 +65,23 @@ func insertQuery(v interface{}) string {
 			}
 			if v != "NULL" && val.Field(i).Type().Name() == "string" {
 				v = fmt.Sprintf(`'%s'`, v)
+			}
+			if v != "NULL" && val.Field(i).Type().Name() == "nodePower" {
+				// Construct the nodePower object
+				val2 := val.Field(i)
+				power := make(map[string]string)
+				for j := 0; j < val2.NumField(); j++ {
+					fieldName := val2.Type().Field(j).Name
+					fieldValue := val2.Field(j).String()
+					power[fieldName] = fieldValue
+				}
+
+				// Marshal the power map to JSON and wrap it in quotes
+				powerJSON, err := json.Marshal(power)
+				if err != nil {
+					panic(err)
+				}
+				v = fmt.Sprintf("'%s'", string(powerJSON))
 			}
 			query = fmt.Sprintf("%s, %s", query, val.Type().Field(i).Name)
 			vals = fmt.Sprintf("%s, %s", vals, v)


### PR DESCRIPTION
### Description
This PR introduces a new node status called standby, which will flag the nodes that were powered off by farmerbot.

### Changes
To support this new node status, the Node and NodeWithNestedCapacity structs have been updated to include a power field. 
Additionally, the node status check has been modified to accommodate this new status.

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/106