### PR TITLE
Separate parent context cancel from local context

### DIFF
--- a/rmb-sdk-go/direct/connection.go
+++ b/rmb-sdk-go/direct/connection.go
@@ -93,8 +93,12 @@ func (c *InnerConnection) loop(ctx context.Context, con *websocket.Conn, output,
 	lastPong := time.Now()
 	for {
 		select {
+		case <-ctx.Done():
+			return ctx.Err()
 		case <-local.Done():
-			return local.Err()
+			// error happened with the connection
+			// we return nil to try again
+			return nil
 		case data := <-input:
 			if err := con.WriteMessage(websocket.BinaryMessage, data); err != nil {
 				return err


### PR DESCRIPTION
### Description

Separate parent context from local context cancel so writer channel doesn't get closed from connection errors

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-go/issues/104
