### PR TITLE
add docs for gridproxy releasing

### DIFF
--- a/.github/workflows/gridproxy-release.yml
+++ b/.github/workflows/gridproxy-release.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           images: ghcr.io/threefoldtech/tfgridproxy
           tags: |
-            type=semver,pattern={{raw}}
+            type=semver,pattern={{version}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4

--- a/docs/release.md
+++ b/docs/release.md
@@ -17,6 +17,7 @@ let's say the next tag is `v1.0.0`, release will be:
 
 - Create a tag `git tag -a grid-proxy/v1.0.0 -m "release grid-proxy/v1.0.0"`
 - Push the tag `git push origin grid-proxy/v1.0.0`
+For Further info check Grid-proxy release [docs](../grid-proxy/docs/release.md).
 
 ### RMB-sdk-go
 
@@ -29,3 +30,12 @@ let's say the next tag is `v1.0.0`, release will be:
 - Create a tag `git tag -a v1.0.0 -m "release v1.0.0"`
 - Push the tag `git push origin v1.0.0`
 - the release workflow will release the tag automatically
+
+## Tags Convention
+The following convention should be followed for tagging in this project:
+
+Release Tags: For release names and GitHub tags, the tag format should be prefixed with v0.0.0. For example, a release tag could be v1.2.3, where 1.2.3 represents the version number of the release.
+
+Docker Image Tags: For generated Docker images, such as in the tfgridproxy component, the tag format should only include the tag number without the v prefix. For example, a Docker image tag could be 0.0.0, representing the specific version of the image.
+
+Following this convention will help maintain consistency and clarity in tagging across all the grid components.

--- a/grid-proxy/docs/production.md
+++ b/grid-proxy/docs/production.md
@@ -100,11 +100,3 @@ docker run --name gridproxy -e POSTGRES_HOST="127.0.0.1" -e POSTGRES_PORT="5432"
   ```bash
   helm install gridproxy/gridproxy
   ```
-
-## Release
-
-- Update the `appVersion` in `charts/Chart.yaml`. (push, open PR, merge)
-- Draft new release with [Github UI Releaser](https://github.com/threefoldtech/tfgridclient_proxy/releases/new)
-  - In the tags dropdown menu write the new tag `appVersion` and create it.
-  - Generate release notes
-  - Mark as release or pre-release and publish

--- a/grid-proxy/docs/release.md
+++ b/grid-proxy/docs/release.md
@@ -1,0 +1,17 @@
+## Release Grid-Proxy
+To release a new version of the Grid-Proxy component, follow these steps:
+
+Update the `appVersion` field in the `charts/Chart.yaml` file. This field should reflect the new version number of the release.
+
+The release process includes generating and pushing a Docker image with the latest GitHub tag. This step is automated through the `gridproxy-release.yml` workflow.
+
+Trigger the `gridproxy-release.yml` workflow by pushing the desired tag to the repository. This will initiate the workflow, which will generate the Docker image based on the tag and push it to the appropriate registry.
+
+## Debugging
+In the event that the workflow does not run automatically after pushing the tag and making the release, you can manually execute it using the GitHub Actions interface. Follow these steps:
+
+Go to the [GitHub Actions page](https://github.com/threefoldtech/tfgrid-sdk-go/actions/workflows/gridproxy-release.yml) for the Grid-Proxy repository.
+
+Locate the workflow named gridproxy-release.yml.
+
+Trigger the workflow manually by selecting the "Run workflow" option.


### PR DESCRIPTION
- add docs for gridproxy releasing process
- update the workflow to have the generated docker image without `v` prefixed in the tag.