### PR TITLE
expose NotFound errors and use them in loaders

### DIFF
--- a/grid-client/state/state.go
+++ b/grid-client/state/state.go
@@ -30,6 +30,13 @@ type State struct {
 	Substrate subi.SubstrateExt
 }
 
+var (
+	WorkloadNotFoundErr   = errors.New("workload not found")
+	DeploymentNotFoundErr = errors.New("deployment not found")
+	K8sClusterNotFoundErr = errors.New("kubernetes cluster not found")
+	NetworkNotFoundErr    = errors.New("network not found")
+)
+
 // NewState generates a new state
 func NewState(ncPool client.NodeClientGetter, substrate subi.SubstrateExt) *State {
 	return &State{
@@ -176,7 +183,7 @@ func (st *State) LoadK8sFromGrid(nodeIDs []uint32, deploymentName string) (workl
 		}
 	}
 	if cluster.Master == nil {
-		return workloads.K8sCluster{}, errors.Errorf("failed to get master node for k8s cluster %s", deploymentName)
+		return workloads.K8sCluster{}, errors.Wrapf(K8sClusterNotFoundErr, "failed to get master node for k8s cluster %s", deploymentName)
 	}
 	cluster.NodeDeploymentID = nodeDeploymentID
 	cluster.NetworkName = cluster.Master.NetworkName
@@ -310,7 +317,7 @@ func (st *State) LoadNetworkFromGrid(name string) (znet workloads.ZNet, err erro
 	}
 
 	if reflect.DeepEqual(znet, workloads.ZNet{}) {
-		return znet, errors.Errorf("failed to get network %s", name)
+		return znet, errors.Wrapf(NetworkNotFoundErr, "failed to get network %s", name)
 	}
 
 	// merge networks
@@ -403,9 +410,9 @@ func (st *State) GetWorkloadInDeployment(nodeID uint32, name string, deploymentN
 				}
 			}
 		}
-		return gridtypes.Workload{}, gridtypes.Deployment{}, errors.Errorf("could not get workload with name %s", name)
+		return gridtypes.Workload{}, gridtypes.Deployment{}, errors.Wrapf(WorkloadNotFoundErr, "failed to find workload '%s'", name)
 	}
-	return gridtypes.Workload{}, gridtypes.Deployment{}, errors.Errorf("could not get workload '%s' with node ID %d", name, nodeID)
+	return gridtypes.Workload{}, gridtypes.Deployment{}, errors.Wrapf(DeploymentNotFoundErr, "failed to find deployment %s on node %d", name, nodeID)
 }
 
 // AssignNodesIPRange to assign ip range of k8s cluster nodes


### PR DESCRIPTION
## Description:

This PR specifies if the loaders in the grid-client had no issues except that the deployment/workload being loaded is not found