### PR TITLE
remove error check for "ContractNotExists" when canceling a contract

### DIFF
--- a/grid-client/subi/substrate_manager.go
+++ b/grid-client/subi/substrate_manager.go
@@ -3,6 +3,7 @@ package subi
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -149,7 +150,7 @@ func (s *SubstrateImpl) CancelContract(identity substrate.Identity, contractID u
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	if err := s.Substrate.CancelContract(identity, contractID); err != nil && err.Error() != "ContractNotExists" {
+	if err := s.Substrate.CancelContract(identity, contractID); err != nil && !strings.Contains(err.Error(), "ContractNotExists") {
 		return normalizeNotFoundErrors(err)
 	}
 	return nil
@@ -164,7 +165,7 @@ func (s *SubstrateImpl) EnsureContractCanceled(identity substrate.Identity, cont
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	if err := s.Substrate.CancelContract(identity, contractID); err != nil && err.Error() != "ContractNotExists" {
+	if err := s.Substrate.CancelContract(identity, contractID); err != nil && !strings.Contains(err.Error(), "ContractNotExists") {
 		return normalizeNotFoundErrors(err)
 	}
 	return nil

--- a/grid-client/subi/substrate_manager.go
+++ b/grid-client/subi/substrate_manager.go
@@ -3,7 +3,6 @@ package subi
 
 import (
 	"context"
-	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -150,7 +149,7 @@ func (s *SubstrateImpl) CancelContract(identity substrate.Identity, contractID u
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	if err := s.Substrate.CancelContract(identity, contractID); err != nil && !strings.Contains(err.Error(), "ContractNotExists") {
+	if err := s.Substrate.CancelContract(identity, contractID); err != nil {
 		return normalizeNotFoundErrors(err)
 	}
 	return nil
@@ -165,7 +164,7 @@ func (s *SubstrateImpl) EnsureContractCanceled(identity substrate.Identity, cont
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	if err := s.Substrate.CancelContract(identity, contractID); err != nil && !strings.Contains(err.Error(), "ContractNotExists") {
+	if err := s.Substrate.CancelContract(identity, contractID); err != nil {
 		return normalizeNotFoundErrors(err)
 	}
 	return nil


### PR DESCRIPTION
## Description:

Currently, when a user cancels their contract, the subi interface checks whether the returned error string is "ContractNotExists" and if so, ignores it. but actually the returned error string is not just "ContractNotExists", the error includes it, so the check does not do anything.
And as stated below, this maybe the way to go, where we let the user decide what to do when such error returns. So, this pr removes the current check, which does not do anything except remove the confusion.