### PR TITLE
Fixing get vm and kubernates

### DIFF
--- a/grid-cli/internal/cmd/get.go
+++ b/grid-cli/internal/cmd/get.go
@@ -8,6 +8,16 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
 )
 
+func SetOrAppend(t deployer.TFPluginClient, contractIDs map[uint32]uint64, node uint32, contractID uint64) {
+	if len(contractIDs) == 0 {
+		t.State.CurrentNodeDeployments[node] = []uint64{contractID}
+
+	} else {
+		t.State.CurrentNodeDeployments[node] = append(t.State.CurrentNodeDeployments[node], contractID)
+
+	}
+}
+
 // GetVM gets a vm with its project name
 func GetVM(t deployer.TFPluginClient, name string) (workloads.Deployment, error) {
 	nodeContractIDs, err := t.ContractsGetter.GetNodeContractsByTypeAndName(name, workloads.VMType, name)
@@ -21,12 +31,12 @@ func GetVM(t deployer.TFPluginClient, name string) (workloads.Deployment, error)
 	}
 
 	for node, contractID := range networkContractIDs {
-		t.State.CurrentNodeDeployments[node] = []uint64{contractID}
+		SetOrAppend(t, networkContractIDs, node, contractID)
 	}
 
 	var nodeID uint32
 	for node, contractID := range nodeContractIDs {
-		t.State.CurrentNodeDeployments[node] = append(t.State.CurrentNodeDeployments[node], contractID)
+		SetOrAppend(t, nodeContractIDs, node, contractID)
 		nodeID = node
 	}
 

--- a/grid-cli/internal/cmd/get.go
+++ b/grid-cli/internal/cmd/get.go
@@ -8,14 +8,22 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
 )
 
-func SetOrAppend(t deployer.TFPluginClient, contractIDs map[uint32]uint64, node uint32, contractID uint64) {
-	if len(contractIDs) == 0 {
-		t.State.CurrentNodeDeployments[node] = []uint64{contractID}
+func checkIfExistAndAppend(t deployer.TFPluginClient, node uint32, contractID uint64) {
+
+	if len(t.State.CurrentNodeDeployments[node]) != 0 {
+
+		for _, n := range t.State.CurrentNodeDeployments[node] {
+
+			if n != contractID {
+				t.State.CurrentNodeDeployments[node] = append(t.State.CurrentNodeDeployments[node], contractID)
+			}
+
+		}
 
 	} else {
 		t.State.CurrentNodeDeployments[node] = append(t.State.CurrentNodeDeployments[node], contractID)
-
 	}
+
 }
 
 // GetVM gets a vm with its project name
@@ -31,12 +39,12 @@ func GetVM(t deployer.TFPluginClient, name string) (workloads.Deployment, error)
 	}
 
 	for node, contractID := range networkContractIDs {
-		SetOrAppend(t, networkContractIDs, node, contractID)
+		checkIfExistAndAppend(t, node, contractID)
 	}
 
 	var nodeID uint32
 	for node, contractID := range nodeContractIDs {
-		SetOrAppend(t, nodeContractIDs, node, contractID)
+		checkIfExistAndAppend(t, node, contractID)
 		nodeID = node
 	}
 

--- a/grid-cli/internal/cmd/get.go
+++ b/grid-cli/internal/cmd/get.go
@@ -26,7 +26,7 @@ func GetVM(t deployer.TFPluginClient, name string) (workloads.Deployment, error)
 
 	var nodeID uint32
 	for node, contractID := range nodeContractIDs {
-		t.State.CurrentNodeDeployments[node] = []uint64{contractID}
+		t.State.CurrentNodeDeployments[node] = append(t.State.CurrentNodeDeployments[node], contractID)
 		nodeID = node
 	}
 
@@ -52,7 +52,7 @@ func GetK8sCluster(t deployer.TFPluginClient, name string) (workloads.K8sCluster
 	}
 
 	for node, contractID := range networkContractIDs {
-		t.State.CurrentNodeDeployments[node] = []uint64{contractID}
+		t.State.CurrentNodeDeployments[node] = append(t.State.CurrentNodeDeployments[node], contractID)
 		nodeIDs = append(nodeIDs, node)
 	}
 

--- a/grid-cli/internal/cmd/get.go
+++ b/grid-cli/internal/cmd/get.go
@@ -10,19 +10,15 @@ import (
 
 func checkIfExistAndAppend(t deployer.TFPluginClient, node uint32, contractID uint64) {
 
-	if len(t.State.CurrentNodeDeployments[node]) != 0 {
+	for _, n := range t.State.CurrentNodeDeployments[node] {
 
-		for _, n := range t.State.CurrentNodeDeployments[node] {
-
-			if n != contractID {
-				t.State.CurrentNodeDeployments[node] = append(t.State.CurrentNodeDeployments[node], contractID)
-			}
-
+		if n == contractID {
+			return
 		}
 
-	} else {
-		t.State.CurrentNodeDeployments[node] = append(t.State.CurrentNodeDeployments[node], contractID)
 	}
+
+	t.State.CurrentNodeDeployments[node] = append(t.State.CurrentNodeDeployments[node], contractID)
 
 }
 


### PR DESCRIPTION
### Description

Fixing the get vm and kubernates commands
### Changes
Appending the networkContractIDs to the state's CurrentNodeDeployments rather than overriding

### Related Issues

#170
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
