### PR TITLE
fix release not triggering proxy build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,4 @@ jobs:
           args: release --rm-dist
         env:
           # GitHub sets this automatically
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_KEY }}


### PR DESCRIPTION
### Description

Use a personal access token during release workflow so it can be possible to trigger the proxy build after a release.


### Related Issues

#117

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
