### PR TITLE
add node gpu info API

### DIFF
--- a/grid-proxy/Makefile
+++ b/grid-proxy/Makefile
@@ -3,7 +3,7 @@ PQ_HOST = $(shell docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddr
 PQ_CONTAINER = postgres
 
 install-swag: 
-	@go install github.com/swaggo/swag/cmd/swag@latest;
+	@go install github.com/swaggo/swag/cmd/swag@v1.8.12;
 
 .PHONY: docs
 docs: install-swag ## Create the swagger docs

--- a/grid-proxy/docs/docs.go
+++ b/grid-proxy/docs/docs.go
@@ -628,6 +628,12 @@ const docTemplate = `{
                         "description": "certificate type Diy or Certified",
                         "name": "certification_type",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "filter nodes on whether they have GPU support or not",
+                        "name": "has_gpu",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -681,6 +687,58 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/types.NodeWithNestedCapacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/nodes/{node_id}/gpu": {
+            "get": {
+                "description": "Get node GPUs through the RMB relay",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "NodeGPUs"
+                ],
+                "summary": "Show node GPUs information",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Node ID",
+                        "name": "node_id",
+                        "in": "path"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.NodeGPU"
+                            }
                         }
                     },
                     "400": {
@@ -1101,6 +1159,9 @@ const docTemplate = `{
                 "dedicated": {
                     "type": "boolean"
                 },
+                "extraFee": {
+                    "type": "integer"
+                },
                 "farmId": {
                     "type": "integer"
                 },
@@ -1109,6 +1170,9 @@ const docTemplate = `{
                 },
                 "gridVersion": {
                     "type": "integer"
+                },
+                "hasGpu": {
+                    "type": "boolean"
                 },
                 "id": {
                     "type": "string"
@@ -1155,6 +1219,20 @@ const docTemplate = `{
                 }
             }
         },
+        "types.NodeGPU": {
+            "type": "object",
+            "properties": {
+                "device": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "vendor": {
+                    "type": "string"
+                }
+            }
+        },
         "types.NodePower": {
             "type": "object",
             "properties": {
@@ -1187,6 +1265,9 @@ const docTemplate = `{
                 "dedicated": {
                     "type": "boolean"
                 },
+                "extraFee": {
+                    "type": "integer"
+                },
                 "farmId": {
                     "type": "integer"
                 },
@@ -1195,6 +1276,9 @@ const docTemplate = `{
                 },
                 "gridVersion": {
                     "type": "integer"
+                },
+                "hasGpu": {
+                    "type": "boolean"
                 },
                 "id": {
                     "type": "string"

--- a/grid-proxy/docs/swagger.json
+++ b/grid-proxy/docs/swagger.json
@@ -620,6 +620,12 @@
                         "description": "certificate type Diy or Certified",
                         "name": "certification_type",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "filter nodes on whether they have GPU support or not",
+                        "name": "has_gpu",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -673,6 +679,58 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/types.NodeWithNestedCapacity"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/nodes/{node_id}/gpu": {
+            "get": {
+                "description": "Get node GPUs through the RMB relay",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "NodeGPUs"
+                ],
+                "summary": "Show node GPUs information",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Node ID",
+                        "name": "node_id",
+                        "in": "path"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.NodeGPU"
+                            }
                         }
                     },
                     "400": {
@@ -1093,6 +1151,9 @@
                 "dedicated": {
                     "type": "boolean"
                 },
+                "extraFee": {
+                    "type": "integer"
+                },
                 "farmId": {
                     "type": "integer"
                 },
@@ -1101,6 +1162,9 @@
                 },
                 "gridVersion": {
                     "type": "integer"
+                },
+                "hasGpu": {
+                    "type": "boolean"
                 },
                 "id": {
                     "type": "string"
@@ -1147,6 +1211,20 @@
                 }
             }
         },
+        "types.NodeGPU": {
+            "type": "object",
+            "properties": {
+                "device": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "vendor": {
+                    "type": "string"
+                }
+            }
+        },
         "types.NodePower": {
             "type": "object",
             "properties": {
@@ -1179,6 +1257,9 @@
                 "dedicated": {
                     "type": "boolean"
                 },
+                "extraFee": {
+                    "type": "integer"
+                },
                 "farmId": {
                     "type": "integer"
                 },
@@ -1187,6 +1268,9 @@
                 },
                 "gridVersion": {
                     "type": "integer"
+                },
+                "hasGpu": {
+                    "type": "boolean"
                 },
                 "id": {
                     "type": "string"

--- a/grid-proxy/docs/swagger.yaml
+++ b/grid-proxy/docs/swagger.yaml
@@ -138,12 +138,16 @@ definitions:
         type: integer
       dedicated:
         type: boolean
+      extraFee:
+        type: integer
       farmId:
         type: integer
       farmingPolicyId:
         type: integer
       gridVersion:
         type: integer
+      hasGpu:
+        type: boolean
       id:
         type: string
       location:
@@ -174,6 +178,15 @@ definitions:
       used_resources:
         $ref: '#/definitions/types.Capacity'
     type: object
+  types.NodeGPU:
+    properties:
+      device:
+        type: string
+      id:
+        type: string
+      vendor:
+        type: string
+    type: object
   types.NodePower:
     properties:
       state:
@@ -195,12 +208,16 @@ definitions:
         type: integer
       dedicated:
         type: boolean
+      extraFee:
+        type: integer
       farmId:
         type: integer
       farmingPolicyId:
         type: integer
       gridVersion:
         type: integer
+      hasGpu:
+        type: boolean
       id:
         type: string
       location:
@@ -680,6 +697,10 @@ paths:
         in: query
         name: certification_type
         type: string
+      - description: filter nodes on whether they have GPU support or not
+        in: query
+        name: has_gpu
+        type: boolean
       produces:
       - application/json
       responses:
@@ -732,6 +753,40 @@ paths:
       summary: Show the details for specific node
       tags:
       - GridProxy
+  /nodes/{node_id}/gpu:
+    get:
+      consumes:
+      - application/json
+      description: Get node GPUs through the RMB relay
+      parameters:
+      - description: Node ID
+        in: path
+        name: node_id
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.NodeGPU'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "404":
+          description: Not Found
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Show node GPUs information
+      tags:
+      - NodeGPUs
   /nodes/{node_id}/statistics:
     get:
       consumes:

--- a/grid-proxy/internal/explorer/converters.go
+++ b/grid-proxy/internal/explorer/converters.go
@@ -70,6 +70,8 @@ func nodeFromDBNode(info db.Node) types.Node {
 		RentedByTwinID:    uint(info.RentedByTwinID),
 		SerialNumber:      info.SerialNumber,
 		Power:             types.NodePower(info.Power),
+		HasGPU:            info.HasGPU,
+		ExtraFee:          info.ExtraFee,
 	}
 	node.Status = decideNodeStatus(node.Power, node.UpdatedAt)
 	return node
@@ -139,6 +141,8 @@ func nodeWithNestedCapacityFromDBNode(info db.Node) types.NodeWithNestedCapacity
 		RentedByTwinID:    uint(info.RentedByTwinID),
 		SerialNumber:      info.SerialNumber,
 		Power:             types.NodePower(info.Power),
+		HasGPU:            info.HasGPU,
+		ExtraFee:          info.ExtraFee,
 	}
 	node.Status = decideNodeStatus(node.Power, node.UpdatedAt)
 	return node

--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -371,6 +371,8 @@ func (d *PostgresDatabase) nodeTableQuery() *gorm.DB {
 			"convert_to_decimal(location.longitude) as longitude",
 			"convert_to_decimal(location.latitude) as latitude",
 			"node.power",
+			"node.has_gpu",
+			"node.extra_fee",
 		).
 		Joins(
 			"LEFT JOIN nodes_resources_view ON node.node_id = nodes_resources_view.node_id",
@@ -481,6 +483,9 @@ func (d *PostgresDatabase) GetNodes(filter types.NodeFilter, limit types.Limit) 
 	}
 	if filter.CertificationType != nil {
 		q = q.Where("node.certification ILIKE ?", *filter.CertificationType)
+	}
+	if filter.HasGPU != nil {
+		q = q.Where("node.has_gpu = ?", *filter.HasGPU)
 	}
 
 	var count int64

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -64,6 +64,8 @@ type Node struct {
 	Longitude       *float64
 	Latitude        *float64
 	Power           NodePower `gorm:"type:jsonb"`
+	HasGPU          bool
+	ExtraFee        uint64
 }
 
 // NodePower struct is the farmerbot report for node status

--- a/grid-proxy/internal/explorer/helpers.go
+++ b/grid-proxy/internal/explorer/helpers.go
@@ -155,6 +155,7 @@ func (a *App) handleNodeRequestsQueryParams(r *http.Request) (types.NodeFilter, 
 		"dedicated": &filter.Dedicated,
 		"rentable":  &filter.Rentable,
 		"rented":    &filter.Rented,
+		"has_gpu":   &filter.HasGPU,
 	}
 	listOfInts := map[string]*[]uint64{
 		"farm_ids": &filter.FarmIDs,

--- a/grid-proxy/pkg/client/utils.go
+++ b/grid-proxy/pkg/client/utils.go
@@ -113,6 +113,9 @@ func nodeParams(filter types.NodeFilter, limit types.Limit) string {
 	if filter.CertificationType != nil && *filter.CertificationType != "" {
 		fmt.Fprintf(&builder, "certification_type=%s&", url.QueryEscape(*filter.CertificationType))
 	}
+	if filter.HasGPU != nil {
+		fmt.Fprintf(&builder, "has_gpu=%t&", *filter.HasGPU)
+	}
 
 	res := builder.String()
 	// pop the extra ? or &

--- a/grid-proxy/pkg/types/types.go
+++ b/grid-proxy/pkg/types/types.go
@@ -109,6 +109,7 @@ type NodeFilter struct {
 	NodeID            *uint64
 	TwinID            *uint64
 	CertificationType *string
+	HasGPU            *bool
 }
 
 // FarmFilter farm filters
@@ -186,6 +187,8 @@ type Node struct {
 	RentedByTwinID    uint         `json:"rentedByTwinId"`
 	SerialNumber      string       `json:"serialNumber"`
 	Power             NodePower    `json:"power"`
+	HasGPU            bool         `json:"hasGpu"`
+	ExtraFee          uint64       `json:"extraFee"`
 }
 
 // CapacityResult is the NodeData capacity results to unmarshal json in it
@@ -217,6 +220,8 @@ type NodeWithNestedCapacity struct {
 	RentedByTwinID    uint           `json:"rentedByTwinId"`
 	SerialNumber      string         `json:"serialNumber"`
 	Power             NodePower      `json:"power"`
+	HasGPU            bool           `json:"hasGpu"`
+	ExtraFee          uint64         `json:"extraFee"`
 }
 
 type Twin struct {
@@ -278,6 +283,12 @@ type NodeStatistics struct {
 // NodeStatus is used for status endpoint to decode json in
 type NodeStatus struct {
 	Status string `json:"status"`
+}
+
+type NodeGPU struct {
+	ID     string `json:"id"`
+	Vendor string `json:"vendor"`
+	Device string `json:"device"`
 }
 
 // Serialize is the serializer for node status struct

--- a/grid-proxy/tests/queries/loader.go
+++ b/grid-proxy/tests/queries/loader.go
@@ -51,6 +51,8 @@ func loadNodes(db *sql.DB, data *DBData) error {
 		COALESCE(created_at, 0),
 		COALESCE(updated_at, 0),
 		COALESCE(location_id, ''),
+		COALESCE(has_gpu, false),
+		COALESCE(extra_fee, 0),
 		power
 	FROM
 		node;`)
@@ -77,6 +79,8 @@ func loadNodes(db *sql.DB, data *DBData) error {
 			&node.created_at,
 			&node.updated_at,
 			&node.location_id,
+			&node.HasGPU,
+			&node.ExtraFee,
 			&node.power,
 		); err != nil {
 			return err

--- a/grid-proxy/tests/queries/local_client.go
+++ b/grid-proxy/tests/queries/local_client.go
@@ -343,6 +343,8 @@ func (g *GridProxyClientimpl) Node(nodeID uint32) (res proxytypes.NodeWithNested
 			State:  node.power.State,
 			Target: node.power.Target,
 		},
+		HasGPU:   node.HasGPU,
+		ExtraFee: node.ExtraFee,
 	}
 	return
 }

--- a/grid-proxy/tests/queries/node_test.go
+++ b/grid-proxy/tests/queries/node_test.go
@@ -150,6 +150,16 @@ func TestNode(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Empty(t, nodes)
 	})
+
+	t.Run("nodes test has_gpu filter", func(t *testing.T) {
+		hasGPU := true
+		nodes, _, err := proxyClient.Nodes(proxytypes.NodeFilter{HasGPU: &hasGPU}, proxytypes.Limit{})
+		assert.NoError(t, err)
+
+		for _, node := range nodes {
+			assert.Equal(t, node.HasGPU, hasGPU, "has_gpu filter did not work")
+		}
+	})
 }
 
 func singleNodeCheck(t *testing.T, localClient proxyclient.Client, proxyClient proxyclient.Client) {

--- a/grid-proxy/tests/queries/types.go
+++ b/grid-proxy/tests/queries/types.go
@@ -59,6 +59,8 @@ type node struct {
 	updated_at        uint64
 	location_id       string
 	power             nodePower `gorm:"type:jsonb"`
+	HasGPU            bool
+	ExtraFee          uint64
 }
 
 type nodePower struct {

--- a/grid-proxy/tools/db/generate.go
+++ b/grid-proxy/tools/db/generate.go
@@ -347,6 +347,8 @@ func generateNodes(db *sql.DB) error {
 				State:  powerState[rand.Intn(len(powerState))],
 				Target: powerState[rand.Intn(len(powerState))],
 			},
+			has_gpu:   i%2 == 0,
+			extra_fee: 0,
 		}
 		total_resources := node_resources_total{
 			id:      fmt.Sprintf("total-resources-%d", i),

--- a/grid-proxy/tools/db/schema.sql
+++ b/grid-proxy/tools/db/schema.sql
@@ -329,7 +329,9 @@ CREATE TABLE public.node (
     location_id character varying NOT NULL,
     certification character varying(9),
     connection_price integer,
-    power jsonb
+    power jsonb,
+    has_gpu boolean,
+    extra_fee numeric
 );
 
 

--- a/grid-proxy/tools/db/types.go
+++ b/grid-proxy/tools/db/types.go
@@ -39,6 +39,8 @@ type node struct {
 	updated_at        uint64
 	location_id       string
 	power             nodePower `gorm:"type:jsonb"`
+	has_gpu           bool
+	extra_fee         uint64
 }
 
 type nodePower struct {


### PR DESCRIPTION
### Description

Exposes the new GPU node fields and adds an API to fetch GPU info

### Changes

- Expose new fields `hasGpu and extraFee`
- Adds an API to retrieve GPU info
- Allow filtering nodes based on whether a node suports GPU or nor

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-go/issues/201

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
