### PR TITLE
add building docker image job to workflow

### DIFF
--- a/.github/workflows/gridproxy-build.yml
+++ b/.github/workflows/gridproxy-build.yml
@@ -54,7 +54,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: ./grid-proxy/Dockerfile
+          file: ./Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           #  For workflows triggered by release, `github.ref_name` is the short name for the release tag created.

--- a/.github/workflows/gridproxy-build.yml
+++ b/.github/workflows/gridproxy-build.yml
@@ -50,7 +50,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
 
-      - name: Build and push Docker image
+      - name: Build Docker image
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.github/workflows/gridproxy-build.yml
+++ b/.github/workflows/gridproxy-build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Test version
         run: ./main -v
   
-  build_docker:
+  build-docker:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -44,8 +44,11 @@ jobs:
     permissions:
       contents: read
       packages: write
-      
+
     steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v3.5.3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2.2.0
         with:
@@ -65,7 +68,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: ./Dockerfile
+          file: ./grid-proxy/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           #  For workflows triggered by release, `github.ref_name` is the short name for the release tag created.

--- a/.github/workflows/gridproxy-build.yml
+++ b/.github/workflows/gridproxy-build.yml
@@ -41,7 +41,18 @@ jobs:
     defaults:
       run:
         working-directory: grid-proxy
+    permissions:
+      contents: read
+      packages: write
+      
     steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4

--- a/.github/workflows/gridproxy-build.yml
+++ b/.github/workflows/gridproxy-build.yml
@@ -35,3 +35,31 @@ jobs:
 
       - name: Test version
         run: ./main -v
+  
+  build_docker:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: grid-proxy
+    steps:
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/threefoldtech/tfgridproxy
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./grid-proxy/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          #  For workflows triggered by release, `github.ref_name` is the short name for the release tag created.
+          build-args: |
+            version=${{ github.ref_name	 }}
+
+      
+

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -42,7 +42,7 @@ Runs `integration tests` daily
   
 ### Build and lint workflow
 
-Runs `golangci-lint` and `build` with every push.
+Runs `golangci-lint` and builds gridproxy server and docker image with every push.
 
 ### Unit test workflow
 


### PR DESCRIPTION
### Description

adds a job to build gridproxy docker image with each commit push in workflow

### Changes

changed github workflow file

### Related Issues

#216 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
