### PR TITLE
add console url to vm and k8s

### DIFF
--- a/grid-client/workloads/k8s.go
+++ b/grid-client/workloads/k8s.go
@@ -34,6 +34,7 @@ type K8sNode struct {
 	NetworkName   string `json:"network_name"`
 	Token         string `json:"token"`
 	SSHKey        string `json:"ssh_key"`
+	ConsoleURL    string `json:"console_url"`
 }
 
 // K8sCluster struct for k8s cluster
@@ -92,6 +93,7 @@ func NewK8sNodeFromWorkload(wl gridtypes.Workload, nodeID uint32, diskSize int, 
 		NetworkName:   string(d.Network.Interfaces[0].Network),
 		Token:         d.Env["K3S_TOKEN"],
 		SSHKey:        d.Env["SSH_KEY"],
+		ConsoleURL:    result.ConsoleURL,
 	}, nil
 }
 

--- a/grid-client/workloads/vm.go
+++ b/grid-client/workloads/vm.go
@@ -38,6 +38,7 @@ type VM struct {
 	Zlogs         []Zlog            `json:"zlogs"`
 	EnvVars       map[string]string `json:"env_vars"`
 	NetworkName   string            `json:"network_name"`
+	ConsoleURL    string            `json:"console_url"`
 }
 
 // Mount disks struct
@@ -103,6 +104,7 @@ func NewVMFromWorkload(wl *gridtypes.Workload, dl *gridtypes.Deployment) (VM, er
 		Zlogs:         zlogs(dl, wl.Name.String()),
 		EnvVars:       data.Env,
 		NetworkName:   string(data.Network.Interfaces[0].Network),
+		ConsoleURL:    result.ConsoleURL,
 	}, nil
 }
 


### PR DESCRIPTION
### Description
adds  console url to vms and k8s for the user to be able to use this console using wireguard to check vm logs and executes stuff on it

### Changes

console url property to vms and k8snode
### Related Issues
https://github.com/threefoldtech/tfgrid-sdk-go/issues/238

