### PR TITLE
set direct rpc client session id to PID

### DIFF
--- a/grid-proxy/cmds/proxy_server/main.go
+++ b/grid-proxy/cmds/proxy_server/main.go
@@ -158,7 +158,8 @@ func app(s *http.Server, f flags) error {
 }
 
 func createRMBClient(ctx context.Context, relayURL, mnemonics string, sub *substrate.Substrate) (rmb.Client, error) {
-	client, err := direct.NewRpcClient(ctx, direct.KeyTypeSr25519, mnemonics, relayURL, "tfgrid_proxy", sub, false)
+	sessionId := fmt.Sprintf("tfgrid_proxy-%d", os.Getpid())
+	client, err := direct.NewRpcClient(ctx, direct.KeyTypeSr25519, mnemonics, relayURL, sessionId, sub, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create direct RMB client: %w", err)
 	}


### PR DESCRIPTION
while upgrading gridproxy on devnet we faced an issue connecting to the relay https://github.com/threefoldtech/tf_operations/issues/1776#issuecomment-1628391531

it mostly because the session id was set to a fixed value `tfgrid_proxy` so when upgrading the pod. the new pod will create a new connection to the relay with the same session id. 

the relay will close one of the connections and it will try to reconnect so this will make the relay close the other connection and so on..