### PR TITLE
Sort disks before checking pools

### DIFF
--- a/grid-cli/cmd/deploy_gateway_name.go
+++ b/grid-cli/cmd/deploy_gateway_name.go
@@ -43,6 +43,9 @@ var deployGatewayNameCmd = &cobra.Command{
 				cmd.Context(),
 				t,
 				filters.BuildGatewayFilter(farm),
+				nil,
+				nil,
+				nil,
 			)
 			if err != nil {
 				log.Fatal().Err(err).Send()

--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -139,14 +139,19 @@ var deployKubernetesCmd = &cobra.Command{
 		}
 
 		if masterNode == 0 {
+
+			filter, disks, rootfss := filters.BuildK8sFilter(
+				master,
+				masterFarm,
+				1,
+			)
 			nodes, err := deployer.FilterNodes(
 				cmd.Context(),
 				t,
-				filters.BuildK8sFilter(
-					master,
-					masterFarm,
-					1,
-				),
+				filter,
+				disks,
+				nil,
+				rootfss,
 			)
 			if err != nil {
 				log.Fatal().Err(err).Send()
@@ -156,14 +161,19 @@ var deployKubernetesCmd = &cobra.Command{
 		}
 		master.Node = masterNode
 		if workersNode == 0 && len(workers) > 0 {
+
+			filter, disks, rootfss := filters.BuildK8sFilter(
+				workers[0],
+				workersFarm,
+				uint(len(workers)),
+			)
 			workersNodes, err := deployer.FilterNodes(
 				cmd.Context(),
 				t,
-				filters.BuildK8sFilter(
-					workers[0],
-					workersFarm,
-					uint(len(workers)),
-				),
+				filter,
+				disks,
+				nil,
+				rootfss,
 			)
 			if err != nil {
 				log.Fatal().Err(err).Send()

--- a/grid-cli/cmd/deploy_vm.go
+++ b/grid-cli/cmd/deploy_vm.go
@@ -120,10 +120,14 @@ var deployVMCmd = &cobra.Command{
 		}
 
 		if node == 0 {
+			filter, disks, rootfss := filters.BuildVMFilter(vm, mount, farm)
 			nodes, err := deployer.FilterNodes(
 				cmd.Context(),
 				t,
-				filters.BuildVMFilter(vm, mount, farm),
+				filter,
+				disks,
+				nil,
+				rootfss,
 			)
 			if err != nil {
 				log.Fatal().Err(err).Send()

--- a/grid-cli/cmd/deploy_zdb.go
+++ b/grid-cli/cmd/deploy_zdb.go
@@ -112,10 +112,14 @@ var deployZDBCmd = &cobra.Command{
 		}
 
 		if node == 0 {
+			filter, disks := filters.BuildZDBFilter(zdb, count, farm)
 			nodes, err := deployer.FilterNodes(
 				cmd.Context(),
 				t,
-				filters.BuildZDBFilter(zdb, count, farm),
+				filter,
+				nil,
+				disks,
+				nil,
 			)
 			if err != nil {
 				log.Fatal().Err(err).Send()

--- a/grid-cli/internal/filters/filters.go
+++ b/grid-cli/internal/filters/filters.go
@@ -7,7 +7,7 @@ import (
 )
 
 // BuildK8sFilter build a filter for a k8s node
-func BuildK8sFilter(k8sNode workloads.K8sNode, farmID uint64, k8sNodesNum uint) types.NodeFilter {
+func BuildK8sFilter(k8sNode workloads.K8sNode, farmID uint64, k8sNodesNum uint) (types.NodeFilter, []uint64, []uint64) {
 	freeMRUs := uint64(k8sNode.Memory*int(k8sNodesNum)) / 1024
 	freeSRUs := uint64(k8sNode.DiskSize * int(k8sNodesNum))
 	freeIPs := uint64(0)
@@ -15,11 +15,19 @@ func BuildK8sFilter(k8sNode workloads.K8sNode, farmID uint64, k8sNodesNum uint) 
 		freeIPs = uint64(k8sNodesNum)
 	}
 
-	return buildGenericFilter(&freeMRUs, &freeSRUs, &freeIPs, []uint64{farmID}, nil)
+	disks := make([]uint64, k8sNodesNum)
+	rootfss := make([]uint64, k8sNodesNum)
+	for i := 0; i < int(k8sNodesNum); i++ {
+		disks = append(disks, *convertGBToBytes(uint64(k8sNode.DiskSize)))
+		// k8s rootfs is either 2 or 0.5
+		rootfss = append(rootfss, *convertGBToBytes(uint64(2)))
+	}
+
+	return buildGenericFilter(&freeMRUs, &freeSRUs, nil, &freeIPs, []uint64{farmID}, nil), disks, rootfss
 }
 
 // BuildVMFilter build a filter for a vm
-func BuildVMFilter(vm workloads.VM, disk workloads.Disk, farmID uint64) types.NodeFilter {
+func BuildVMFilter(vm workloads.VM, disk workloads.Disk, farmID uint64) (types.NodeFilter, []uint64, []uint64) {
 	freeMRUs := uint64(vm.Memory) / 1024
 	freeSRUs := uint64(vm.RootfsSize) / 1024
 	freeIPs := uint64(0)
@@ -27,39 +35,55 @@ func BuildVMFilter(vm workloads.VM, disk workloads.Disk, farmID uint64) types.No
 		freeIPs = 1
 	}
 	freeSRUs += uint64(disk.SizeGB)
-	return buildGenericFilter(&freeMRUs, &freeSRUs, &freeIPs, []uint64{farmID}, nil)
+
+	disks := make([]uint64, 0)
+	if disk.SizeGB > 0 {
+		disks = append(disks, *convertGBToBytes(uint64(disk.SizeGB)))
+	}
+	rootfss := []uint64{*convertGBToBytes(uint64(vm.RootfsSize) / 1024)}
+	return buildGenericFilter(&freeMRUs, &freeSRUs, nil, &freeIPs, []uint64{farmID}, nil), disks, rootfss
 }
 
 // BuildGatewayFilter build a filter for a gateway
 func BuildGatewayFilter(farmID uint64) types.NodeFilter {
 	domain := true
-	return buildGenericFilter(nil, nil, nil, []uint64{farmID}, &domain)
+	return buildGenericFilter(nil, nil, nil, nil, []uint64{farmID}, &domain)
 }
 
 // BuildZDBFilter build a filter for a zdbs
-func BuildZDBFilter(zdb workloads.ZDB, n int, farmID uint64) types.NodeFilter {
-	freeHRUs := uint64(zdb.Size*n) / 1024
-	status := "up"
-	return types.NodeFilter{
-		Status:  &status,
-		FreeHRU: convertGBToBytes(&freeHRUs),
-		FarmIDs: []uint64{farmID},
-	}
+func BuildZDBFilter(zdb workloads.ZDB, n int, farmID uint64) (types.NodeFilter, []uint64) {
+	freeHRUs := uint64(zdb.Size * n)
+	return buildGenericFilter(nil, nil, &freeHRUs, nil, []uint64{farmID}, nil), []uint64{*convertGBToBytes(freeHRUs)}
 }
 
-func buildGenericFilter(mrus, srus, ips *uint64, farmIDs []uint64, domain *bool) types.NodeFilter {
+func buildGenericFilter(mrus, srus, hrus, ips *uint64, farmIDs []uint64, domain *bool) types.NodeFilter {
+	var freeMRUs *uint64
+	if mrus != nil {
+		freeMRUs = convertGBToBytes(*mrus)
+	}
+	var freeSRUs *uint64
+	if srus != nil {
+		freeSRUs = convertGBToBytes(*srus)
+	}
+	var freeHRUs *uint64
+	if hrus != nil {
+		freeHRUs = convertGBToBytes(*hrus)
+	}
 	status := "up"
+	rented := false
 	return types.NodeFilter{
 		Status:  &status,
-		FreeMRU: convertGBToBytes(mrus),
-		FreeSRU: convertGBToBytes(srus),
+		FreeMRU: freeMRUs,
+		FreeSRU: freeSRUs,
+		FreeHRU: freeHRUs,
 		FreeIPs: ips,
 		FarmIDs: farmIDs,
 		Domain:  domain,
+		Rented:  &rented,
 	}
 }
 
-func convertGBToBytes(gb *uint64) *uint64 {
-	bytes := (*gb) * 1024 * 1024 * 1024
+func convertGBToBytes(gb uint64) *uint64 {
+	bytes := gb * 1024 * 1024 * 1024
 	return &bytes
 }

--- a/grid-client/deployer/node_filter_test.go
+++ b/grid-client/deployer/node_filter_test.go
@@ -1,0 +1,72 @@
+package deployer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	client "github.com/threefoldtech/tfgrid-sdk-go/grid-client/node"
+	"github.com/threefoldtech/zos/pkg/gridtypes/zos"
+)
+
+func TestHasEnoughStorage(t *testing.T) {
+	// free overall storage is 14 separated in two pools for SSD and 10 free HDD
+	pools := []client.PoolMetrics{
+		{
+			Type: zos.SSDDevice,
+			Size: 10,
+			Used: 5,
+		},
+		{
+			Type: zos.SSDDevice,
+			Size: 10,
+			Used: 1,
+		},
+		{
+			Type: zos.SSDDevice,
+			Size: 10,
+			Used: 10,
+		},
+		{
+			Type: zos.HDDDevice,
+			Size: 10,
+			Used: 0,
+		},
+	}
+	t.Run("fails because order because disks order", func(t *testing.T) {
+		poolsCopy := make([]client.PoolMetrics, len(pools))
+		copy(poolsCopy, pools)
+
+		// 11 < 14
+		disks := []uint64{3, 2, 1, 5}
+		check := hasEnoughStorage(poolsCopy, disks, zos.SSDDevice)
+		assert.False(t, check)
+
+	})
+	t.Run("fails because order because disks size", func(t *testing.T) {
+		poolsCopy := make([]client.PoolMetrics, len(pools))
+		copy(poolsCopy, pools)
+
+		// 20 > 14
+		disks := []uint64{20}
+		check := hasEnoughStorage(poolsCopy, disks, zos.SSDDevice)
+		assert.False(t, check)
+	})
+	t.Run("should fit", func(t *testing.T) {
+		poolsCopy := make([]client.PoolMetrics, len(pools))
+		copy(poolsCopy, pools)
+
+		// 12 < 14
+		disks := []uint64{4, 3, 5}
+		check := hasEnoughStorage(poolsCopy, disks, zos.SSDDevice)
+		assert.True(t, check)
+	})
+	t.Run("hru", func(t *testing.T) {
+		poolsCopy := make([]client.PoolMetrics, len(pools))
+		copy(poolsCopy, pools)
+
+		disks := []uint64{6, 4}
+		check := hasEnoughStorage(poolsCopy, disks, zos.HDDDevice)
+		assert.True(t, check)
+
+	})
+}

--- a/grid-client/integration_tests/batch_gateway_name_test.go
+++ b/grid-client/integration_tests/batch_gateway_name_test.go
@@ -28,7 +28,7 @@ func TestBatchGatewayNameDeployment(t *testing.T) {
 	assert.NoError(t, err)
 
 	nodeFilter.Domain = &trueVal
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter)
+	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter, nil, nil, []uint64{minRootfs})
 	if err != nil || len(nodes) < 2 {
 		t.Skip("no available nodes found")
 	}

--- a/grid-client/integration_tests/batch_k8s_test.go
+++ b/grid-client/integration_tests/batch_k8s_test.go
@@ -23,7 +23,14 @@ func TestBatchK8sDeployment(t *testing.T) {
 	publicKey, privateKey, err := GenerateSSHKeyPair()
 	assert.NoError(t, err)
 
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter)
+	nodes, err := deployer.FilterNodes(
+		ctx,
+		tfPluginClient,
+		nodeFilter,
+		[]uint64{*convertGBToBytes(1), *convertGBToBytes(1)},
+		nil,
+		[]uint64{minRootfs, minRootfs},
+	)
 	if err != nil || len(nodes) < 2 {
 		t.Skip("no available nodes found")
 	}

--- a/grid-client/integration_tests/batch_vm_test.go
+++ b/grid-client/integration_tests/batch_vm_test.go
@@ -23,7 +23,7 @@ func TestBatchVMDeployment(t *testing.T) {
 	publicKey, privateKey, err := GenerateSSHKeyPair()
 	assert.NoError(t, err)
 
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter)
+	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter, nil, nil, []uint64{minRootfs})
 	if err != nil || len(nodes) < 2 {
 		t.Skip("no available nodes found")
 	}

--- a/grid-client/integration_tests/disk_test.go
+++ b/grid-client/integration_tests/disk_test.go
@@ -18,7 +18,7 @@ func TestDiskDeployment(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	defer cancel()
 
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter)
+	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter, []uint64{*convertGBToBytes(1)}, nil, nil)
 	if err != nil {
 		t.Skip("no available nodes found")
 	}

--- a/grid-client/integration_tests/gateway_name_test.go
+++ b/grid-client/integration_tests/gateway_name_test.go
@@ -30,7 +30,7 @@ func TestGatewayNameDeployment(t *testing.T) {
 	assert.NoError(t, err)
 
 	nodeFilter.Domain = &trueVal
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter)
+	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter, nil, nil, []uint64{minRootfs})
 	if err != nil || len(nodes) < 2 {
 		t.Skip("no available nodes found")
 	}

--- a/grid-client/integration_tests/gatway_fqdn_test.go
+++ b/grid-client/integration_tests/gatway_fqdn_test.go
@@ -33,7 +33,7 @@ func TestGatewayFQDNDeployment(t *testing.T) {
 	publicKey, privateKey, err := GenerateSSHKeyPair()
 	assert.NoError(t, err)
 
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter)
+	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter, nil, nil, []uint64{minRootfs})
 	if err != nil {
 		t.Skip("no available nodes found")
 	}

--- a/grid-client/integration_tests/k8s_test.go
+++ b/grid-client/integration_tests/k8s_test.go
@@ -42,7 +42,14 @@ func TestK8sDeployment(t *testing.T) {
 	publicKey, privateKey, err := GenerateSSHKeyPair()
 	assert.NoError(t, err)
 
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter)
+	nodes, err := deployer.FilterNodes(
+		ctx,
+		tfPluginClient,
+		nodeFilter,
+		[]uint64{*convertGBToBytes(1), *convertGBToBytes(1)},
+		nil,
+		[]uint64{minRootfs},
+	)
 	if err != nil || len(nodes) < 2 {
 		t.Skip("no available nodes found")
 	}

--- a/grid-client/integration_tests/network_test.go
+++ b/grid-client/integration_tests/network_test.go
@@ -20,7 +20,7 @@ func TestNetworkDeployment(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter)
+	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter, nil, nil, nil)
 	if err != nil || len(nodes) < 2 {
 		t.Skip("no available nodes found")
 	}

--- a/grid-client/integration_tests/presearch_test.go
+++ b/grid-client/integration_tests/presearch_test.go
@@ -26,7 +26,7 @@ func TestPresearchDeployment(t *testing.T) {
 
 	nodeFilter.IPv4 = &trueVal
 	nodeFilter.FreeIPs = &value1
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter)
+	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter, []uint64{*convertGBToBytes(1)}, nil, []uint64{*convertGBToBytes(20)})
 	if err != nil {
 		t.Skip("no available nodes found")
 	}

--- a/grid-client/integration_tests/qsfs_test.go
+++ b/grid-client/integration_tests/qsfs_test.go
@@ -20,6 +20,7 @@ import (
 const (
 	DataZDBNum = 4
 	MetaZDBNum = 4
+	zdbSize    = 1
 )
 
 func TestQSFSDeployment(t *testing.T) {
@@ -32,7 +33,12 @@ func TestQSFSDeployment(t *testing.T) {
 	publicKey, privateKey, err := GenerateSSHKeyPair()
 	assert.NoError(t, err)
 
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter)
+	zdbSizes := make([]uint64, 0)
+	for i := 0; i < DataZDBNum+MetaZDBNum; i++ {
+		zdbSizes = append(zdbSizes, zdbSize)
+	}
+
+	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter, nil, zdbSizes, []uint64{minRootfs})
 	if err != nil {
 		t.Skip("no available nodes found")
 	}
@@ -57,7 +63,7 @@ func TestQSFSDeployment(t *testing.T) {
 			Name:        "qsfsDataZdb" + strconv.Itoa(i),
 			Password:    "password",
 			Public:      true,
-			Size:        1,
+			Size:        zdbSize,
 			Description: "zdb for testing",
 			Mode:        zos.ZDBModeSeq,
 		}
@@ -69,7 +75,7 @@ func TestQSFSDeployment(t *testing.T) {
 			Name:        "qsfsMetaZdb" + strconv.Itoa(i),
 			Password:    "password",
 			Public:      true,
-			Size:        1,
+			Size:        zdbSize,
 			Description: "zdb for testing",
 			Mode:        zos.ZDBModeUser,
 		}

--- a/grid-client/integration_tests/setup.go
+++ b/grid-client/integration_tests/setup.go
@@ -18,9 +18,11 @@ import (
 )
 
 var (
-	trueVal  = true
-	statusUp = "up"
-	value1   = uint64(1)
+	trueVal   = true
+	falseVal  = false
+	statusUp  = "up"
+	value1    = uint64(1)
+	minRootfs = *convertGBToBytes(2)
 )
 
 var nodeFilter = types.NodeFilter{
@@ -29,7 +31,7 @@ var nodeFilter = types.NodeFilter{
 	FreeHRU: convertGBToBytes(2),
 	FreeMRU: convertGBToBytes(2),
 	FarmIDs: []uint64{1},
-	IPv6:    &trueVal,
+	Rented:  &falseVal,
 }
 
 func convertGBToBytes(gb uint64) *uint64 {

--- a/grid-client/integration_tests/two_vms_same_network_test.go
+++ b/grid-client/integration_tests/two_vms_same_network_test.go
@@ -24,7 +24,7 @@ func TestTwoVMsSameNetwork(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter)
+	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter, nil, nil, []uint64{minRootfs, minRootfs})
 	if err != nil {
 		t.Skip("no available nodes found")
 	}

--- a/grid-client/integration_tests/vm_disk_test.go
+++ b/grid-client/integration_tests/vm_disk_test.go
@@ -25,7 +25,7 @@ func TestVmDisk(t *testing.T) {
 	publicKey, privateKey, err := GenerateSSHKeyPair()
 	assert.NoError(t, err)
 
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter)
+	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter, []uint64{*convertGBToBytes(1)}, nil, []uint64{minRootfs})
 	if err != nil {
 		t.Skip("no available nodes found")
 	}

--- a/grid-client/integration_tests/vm_gpu_test.go
+++ b/grid-client/integration_tests/vm_gpu_test.go
@@ -43,7 +43,7 @@ func TestVMWithGPUDeployment(t *testing.T) {
 		HasGPU:   &trueVal,
 	}
 
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter)
+	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter, []uint64{*convertGBToBytes(20)}, nil, []uint64{minRootfs})
 	if err != nil {
 		t.Skip("no available nodes found")
 	}

--- a/grid-client/integration_tests/vm_test.go
+++ b/grid-client/integration_tests/vm_test.go
@@ -26,7 +26,7 @@ func TestVMDeployment(t *testing.T) {
 
 	nodeFilter.IPv4 = &trueVal
 	nodeFilter.FreeIPs = &value1
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter)
+	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter, nil, nil, []uint64{minRootfs})
 	if err != nil {
 		t.Skip("no available nodes found")
 	}

--- a/grid-client/integration_tests/vm_with_two_disks_test.go
+++ b/grid-client/integration_tests/vm_with_two_disks_test.go
@@ -25,7 +25,14 @@ func TestVMWithTwoDisk(t *testing.T) {
 	publicKey, privateKey, err := GenerateSSHKeyPair()
 	assert.NoError(t, err)
 
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter)
+	nodes, err := deployer.FilterNodes(
+		ctx,
+		tfPluginClient,
+		nodeFilter,
+		[]uint64{*convertGBToBytes(2), *convertGBToBytes(1)},
+		nil,
+		[]uint64{minRootfs},
+	)
 	if err != nil {
 		t.Skip("no available nodes found")
 	}

--- a/grid-client/integration_tests/wireguard_test.go
+++ b/grid-client/integration_tests/wireguard_test.go
@@ -29,7 +29,7 @@ func TestWG(t *testing.T) {
 	publicKey, privateKey, err := GenerateSSHKeyPair()
 	assert.NoError(t, err)
 
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter)
+	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter, nil, nil, []uint64{minRootfs})
 	if err != nil {
 		t.Skip("no available nodes found")
 	}

--- a/grid-client/integration_tests/zdb_test.go
+++ b/grid-client/integration_tests/zdb_test.go
@@ -19,7 +19,7 @@ func TestZDBDeployment(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	defer cancel()
 
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter)
+	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, nodeFilter, nil, []uint64{*convertGBToBytes(10)}, nil)
 	if err != nil {
 		t.Skip("no available nodes found")
 	}

--- a/gridify/internal/deployer/deployer.go
+++ b/gridify/internal/deployer/deployer.go
@@ -59,7 +59,7 @@ func (d *Deployer) Deploy(ctx context.Context, vmSpec VMSpec, ports []uint) (map
 
 	d.logger.Debug().Msg("getting nodes with free resources")
 
-	node, err := d.tfPluginClient.GetAvailableNode(ctx, buildNodeFilter(vmSpec))
+	node, err := d.tfPluginClient.GetAvailableNode(ctx, buildNodeFilter(vmSpec), uint64(vmSpec.Storage))
 	if err != nil {
 		return map[uint]string{}, errors.Wrapf(
 			err,

--- a/gridify/internal/deployer/deployer_test.go
+++ b/gridify/internal/deployer/deployer_test.go
@@ -61,7 +61,7 @@ func TestDeploy(t *testing.T) {
 
 		clientMock.
 			EXPECT().
-			GetAvailableNode(gomock.Any(), filter).
+			GetAvailableNode(gomock.Any(), filter, uint64(Eco.Storage)).
 			Return(uint32(0), errors.New("error"))
 
 		clientMock.
@@ -81,7 +81,7 @@ func TestDeploy(t *testing.T) {
 
 		clientMock.
 			EXPECT().
-			GetAvailableNode(gomock.Any(), filter).
+			GetAvailableNode(gomock.Any(), filter, uint64(Eco.Storage)).
 			Return(uint32(1), nil)
 
 		clientMock.
@@ -101,7 +101,7 @@ func TestDeploy(t *testing.T) {
 
 		clientMock.
 			EXPECT().
-			GetAvailableNode(gomock.Any(), filter).
+			GetAvailableNode(gomock.Any(), filter, uint64(Eco.Storage)).
 			Return(uint32(1), nil)
 
 		clientMock.
@@ -126,7 +126,7 @@ func TestDeploy(t *testing.T) {
 
 		clientMock.
 			EXPECT().
-			GetAvailableNode(gomock.Any(), filter).
+			GetAvailableNode(gomock.Any(), filter, uint64(Eco.Storage)).
 			Return(uint32(1), nil)
 
 		clientMock.
@@ -156,7 +156,7 @@ func TestDeploy(t *testing.T) {
 
 		clientMock.
 			EXPECT().
-			GetAvailableNode(gomock.Any(), filter).
+			GetAvailableNode(gomock.Any(), filter, uint64(Eco.Storage)).
 			Return(uint32(1), nil)
 
 		clientMock.
@@ -191,7 +191,7 @@ func TestDeploy(t *testing.T) {
 
 		clientMock.
 			EXPECT().
-			GetAvailableNode(gomock.Any(), filter).
+			GetAvailableNode(gomock.Any(), filter, uint64(Eco.Storage)).
 			Return(uint32(1), nil)
 
 		clientMock.
@@ -231,7 +231,7 @@ func TestDeploy(t *testing.T) {
 
 		clientMock.
 			EXPECT().
-			GetAvailableNode(gomock.Any(), filter).
+			GetAvailableNode(gomock.Any(), filter, uint64(Eco.Storage)).
 			Return(uint32(1), nil)
 
 		clientMock.
@@ -272,7 +272,7 @@ func TestDeploy(t *testing.T) {
 
 		clientMock.
 			EXPECT().
-			GetAvailableNode(gomock.Any(), filter).
+			GetAvailableNode(gomock.Any(), filter, uint64(Eco.Storage)).
 			Return(uint32(1), nil)
 
 		clientMock.

--- a/gridify/internal/mocks/tfpluginclient_mock.go
+++ b/gridify/internal/mocks/tfpluginclient_mock.go
@@ -94,18 +94,18 @@ func (mr *MockTFPluginClientInterfaceMockRecorder) DeployNetwork(ctx, znet inter
 }
 
 // GetAvailableNode mocks base method.
-func (m *MockTFPluginClientInterface) GetAvailableNode(ctx context.Context, options types.NodeFilter) (uint32, error) {
+func (m *MockTFPluginClientInterface) GetAvailableNode(ctx context.Context, options types.NodeFilter, rootfs uint64) (uint32, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAvailableNode", ctx, options)
+	ret := m.ctrl.Call(m, "GetAvailableNode", ctx, options, rootfs)
 	ret0, _ := ret[0].(uint32)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAvailableNode indicates an expected call of GetAvailableNode.
-func (mr *MockTFPluginClientInterfaceMockRecorder) GetAvailableNode(ctx, options interface{}) *gomock.Call {
+func (mr *MockTFPluginClientInterfaceMockRecorder) GetAvailableNode(ctx, options, rootfs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAvailableNode", reflect.TypeOf((*MockTFPluginClientInterface)(nil).GetAvailableNode), ctx, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAvailableNode", reflect.TypeOf((*MockTFPluginClientInterface)(nil).GetAvailableNode), ctx, options, rootfs)
 }
 
 // GetGridNetwork mocks base method.

--- a/gridify/internal/tfplugin/tfplugin.go
+++ b/gridify/internal/tfplugin/tfplugin.go
@@ -76,7 +76,7 @@ func (t *TFPluginClient) CancelByProjectName(projectName string) error {
 	return t.tfPluginClient.CancelByProjectName(projectName)
 }
 
-// GetAvailableNode returns nodes that match the given filter
+// GetAvailableNode returns nodes that match the given filter with rootfs specified in GBs
 func (t *TFPluginClient) GetAvailableNode(ctx context.Context, options types.NodeFilter, rootfs uint64) (uint32, error) {
 	nodes, err := deployer.FilterNodes(ctx, *t.tfPluginClient, options, nil, nil, []uint64{rootfs * 1024 * 1024 * 1024})
 	if err != nil {

--- a/gridify/internal/tfplugin/tfplugin.go
+++ b/gridify/internal/tfplugin/tfplugin.go
@@ -20,7 +20,7 @@ type TFPluginClientInterface interface {
 	LoadGatewayNameFromGrid(nodeID uint32, name string, deploymentName string) (workloads.GatewayNameProxy, error)
 	ListContractsOfProjectName(projectName string) (graphql.Contracts, error)
 	CancelByProjectName(projectName string) error
-	GetAvailableNode(ctx context.Context, options types.NodeFilter) (uint32, error)
+	GetAvailableNode(ctx context.Context, options types.NodeFilter, rootfs uint64) (uint32, error)
 	GetGridNetwork() string
 	SetState(nodeID uint32, contractIDs []uint64)
 }
@@ -77,8 +77,8 @@ func (t *TFPluginClient) CancelByProjectName(projectName string) error {
 }
 
 // GetAvailableNode returns nodes that match the given filter
-func (t *TFPluginClient) GetAvailableNode(ctx context.Context, options types.NodeFilter) (uint32, error) {
-	nodes, err := deployer.FilterNodes(ctx, *t.tfPluginClient, options)
+func (t *TFPluginClient) GetAvailableNode(ctx context.Context, options types.NodeFilter, rootfs uint64) (uint32, error) {
+	nodes, err := deployer.FilterNodes(ctx, *t.tfPluginClient, options, nil, nil, []uint64{rootfs * 1024 * 1024 * 1024})
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
### Description

Sort disks before checking available pools

### Changes

- FilterNodes now sort different storage before checking pools
- FilterNodes now checks SSD and HDD pools
- Fix cli panic

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-go/issues/264
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/275

### Checklist

- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstring
