### PR TITLE
Update tfchain client and fix cli node flag

### DIFF
--- a/grid-cli/cmd/deploy_vm.go
+++ b/grid-cli/cmd/deploy_vm.go
@@ -78,6 +78,9 @@ var deployVMCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if len(gpus) > 0 && node == 0 {
+			log.Fatal().Msg("must specify node ID when using GPUs")
+		}
 
 		ipv4, err := cmd.Flags().GetBool("ipv4")
 		if err != nil {
@@ -178,8 +181,6 @@ func init() {
 	deployVMCmd.Flags().Int("disk", 0, "disk size in gb mounted on /data")
 	deployVMCmd.Flags().String("flist", ubuntuFlist, "flist for vm")
 	deployVMCmd.Flags().StringSlice("gpus", []string{}, "gpus for vm")
-	// to ensure node is provided for gpus
-	deployVMCmd.MarkFlagsRequiredTogether("gpus", "node")
 
 	deployVMCmd.Flags().String("entrypoint", ubuntuFlistEntrypoint, "entrypoint for vm")
 	// to ensure entrypoint is provided for custom flist

--- a/grid-client/go.mod
+++ b/grid-client/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.30.0
 	github.com/stretchr/testify v1.8.4
-	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20230809064214-d8ef5ca360eb
+	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20230810083358-814ba4cba152
 	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.10.2
 	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.10.2
 	github.com/threefoldtech/zos v0.5.6-0.20230809073554-ddb0ad98fc4c

--- a/grid-client/go.sum
+++ b/grid-client/go.sum
@@ -102,6 +102,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20230809064214-d8ef5ca360eb h1:ljvL1BMwTPrV0kAz9E56zJ5jq39TPRsd/tP6l0+0TzY=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20230809064214-d8ef5ca360eb/go.mod h1:dtDKAPiUDxAwIkfHV7xcAFZcOm+xwNIuOI1MLFS+MeQ=
+github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20230810083358-814ba4cba152 h1:jUfeOQHDUZVAX4BON7xZOj3sQTn0BIjkU84ZhhGzwXw=
+github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20230810083358-814ba4cba152/go.mod h1:dtDKAPiUDxAwIkfHV7xcAFZcOm+xwNIuOI1MLFS+MeQ=
 github.com/threefoldtech/zos v0.5.6-0.20230809073554-ddb0ad98fc4c h1:koGfjcZgxN/Yyo+hM5t5Xyfz/kodxOxitTEmcRD4t9I=
 github.com/threefoldtech/zos v0.5.6-0.20230809073554-ddb0ad98fc4c/go.mod h1:Ao/K9+ChdIQbTCjSGmdG/MEKI1PpP6f2tgugkpSFLY8=
 github.com/tklauser/go-sysconf v0.3.9 h1:JeUVdAOWhhxVcU6Eqr/ATFHgXk/mmiItdKeJPev3vTo=
@@ -134,6 +136,7 @@ golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
### Description

Update tfchain client and fix cli node flag

### Changes

- errors from tfchain are now readable
- cli now can use node flag with no errors

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-go/issues/324
- https://github.com/threefoldtech/terraform-provider-grid/issues/707
