### PR TITLE
enhance contracts query

### DIFF
--- a/grid-proxy/docs/docs.go
+++ b/grid-proxy/docs/docs.go
@@ -132,6 +132,125 @@ const docTemplate = `{
                 }
             }
         },
+        "/contracts/{contract_id}": {
+            "get": {
+                "description": "Get data about a single contract with its id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Contract"
+                ],
+                "summary": "Show single contract info",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Contract ID",
+                        "name": "contract_id",
+                        "in": "path"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Contract"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/contracts/{contract_id}/bills": {
+            "get": {
+                "description": "Get all bills reports for a single contract with its id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ContractDills"
+                ],
+                "summary": "Show single contract bills",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Contract ID",
+                        "name": "contract_id",
+                        "in": "path"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Max result per page",
+                        "name": "size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Set bill reports' count on headers",
+                        "name": "ret_count",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.ContractBilling"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/farms": {
             "get": {
                 "description": "Get all farms on the grid, It has pagination",
@@ -1112,12 +1231,6 @@ const docTemplate = `{
         "types.Contract": {
             "type": "object",
             "properties": {
-                "billing": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.ContractBilling"
-                    }
-                },
                 "contractId": {
                     "type": "integer"
                 },

--- a/grid-proxy/docs/swagger.json
+++ b/grid-proxy/docs/swagger.json
@@ -124,6 +124,125 @@
                 }
             }
         },
+        "/contracts/{contract_id}": {
+            "get": {
+                "description": "Get data about a single contract with its id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Contract"
+                ],
+                "summary": "Show single contract info",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Contract ID",
+                        "name": "contract_id",
+                        "in": "path"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Contract"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/contracts/{contract_id}/bills": {
+            "get": {
+                "description": "Get all bills reports for a single contract with its id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ContractDills"
+                ],
+                "summary": "Show single contract bills",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Contract ID",
+                        "name": "contract_id",
+                        "in": "path"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Max result per page",
+                        "name": "size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Set bill reports' count on headers",
+                        "name": "ret_count",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.ContractBilling"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/farms": {
             "get": {
                 "description": "Get all farms on the grid, It has pagination",
@@ -1104,12 +1223,6 @@
         "types.Contract": {
             "type": "object",
             "properties": {
-                "billing": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.ContractBilling"
-                    }
-                },
                 "contractId": {
                     "type": "integer"
                 },

--- a/grid-proxy/docs/swagger.yaml
+++ b/grid-proxy/docs/swagger.yaml
@@ -38,10 +38,6 @@ definitions:
     type: object
   types.Contract:
     properties:
-      billing:
-        items:
-          $ref: '#/definitions/types.ContractBilling'
-        type: array
       contractId:
         type: integer
       created_at:
@@ -401,6 +397,84 @@ paths:
       summary: Show contracts on the grid
       tags:
       - GridProxy
+  /contracts/{contract_id}:
+    get:
+      consumes:
+      - application/json
+      description: Get data about a single contract with its id
+      parameters:
+      - description: Contract ID
+        in: path
+        name: contract_id
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Contract'
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "404":
+          description: Not Found
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Show single contract info
+      tags:
+      - Contract
+  /contracts/{contract_id}/bills:
+    get:
+      consumes:
+      - application/json
+      description: Get all bills reports for a single contract with its id
+      parameters:
+      - description: Contract ID
+        in: path
+        name: contract_id
+        type: integer
+      - description: Page number
+        in: query
+        name: page
+        type: integer
+      - description: Max result per page
+        in: query
+        name: size
+        type: integer
+      - description: Set bill reports' count on headers
+        in: query
+        name: ret_count
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.ContractBilling'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "404":
+          description: Not Found
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Show single contract bills
+      tags:
+      - ContractDills
   /farms:
     get:
       consumes:

--- a/grid-proxy/internal/explorer/converters.go
+++ b/grid-proxy/internal/explorer/converters.go
@@ -133,6 +133,16 @@ func nodeWithNestedCapacityFromDBNode(info db.Node) types.NodeWithNestedCapacity
 	return node
 }
 
+func contractBillFromDBContractBill(info db.ContractBilling) types.ContractBilling {
+	bill := types.ContractBilling{
+		AmountBilled:     info.AmountBilled,
+		Timestamp:        info.Timestamp,
+		DiscountReceived: info.DiscountReceived,
+	}
+
+	return bill
+}
+
 func contractFromDBContract(info db.DBContract) (types.Contract, error) {
 	var details interface{}
 	switch info.Type {
@@ -159,9 +169,6 @@ func contractFromDBContract(info db.DBContract) (types.Contract, error) {
 		CreatedAt:  info.CreatedAt,
 		Type:       info.Type,
 		Details:    details,
-	}
-	if err := json.Unmarshal([]byte(info.ContractBillings), &contract.Billing); err != nil {
-		return contract, errors.Wrap(err, "couldn't parse contract billing")
 	}
 	return contract, nil
 }

--- a/grid-proxy/internal/explorer/converters.go
+++ b/grid-proxy/internal/explorer/converters.go
@@ -133,16 +133,6 @@ func nodeWithNestedCapacityFromDBNode(info db.Node) types.NodeWithNestedCapacity
 	return node
 }
 
-func contractBillFromDBContractBill(info db.ContractBilling) types.ContractBilling {
-	bill := types.ContractBilling{
-		AmountBilled:     info.AmountBilled,
-		Timestamp:        info.Timestamp,
-		DiscountReceived: info.DiscountReceived,
-	}
-
-	return bill
-}
-
 func contractFromDBContract(info db.DBContract) (types.Contract, error) {
 	var details interface{}
 	switch info.Type {

--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -840,7 +840,8 @@ func (d *PostgresDatabase) GetContractBills(contractID uint32, limit types.Limit
 		Where("contract_id = ?", contractID)
 
 	q = q.Limit(int(limit.Size)).
-		Offset(int(limit.Page-1) * int(limit.Size))
+		Offset(int(limit.Page-1) * int(limit.Size)).
+		Order("timestamp DESC")
 
 	var count int64
 	if limit.RetCount {

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -13,8 +13,12 @@ type Database interface {
 	GetFarms(filter types.FarmFilter, limit types.Limit) ([]Farm, uint, error)
 	GetTwins(filter types.TwinFilter, limit types.Limit) ([]types.Twin, uint, error)
 	GetContracts(filter types.ContractFilter, limit types.Limit) ([]DBContract, uint, error)
+	GetContract(contractID uint32) (DBContract, error)
+	GetContractBills(contractID uint32, limit types.Limit) ([]ContractBilling, uint, error)
 	UpsertNodesGPU(nodesGPU []types.NodeGPU) error
 }
+
+type ContractBilling types.ContractBilling
 
 // DBContract is contract info
 type DBContract struct {
@@ -28,7 +32,6 @@ type DBContract struct {
 	DeploymentHash    string
 	NumberOfPublicIps uint
 	Type              string
-	ContractBillings  string
 }
 
 // Node data about a node which is calculated from the chain

--- a/grid-proxy/internal/explorer/helpers.go
+++ b/grid-proxy/internal/explorer/helpers.go
@@ -358,7 +358,7 @@ func (a *App) getContractBillsData(contractIDStr string, limit types.Limit) ([]t
 
 	bills := []types.ContractBilling{}
 	for _, report := range info {
-		bills = append(bills, contractBillFromDBContractBill(report))
+		bills = append(bills, types.ContractBilling(report))
 	}
 
 	return bills, billsCount, nil

--- a/grid-proxy/internal/explorer/models.go
+++ b/grid-proxy/internal/explorer/models.go
@@ -12,8 +12,9 @@ import (
 
 // ErrNodeNotFound creates new error type to define node existence or server problem
 var (
-	ErrNodeNotFound    = errors.New("node not found")
-	ErrGatewayNotFound = errors.New("gateway not found")
+	ErrNodeNotFound     = errors.New("node not found")
+	ErrGatewayNotFound  = errors.New("gateway not found")
+	ErrContractNotFound = errors.New("contract not found")
 )
 
 // ErrBadGateway creates new error type to define node existence or server problem

--- a/grid-proxy/pkg/client/grid_client.go
+++ b/grid-proxy/pkg/client/grid_client.go
@@ -159,27 +159,9 @@ func (g *Clientimpl) Contracts(filter types.ContractFilter, limit types.Limit) (
 	if err != nil {
 		return
 	}
-	err = json.Unmarshal(data, &res)
+	res, err = decodeMultipleContracts(data)
 	if err != nil {
 		return
-	}
-	for idx := range res {
-		if res[idx].Type == "node" {
-			res[idx].Details = types.NodeContractDetails{
-				NodeID:            res[idx].Details.(types.NodeContractDetails).NodeID,
-				DeploymentData:    res[idx].Details.(types.NodeContractDetails).DeploymentData,
-				DeploymentHash:    res[idx].Details.(types.NodeContractDetails).DeploymentHash,
-				NumberOfPublicIps: res[idx].Details.(types.NodeContractDetails).NumberOfPublicIps,
-			}
-		} else if res[idx].Type == "rent" {
-			res[idx].Details = types.RentContractDetails{
-				NodeID: res[idx].Details.(types.RentContractDetails).NodeID,
-			}
-		} else if res[idx].Type == "name" {
-			res[idx].Details = types.NameContractDetails{
-				Name: res[idx].Details.(types.NameContractDetails).Name,
-			}
-		}
 	}
 	totalCount, err = requestCounters(req)
 	return
@@ -250,8 +232,11 @@ func (g *Clientimpl) Contract(contractID uint32) (res types.Contract, err error)
 	if err != nil {
 		return
 	}
-	err = res.UnmarshalJSON(data)
 
+	res, err = decodeSingleContract(data)
+	if err != nil {
+		return
+	}
 	return
 }
 

--- a/grid-proxy/pkg/client/retrying_grid_client.go
+++ b/grid-proxy/pkg/client/retrying_grid_client.go
@@ -115,3 +115,23 @@ func (g *RetryingClient) NodeStatus(nodeID uint32) (res types.NodeStatus, err er
 	err = backoff.RetryNotify(f, bf(g.timeout), notify("node_status"))
 	return
 }
+
+// Contract returns the contract with the give id
+func (g *RetryingClient) Contract(contractID uint32) (res types.Contract, err error) {
+	f := func() error {
+		res, err = g.cl.Contract(contractID)
+		return err
+	}
+	err = backoff.RetryNotify(f, bf(g.timeout), notify("contract"))
+	return
+}
+
+// ContractBills returns the contract bills with the give id
+func (g *RetryingClient) ContractBills(contractID uint32, limit types.Limit) (res []types.ContractBilling, totalCount uint, err error) {
+	f := func() error {
+		res, totalCount, err = g.cl.ContractBills(contractID, limit)
+		return err
+	}
+	err = backoff.RetryNotify(f, bf(g.timeout), notify("contract_bills"))
+	return
+}

--- a/grid-proxy/pkg/client/retrying_grid_client_test.go
+++ b/grid-proxy/pkg/client/retrying_grid_client_test.go
@@ -50,6 +50,16 @@ func (r *requestCounter) Counters(filter types.StatsFilter) (res types.Counters,
 	return types.Counters{}, errors.New("error")
 }
 
+func (r *requestCounter) Contract(contractID uint32) (res types.Contract, err error) {
+	r.Counter++
+	return types.Contract{}, errors.New("error")
+}
+
+func (r *requestCounter) ContractBills(contractID uint32, limit types.Limit) (res []types.ContractBilling, totalCount uint, err error) {
+	r.Counter++
+	return nil, 0, errors.New("error")
+}
+
 func retryingConstructor(u string) Client {
 	return NewRetryingClientWithTimeout(NewClient(u), 1*time.Millisecond)
 }

--- a/grid-proxy/pkg/client/utils.go
+++ b/grid-proxy/pkg/client/utils.go
@@ -1,11 +1,13 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
 )
 
@@ -345,4 +347,71 @@ func billsParams(limit types.Limit) string {
 	res := builder.String()
 	// pop the extra ? or &
 	return res[:len(res)-1]
+}
+
+func decodeMultipleContracts(data []byte) ([]types.Contract, error) {
+	// Unmarshal the data byte array into a slice of types.RawContract structs
+	var rContracts []types.RawContract
+	if err := json.Unmarshal(data, &rContracts); err != nil {
+		return nil, err
+	}
+
+	contracts := []types.Contract{}
+	for _, rContract := range rContracts {
+		// Call the newContractFromRawContract function to convert each types.RawContract into a types.Contract struct
+		contract, err := newContractFromRawContract(rContract)
+		if err != nil {
+			return nil, err
+		}
+		contracts = append(contracts, contract)
+	}
+
+	return contracts, nil
+}
+
+func decodeSingleContract(data []byte) (types.Contract, error) {
+	var rContract types.RawContract
+	if err := json.Unmarshal(data, &rContract); err != nil {
+		return types.Contract{}, err
+	}
+
+	return newContractFromRawContract(rContract)
+}
+
+func newContractFromRawContract(rContract types.RawContract) (types.Contract, error) {
+	var contract types.Contract
+
+	// Assign values from the RawContract object to the corresponding fields in the Contract object
+	contract.ContractID = rContract.ContractID
+	contract.TwinID = rContract.TwinID
+	contract.State = rContract.State
+	contract.CreatedAt = rContract.CreatedAt
+	contract.Type = rContract.Type
+
+	switch rContract.Type {
+	case "node":
+		// Unmarshal the details of the contract based on the type
+		var details types.NodeContractDetails
+		if err := json.Unmarshal(rContract.Details, &details); err != nil {
+			return types.Contract{}, err
+		}
+		contract.Details = details
+		return contract, nil
+	case "name":
+		var details types.NameContractDetails
+		if err := json.Unmarshal(rContract.Details, &details); err != nil {
+			return types.Contract{}, err
+		}
+		contract.Details = details
+		return contract, nil
+	case "rent":
+		var details types.RentContractDetails
+		if err := json.Unmarshal(rContract.Details, &details); err != nil {
+			return types.Contract{}, err
+		}
+		contract.Details = details
+		return contract, nil
+	default:
+		return types.Contract{}, errors.Errorf("Unknown contract type: %s", rContract.Type)
+	}
 }

--- a/grid-proxy/pkg/client/utils.go
+++ b/grid-proxy/pkg/client/utils.go
@@ -324,3 +324,25 @@ func statsParams(filter types.StatsFilter) string {
 	// pop the extra ? or &
 	return res[:len(res)-1]
 }
+
+func billsParams(limit types.Limit) string {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "?")
+
+	if limit.Page != 0 {
+		fmt.Fprintf(&builder, "page=%d&", limit.Page)
+	}
+	if limit.Size != 0 {
+		fmt.Fprintf(&builder, "size=%d&", limit.Size)
+	}
+	if limit.RetCount {
+		fmt.Fprintf(&builder, "ret_count=true&")
+	}
+	if limit.Randomize {
+		fmt.Fprintf(&builder, "randomize=true&")
+	}
+
+	res := builder.String()
+	// pop the extra ? or &
+	return res[:len(res)-1]
+}

--- a/grid-proxy/pkg/types/types.go
+++ b/grid-proxy/pkg/types/types.go
@@ -258,53 +258,24 @@ type RentContractDetails struct {
 	NodeID uint `json:"nodeId"`
 }
 
-type ContractDetails interface{}
-
+// Contract represents a contract and its details after decoding to one of Details structs.
 type Contract struct {
+	ContractID uint        `json:"contract_id"`
+	TwinID     uint        `json:"twin_id"`
+	State      string      `json:"state"`
+	CreatedAt  uint        `json:"created_at"`
+	Type       string      `json:"type"`
+	Details    interface{} `json:"details"`
+}
+
+// RawContract represents a contract and its details in json RawMessage before decoding.
+type RawContract struct {
 	ContractID uint            `json:"contract_id"`
 	TwinID     uint            `json:"twin_id"`
 	State      string          `json:"state"`
 	CreatedAt  uint            `json:"created_at"`
 	Type       string          `json:"type"`
-	Details    ContractDetails `json:"details"`
-}
-
-type ContractAlias Contract
-
-type TempContract struct {
-	Details map[string]interface{} `json:"details"`
-	*ContractAlias
-}
-
-// UnmarshalJSON is a custom unmarshal method that can marshal the nested Details based on type.
-func (c *Contract) UnmarshalJSON(data []byte) error {
-	temp := &TempContract{
-		ContractAlias: (*ContractAlias)(c),
-	}
-
-	if err := json.Unmarshal(data, &temp); err != nil {
-		return err
-	}
-
-	switch c.Type {
-	case "node":
-		c.Details = NodeContractDetails{
-			NodeID:            uint(temp.Details["nodeId"].(float64)),
-			DeploymentData:    temp.Details["deployment_data"].(string),
-			DeploymentHash:    temp.Details["deployment_hash"].(string),
-			NumberOfPublicIps: uint(temp.Details["number_of_public_ips"].(float64)),
-		}
-	case "name":
-		c.Details = NameContractDetails{
-			Name: temp.Details["name"].(string),
-		}
-	case "rent":
-		c.Details = RentContractDetails{
-			NodeID: uint(temp.Details["nodeId"].(float64)),
-		}
-	}
-
-	return nil
+	Details    json.RawMessage `json:"details"`
 }
 
 type Version struct {

--- a/grid-proxy/pkg/types/types.go
+++ b/grid-proxy/pkg/types/types.go
@@ -269,42 +269,38 @@ type Contract struct {
 	Details    ContractDetails `json:"details"`
 }
 
+type ContractAlias Contract
+
+type TempContract struct {
+	Details map[string]interface{} `json:"details"`
+	*ContractAlias
+}
+
 // UnmarshalJSON is a custom unmarshal method that can marshal the nested Details based on type.
 func (c *Contract) UnmarshalJSON(data []byte) error {
-	type ContractAlias Contract
-
-	aux := &struct {
-		Details map[string]interface{} `json:"details"`
-		*ContractAlias
-	}{
+	temp := &TempContract{
 		ContractAlias: (*ContractAlias)(c),
 	}
 
-	if err := json.Unmarshal(data, &aux); err != nil {
+	if err := json.Unmarshal(data, &temp); err != nil {
 		return err
 	}
 
 	switch c.Type {
 	case "node":
-		{
-			c.Details = NodeContractDetails{
-				NodeID:            uint(aux.Details["nodeId"].(float64)),
-				DeploymentData:    aux.Details["deployment_data"].(string),
-				DeploymentHash:    aux.Details["deployment_hash"].(string),
-				NumberOfPublicIps: uint(aux.Details["number_of_public_ips"].(float64)),
-			}
+		c.Details = NodeContractDetails{
+			NodeID:            uint(temp.Details["nodeId"].(float64)),
+			DeploymentData:    temp.Details["deployment_data"].(string),
+			DeploymentHash:    temp.Details["deployment_hash"].(string),
+			NumberOfPublicIps: uint(temp.Details["number_of_public_ips"].(float64)),
 		}
 	case "name":
-		{
-			c.Details = NameContractDetails{
-				Name: aux.Details["name"].(string),
-			}
+		c.Details = NameContractDetails{
+			Name: temp.Details["name"].(string),
 		}
 	case "rent":
-		{
-			c.Details = RentContractDetails{
-				NodeID: uint(aux.Details["nodeId"].(float64)),
-			}
+		c.Details = RentContractDetails{
+			NodeID: uint(temp.Details["nodeId"].(float64)),
 		}
 	}
 

--- a/grid-proxy/pkg/types/types.go
+++ b/grid-proxy/pkg/types/types.go
@@ -259,13 +259,12 @@ type RentContractDetails struct {
 }
 
 type Contract struct {
-	ContractID uint              `json:"contractId"`
-	TwinID     uint              `json:"twinId"`
-	State      string            `json:"state"`
-	CreatedAt  uint              `json:"created_at"`
-	Type       string            `json:"type"`
-	Details    interface{}       `json:"details"`
-	Billing    []ContractBilling `json:"billing"`
+	ContractID uint        `json:"contractId"`
+	TwinID     uint        `json:"twinId"`
+	State      string      `json:"state"`
+	CreatedAt  uint        `json:"created_at"`
+	Type       string      `json:"type"`
+	Details    interface{} `json:"details"`
 }
 
 type Version struct {

--- a/grid-proxy/tests/queries/contract_test.go
+++ b/grid-proxy/tests/queries/contract_test.go
@@ -166,6 +166,7 @@ func TestBills(t *testing.T) {
 			if l.Page*l.Size >= uint64(wantCount) {
 				break
 			}
+			l.Page++
 		}
 	})
 }

--- a/grid-proxy/tests/queries/contract_test.go
+++ b/grid-proxy/tests/queries/contract_test.go
@@ -147,7 +147,7 @@ func TestBills(t *testing.T) {
 		contractID := rand.Intn(CONTRACTS_TESTS)
 
 		l := proxytypes.Limit{
-			Size:     5,
+			Size:     99999,
 			Page:     1,
 			RetCount: true,
 		}

--- a/grid-proxy/tests/queries/mock_client/contracts.go
+++ b/grid-proxy/tests/queries/mock_client/contracts.go
@@ -16,19 +16,6 @@ func (g *GridProxyMockClient) Contracts(filter types.ContractFilter, limit types
 	if limit.Size == 0 {
 		limit.Size = 50
 	}
-	billings := make(map[uint64][]types.ContractBilling)
-	for contractID, contractBillings := range g.data.Billings {
-		for _, billing := range contractBillings {
-			billings[contractID] = append(billings[contractID], types.ContractBilling{
-				AmountBilled:     billing.AmountBilled,
-				DiscountReceived: billing.DiscountReceived,
-				Timestamp:        billing.Timestamp,
-			})
-		}
-		sort.Slice(billings[contractID], func(i, j int) bool {
-			return billings[contractID][i].Timestamp < billings[contractID][j].Timestamp
-		})
-	}
 
 	for _, contract := range g.data.NodeContracts {
 		if contract.satisfies(filter) {

--- a/grid-proxy/tests/queries/mock_client/contracts.go
+++ b/grid-proxy/tests/queries/mock_client/contracts.go
@@ -209,3 +209,68 @@ func (c *NameContract) satisfies(f types.ContractFilter) bool {
 
 	return true
 }
+
+// Contract returns a single contract with the given contractID
+func (g *GridProxyMockClient) Contract(contractID uint32) (res types.Contract, err error) {
+	nodeContract, ok := g.data.NodeContracts[uint64(contractID)]
+	if ok {
+		return types.Contract{
+			ContractID: uint(nodeContract.ContractID),
+			TwinID:     uint(nodeContract.TwinID),
+			State:      nodeContract.State,
+			CreatedAt:  uint(nodeContract.CreatedAt),
+			Type:       "node",
+			Details: types.NodeContractDetails{
+				NodeID:            uint(nodeContract.NodeID),
+				DeploymentData:    nodeContract.DeploymentData,
+				DeploymentHash:    nodeContract.DeploymentHash,
+				NumberOfPublicIps: uint(nodeContract.NumberOfPublicIPs),
+			},
+		}, err
+	}
+
+	nameContract, ok := g.data.NameContracts[uint64(contractID)]
+	if ok {
+		return types.Contract{
+			ContractID: uint(nameContract.ContractID),
+			TwinID:     uint(nameContract.TwinID),
+			State:      nameContract.State,
+			CreatedAt:  uint(nameContract.CreatedAt),
+			Type:       "name",
+			Details: types.NameContractDetails{
+				Name: nameContract.Name,
+			},
+		}, err
+	}
+
+	rentContract, ok := g.data.RentContracts[uint64(contractID)]
+	if ok {
+		return types.Contract{
+			ContractID: uint(rentContract.ContractID),
+			TwinID:     uint(rentContract.TwinID),
+			State:      rentContract.State,
+			CreatedAt:  uint(rentContract.CreatedAt),
+			Type:       "rent",
+			Details: types.RentContractDetails{
+				NodeID: uint(rentContract.NodeID),
+			},
+		}, err
+	}
+
+	return res, err
+}
+
+// ContractBills returns all bills reports for a contract with the given contract id and pagination parameters
+func (g *GridProxyMockClient) ContractBills(contractID uint32, limit types.Limit) (res []types.ContractBilling, totalCount uint, err error) {
+	bills := g.data.Billings[uint64(contractID)]
+
+	for _, bill := range bills {
+		res = append(res, types.ContractBilling{
+			AmountBilled:     bill.AmountBilled,
+			DiscountReceived: bill.DiscountReceived,
+			Timestamp:        bill.Timestamp,
+		})
+	}
+
+	return res, totalCount, err
+}

--- a/grid-proxy/tests/queries/mock_client/contracts.go
+++ b/grid-proxy/tests/queries/mock_client/contracts.go
@@ -44,7 +44,6 @@ func (g *GridProxyMockClient) Contracts(filter types.ContractFilter, limit types
 					DeploymentHash:    contract.DeploymentHash,
 					NumberOfPublicIps: uint(contract.NumberOfPublicIPs),
 				},
-				Billing: append([]types.ContractBilling{}, billings[contract.ContractID]...),
 			}
 			res = append(res, contract)
 		}
@@ -61,7 +60,6 @@ func (g *GridProxyMockClient) Contracts(filter types.ContractFilter, limit types
 				Details: types.RentContractDetails{
 					NodeID: uint(contract.NodeID),
 				},
-				Billing: append([]types.ContractBilling{}, billings[contract.ContractID]...),
 			}
 			res = append(res, contract)
 		}
@@ -78,7 +76,6 @@ func (g *GridProxyMockClient) Contracts(filter types.ContractFilter, limit types
 				Details: types.NameContractDetails{
 					Name: contract.Name,
 				},
-				Billing: append([]types.ContractBilling{}, billings[contract.ContractID]...),
 			}
 			res = append(res, contract)
 		}

--- a/grid-proxy/tests/queries/mock_client/contracts.go
+++ b/grid-proxy/tests/queries/mock_client/contracts.go
@@ -272,5 +272,6 @@ func (g *GridProxyMockClient) ContractBills(contractID uint32, limit types.Limit
 		})
 	}
 
+	totalCount = uint(len(bills))
 	return res, totalCount, err
 }

--- a/grid-proxy/tests/queries/mock_client/contracts.go
+++ b/grid-proxy/tests/queries/mock_client/contracts.go
@@ -249,6 +249,7 @@ func (g *GridProxyMockClient) Contract(contractID uint32) (res types.Contract, e
 
 // ContractBills returns all bills reports for a contract with the given contract id and pagination parameters
 func (g *GridProxyMockClient) ContractBills(contractID uint32, limit types.Limit) (res []types.ContractBilling, totalCount uint, err error) {
+	res = []types.ContractBilling{}
 	bills := g.data.Billings[uint64(contractID)]
 
 	for _, bill := range bills {

--- a/grid-proxy/tests/queries/mock_client/loader.go
+++ b/grid-proxy/tests/queries/mock_client/loader.go
@@ -454,7 +454,9 @@ func loadContractBillingReports(db *sql.DB, data *DBData) error {
 		COALESCE(amount_billed, 0),
 		COALESCE(timestamp, 0)
 	FROM
-		contract_bill_report;`)
+		contract_bill_report
+	ORDER BY
+        timestamp DESC;`)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description
separate contracts bills in a new query to speed up the contracts query

### Changes
- add two new endpoints `/contracts/contract_id` and `/contracts/contract_id/bills`
- add helper method for creating response with count pagination headers
- remove billing from contract response and remove the join with contract_bills table

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/347
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/231

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
