### PR TITLE
refactoring generate.go queries

### DIFF
--- a/grid-proxy/tests/queries/mock_client/farms.go
+++ b/grid-proxy/tests/queries/mock_client/farms.go
@@ -158,6 +158,10 @@ func (f *Farm) satisfyFarmNodesFilter(data *DBData, filter types.FarmFilter) boo
 			continue
 		}
 
+		if filter.Country != nil && !strings.EqualFold(*filter.Country, node.Country) {
+			continue
+		}
+
 		return true
 	}
 	return false

--- a/grid-proxy/tools/db/generate.go
+++ b/grid-proxy/tools/db/generate.go
@@ -29,14 +29,14 @@ const (
 	contractCreatedRatio = .1 // from devnet
 	usedPublicIPsRatio   = .9
 	nodeUpRatio          = .5
-	nodeCount            = 100000
-	farmCount            = 10000
-	normalUsers          = 50000
+	nodeCount            = 1000
+	farmCount            = 100
+	normalUsers          = 2000
 	publicIPCount        = 1000
 	twinCount            = nodeCount + farmCount + normalUsers
-	nodeContractCount    = 100000
-	rentContractCount    = 1000
-	nameContractCount    = 1000
+	nodeContractCount    = 3000
+	rentContractCount    = 100
+	nameContractCount    = 300
 
 	maxContractHRU = 1024 * 1024 * 1024 * 300
 	maxContractSRU = 1024 * 1024 * 1024 * 300

--- a/grid-proxy/tools/db/generate.go
+++ b/grid-proxy/tools/db/generate.go
@@ -62,11 +62,11 @@ var (
 func initSchema(db *sql.DB) error {
 	schema, err := os.ReadFile("./schema.sql")
 	if err != nil {
-		panic(err)
+		return err
 	}
 	_, err = db.Exec(string(schema))
 	if err != nil {
-		panic(err)
+		return err
 	}
 	return nil
 }
@@ -86,7 +86,7 @@ func generateTwins(db *sql.DB) error {
 
 		value, err := extractValuesFromInsertQuery(insertQuery(&twin))
 		if err != nil {
-			panic(err)
+			return err
 		}
 		values = append(values, value)
 	}
@@ -96,7 +96,7 @@ func generateTwins(db *sql.DB) error {
 		query += strings.Join(values, ",") + ";"
 
 		if _, err := db.Exec(query); err != nil {
-			panic(err)
+			return err
 		}
 
 	}
@@ -125,7 +125,7 @@ func generatePublicIPs(db *sql.DB) error {
 
 		value, err := extractValuesFromInsertQuery(insertQuery(&public_ip))
 		if err != nil {
-			panic(err)
+			return err
 		}
 		publicIPValues = append(publicIPValues, value)
 		nodeContractUpdateValues = append(nodeContractUpdateValues, fmt.Sprintf("%d", contract_id))
@@ -137,7 +137,7 @@ func generatePublicIPs(db *sql.DB) error {
 		query += strings.Join(publicIPValues, ",") + ";"
 
 		if _, err := db.Exec(query); err != nil {
-			panic(err)
+			return err
 		}
 	}
 
@@ -145,7 +145,7 @@ func generatePublicIPs(db *sql.DB) error {
 		query := "UPDATE node_contract set number_of_public_i_ps = number_of_public_i_ps + 1 WHERE contract_id IN ("
 		query += strings.Join(nodeContractUpdateValues, ",") + ");"
 		if _, err := db.Exec(query); err != nil {
-			panic(err)
+			return err
 		}
 	}
 	fmt.Println("public IPs generated")
@@ -173,7 +173,7 @@ func generateFarms(db *sql.DB) error {
 
 		value, err := extractValuesFromInsertQuery(insertQuery(&farm))
 		if err != nil {
-			panic(err)
+			return err
 		}
 		values = append(values, value)
 	}
@@ -182,7 +182,7 @@ func generateFarms(db *sql.DB) error {
 		query := "INSERT INTO farm (id, grid_version, farm_id, name, twin_id, pricing_policy_id, certification, stellar_address, dedicated_farm) VALUES"
 		query += strings.Join(values, ",") + ";"
 		if _, err := db.Exec(query); err != nil {
-			panic(err)
+			return err
 		}
 	}
 	fmt.Println("Farms generated")
@@ -252,13 +252,13 @@ func generateContracts(db *sql.DB) error {
 
 		value, err := extractValuesFromInsertQuery(insertQuery(&contract))
 		if err != nil {
-			panic(err)
+			return err
 		}
 		contractsValues = append(contractsValues, value)
 
 		value, err = extractValuesFromInsertQuery(insertQuery(&contract_resources))
 		if err != nil {
-			panic(err)
+			return err
 		}
 		contractResourcesValues = append(contractResourcesValues, value)
 
@@ -275,7 +275,7 @@ func generateContracts(db *sql.DB) error {
 
 			value, err = extractValuesFromInsertQuery(insertQuery(&billing))
 			if err != nil {
-				panic(err)
+				return err
 			}
 			billingValues = append(billingValues, value)
 		}
@@ -286,7 +286,7 @@ func generateContracts(db *sql.DB) error {
 		query := "INSERT INTO node_contract (id, grid_version, contract_id, twin_id, node_id, deployment_data, deployment_hash, number_of_public_i_ps, state, created_at, resources_used_id) VALUES"
 		query += strings.Join(contractsValues, ",") + ";"
 		if _, err := db.Exec(query); err != nil {
-			panic(err)
+			return err
 		}
 	}
 
@@ -294,21 +294,21 @@ func generateContracts(db *sql.DB) error {
 		query := "INSERT INTO contract_resources (id, hru, sru, cru, mru, contract_id) VALUES"
 		query += strings.Join(contractResourcesValues, ",") + ";"
 		if _, err := db.Exec(query); err != nil {
-			panic(err)
+			return err
 		}
 	}
 
 	query := fmt.Sprintf(`UPDATE node_contract SET resources_used_id = CONCAT('contract-resources-',split_part(id, '-', -1))
 		WHERE CAST(split_part(id, '-', -1) AS INTEGER) BETWEEN %d AND %d;`, startContractCnt, contractCnt-1)
 	if _, err := db.Exec(query); err != nil {
-		panic(err)
+		return err
 	}
 
 	if len(billingValues) != 0 {
 		query := "INSERT INTO contract_bill_report (id, contract_id, discount_received, amount_billed, timestamp) VALUES"
 		query += strings.Join(billingValues, ",") + ";"
 		if _, err := db.Exec(query); err != nil {
-			panic(err)
+			return err
 		}
 	}
 
@@ -350,7 +350,7 @@ func generateNameContracts(db *sql.DB) error {
 
 		value, err := extractValuesFromInsertQuery(insertQuery(&contract))
 		if err != nil {
-			panic(err)
+			return err
 		}
 		contractValues = append(contractValues, value)
 
@@ -367,7 +367,7 @@ func generateNameContracts(db *sql.DB) error {
 
 			value, err = extractValuesFromInsertQuery(insertQuery(&billing))
 			if err != nil {
-				panic(err)
+				return err
 			}
 			billReportsValues = append(billReportsValues, value)
 		}
@@ -378,7 +378,7 @@ func generateNameContracts(db *sql.DB) error {
 		query := "INSERT INTO name_contract (id, grid_version, contract_id, twin_id, name, state, created_at) VALUES"
 		query += strings.Join(contractValues, ",") + ";"
 		if _, err := db.Exec(query); err != nil {
-			panic(err)
+			return err
 		}
 	}
 
@@ -386,7 +386,7 @@ func generateNameContracts(db *sql.DB) error {
 		query := "INSERT INTO contract_bill_report (id, contract_id, discount_received, amount_billed, timestamp) VALUES"
 		query += strings.Join(billReportsValues, ",") + ";"
 		if _, err := db.Exec(query); err != nil {
-			panic(err)
+			return err
 		}
 	}
 
@@ -424,7 +424,7 @@ func generateRentContracts(db *sql.DB) error {
 
 		value, err := extractValuesFromInsertQuery(insertQuery(&contract))
 		if err != nil {
-			panic(err)
+			return err
 		}
 		contractValues = append(contractValues, value)
 
@@ -442,7 +442,7 @@ func generateRentContracts(db *sql.DB) error {
 
 			value, err = extractValuesFromInsertQuery(insertQuery(&billing))
 			if err != nil {
-				panic(err)
+				return err
 			}
 			billReportsValues = append(billReportsValues, value)
 
@@ -454,14 +454,14 @@ func generateRentContracts(db *sql.DB) error {
 		query := "INSERT INTO rent_contract (id, grid_version, contract_id, twin_id, node_id, state, created_at) VALUES"
 		query += strings.Join(contractValues, ",") + ";"
 		if _, err := db.Exec(query); err != nil {
-			panic(err)
+			return err
 		}
 	}
 	if len(billReportsValues) != 0 {
 		query := "INSERT INTO contract_bill_report (id, contract_id, discount_received, amount_billed, timestamp) VALUES"
 		query += strings.Join(billReportsValues, ",") + ";"
 		if _, err := db.Exec(query); err != nil {
-			panic(err)
+			return err
 		}
 	}
 	fmt.Println("rent contracts generated")
@@ -537,19 +537,19 @@ func generateNodes(db *sql.DB) error {
 
 		value, err := extractValuesFromInsertQuery(insertQuery(&location))
 		if err != nil {
-			panic(err)
+			return err
 		}
 		locationValues = append(locationValues, value)
 
 		value, err = extractValuesFromInsertQuery(insertQuery(&node))
 		if err != nil {
-			panic(err)
+			return err
 		}
 		nodeValues = append(nodeValues, value)
 
 		value, err = extractValuesFromInsertQuery(insertQuery(&total_resources))
 		if err != nil {
-			panic(err)
+			return err
 		}
 		totalResourcesValues = append(totalResourcesValues, value)
 
@@ -564,7 +564,7 @@ func generateNodes(db *sql.DB) error {
 				node_id: fmt.Sprintf("node-%d", i),
 			}))
 			if err != nil {
-				panic(err)
+				return err
 			}
 			publicConfigValues = append(publicConfigValues)
 
@@ -575,7 +575,7 @@ func generateNodes(db *sql.DB) error {
 		query := "INSERT INTO location (id, longitude, latitude) VALUES"
 		query += strings.Join(locationValues, ",") + ";"
 		if _, err := db.Exec(query); err != nil {
-			panic(err)
+			return err
 		}
 	}
 
@@ -583,7 +583,7 @@ func generateNodes(db *sql.DB) error {
 		query := "INSERT INTO node (id, grid_version, node_id, farm_id, twin_id, country, city, uptime, created, farming_policy_id, certification, secure, virtualized, serial_number, created_at, updated_at, location_id, power, extra_fee) VALUES"
 		query += strings.Join(nodeValues, ",") + ";"
 		if _, err := db.Exec(query); err != nil {
-			panic(err)
+			return err
 		}
 	}
 
@@ -591,7 +591,7 @@ func generateNodes(db *sql.DB) error {
 		query := "INSERT INTO node_resources_total (id, hru, sru, cru, mru, node_id) VALUES"
 		query += strings.Join(totalResourcesValues, ",") + ";"
 		if _, err := db.Exec(query); err != nil {
-			panic(err)
+			return err
 		}
 	}
 
@@ -599,7 +599,7 @@ func generateNodes(db *sql.DB) error {
 		query := "INSERT INTO public_config (id, ipv4, ipv6, gw4, gw6, domain, node_id) VALUES"
 		query += strings.Join(publicConfigValues, ",") + ";"
 		if _, err := db.Exec(query); err != nil {
-			panic(err)
+			return err
 		}
 	}
 
@@ -621,7 +621,7 @@ func generateNodeGPUs(db *sql.DB) error {
 
 		value, err := extractValuesFromInsertQuery(insertQuery(&g))
 		if err != nil {
-			panic(err)
+			return err
 		}
 		values = append(values, value)
 	}
@@ -630,7 +630,7 @@ func generateNodeGPUs(db *sql.DB) error {
 		query := "INSERT INTO node_gpu (node_twin_id, id, vendor, device, contract) VALUES"
 		query += strings.Join(values, ",") + ";"
 		if _, err := db.Exec(query); err != nil {
-			panic(err)
+			return err
 		}
 	}
 

--- a/grid-proxy/tools/db/generate.go
+++ b/grid-proxy/tools/db/generate.go
@@ -494,12 +494,11 @@ func generateNodes(db *sql.DB) error {
 		}
 		updatedAt := time.Now().Unix() - int64(periodFromLatestUpdate)
 
-		periodFromLatestUpdate, err = rnd(0, 60*40*1)
-		if err != nil {
-			return err
-		}
-
 		if up {
+			periodFromLatestUpdate, err = rnd(0, 60*40*1)
+			if err != nil {
+				return err
+			}
 			updatedAt = time.Now().Unix() - int64(periodFromLatestUpdate)
 		}
 

--- a/grid-proxy/tools/db/generate.go
+++ b/grid-proxy/tools/db/generate.go
@@ -61,11 +61,11 @@ var (
 func initSchema(db *sql.DB) error {
 	schema, err := os.ReadFile("./schema.sql")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to init schema: %w", err)
 	}
 	_, err = db.Exec(string(schema))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to init schema: %w", err)
 	}
 	return nil
 }
@@ -86,7 +86,7 @@ func generateTwins(db *sql.DB) error {
 	}
 
 	if err := insertTuples(db, twin{}, twins); err != nil {
-		return err
+		return fmt.Errorf("failed to insert twins: %w", err)
 	}
 	fmt.Println("twins generated")
 
@@ -102,14 +102,14 @@ func generatePublicIPs(db *sql.DB) error {
 		if flip(usedPublicIPsRatio) {
 			idx, err := rnd(0, uint64(len(createdNodeContracts))-1)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to generate random index: %w", err)
 			}
 			contract_id = createdNodeContracts[idx]
 		}
 		ip := randomIPv4()
 		farmID, err := rnd(1, farmCount)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to generate random farm id: %w", err)
 		}
 
 		public_ip := public_ip{
@@ -124,11 +124,11 @@ func generatePublicIPs(db *sql.DB) error {
 	}
 
 	if err := insertTuples(db, public_ip{}, publicIPs); err != nil {
-		return err
+		return fmt.Errorf("failed to insert public ips: %w", err)
 	}
 
 	if err := updateNodeContractPublicIPs(db, nodeContracts); err != nil {
-		return err
+		return fmt.Errorf("failed to update contract public ips: %w", err)
 	}
 
 	fmt.Println("public IPs generated")
@@ -160,7 +160,7 @@ func generateFarms(db *sql.DB) error {
 	}
 
 	if err := insertTuples(db, farm{}, farms); err != nil {
-		return err
+		return fmt.Errorf("failed to insert farms: %w", err)
 	}
 	fmt.Println("farms generated")
 
@@ -175,7 +175,7 @@ func generateNodeContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 	for i := uint64(1); i <= nodeContractCount; i++ {
 		nodeID, err := rnd(1, nodeCount)
 		if err != nil {
-			return nil, contractsStartID, err
+			return nil, contractsStartID, fmt.Errorf("failed to generate random node id: %w", err)
 		}
 		state := "Deleted"
 
@@ -194,7 +194,7 @@ func generateNodeContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 
 		twinID, err := rnd(1100, 3100)
 		if err != nil {
-			return nil, contractsStartID, err
+			return nil, contractsStartID, fmt.Errorf("failed to generate random twin id: %w", err)
 		}
 
 		if renter, ok := renter[nodeID]; ok {
@@ -222,22 +222,22 @@ func generateNodeContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 
 		cru, err := rnd(minContractCRU, maxContractCRU)
 		if err != nil {
-			return nil, contractsStartID, err
+			return nil, contractsStartID, fmt.Errorf("failed to generate random cru: %w", err)
 		}
 
 		hru, err := rnd(minContractHRU, min(maxContractHRU, nodesHRU[nodeID]))
 		if err != nil {
-			return nil, contractsStartID, err
+			return nil, contractsStartID, fmt.Errorf("failed to generate random hru: %w", err)
 		}
 
 		sru, err := rnd(minContractSRU, min(maxContractSRU, nodesSRU[nodeID]))
 		if err != nil {
-			return nil, contractsStartID, err
+			return nil, contractsStartID, fmt.Errorf("failed to generate random sru: %w", err)
 		}
 
 		mru, err := rnd(minContractMRU, min(maxContractMRU, nodesMRU[nodeID]))
 		if err != nil {
-			return nil, contractsStartID, err
+			return nil, contractsStartID, fmt.Errorf("failed to generate random mru: %w", err)
 		}
 
 		contract_resources := contract_resources{
@@ -261,12 +261,12 @@ func generateNodeContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 
 		billings, err := rnd(0, 10)
 		if err != nil {
-			return nil, contractsStartID, err
+			return nil, contractsStartID, fmt.Errorf("failed to generate random billing count: %w", err)
 		}
 
 		amountBilled, err := rnd(0, 100000)
 		if err != nil {
-			return nil, contractsStartID, err
+			return nil, contractsStartID, fmt.Errorf("failed to generate random amount billed: %w", err)
 		}
 		for j := uint64(0); j < billings; j++ {
 			billing := contract_bill_report{
@@ -284,15 +284,15 @@ func generateNodeContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 	}
 
 	if err := insertTuples(db, node_contract{}, contracts); err != nil {
-		return nil, contractsStartID, err
+		return nil, contractsStartID, fmt.Errorf("failed to insert node contracts: %w", err)
 	}
 
 	if err := insertTuples(db, contract_resources{}, contractResources); err != nil {
-		return nil, contractsStartID, err
+		return nil, contractsStartID, fmt.Errorf("failed to insert contract resources: %w", err)
 	}
 
 	if err := updateNodeContractResourceID(db, contractsStartID-nodeContractCount, contractsStartID); err != nil {
-		return nil, contractsStartID, err
+		return nil, contractsStartID, fmt.Errorf("failed to update node contract resources id: %w", err)
 	}
 
 	fmt.Println("node contracts generated")
@@ -306,7 +306,7 @@ func generateNameContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 	for i := uint64(1); i <= nameContractCount; i++ {
 		nodeID, err := rnd(1, nodeCount)
 		if err != nil {
-			return nil, contractsStartID, err
+			return nil, contractsStartID, fmt.Errorf("failed to generate random node id: %w", err)
 		}
 
 		state := "Deleted"
@@ -320,7 +320,7 @@ func generateNameContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 
 		twinID, err := rnd(1100, 3100)
 		if err != nil {
-			return nil, contractsStartID, err
+			return nil, contractsStartID, fmt.Errorf("failed to generate random twin id: %w", err)
 		}
 
 		if renter, ok := renter[nodeID]; ok {
@@ -346,9 +346,13 @@ func generateNameContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 
 		billings, err := rnd(0, 10)
 		if err != nil {
-			return nil, contractsStartID, err
+			return nil, contractsStartID, fmt.Errorf("failed to generate random billings count: %w", err)
 		}
 		amountBilled, err := rnd(0, 100000)
+		if err != nil {
+			return nil, contractsStartID, fmt.Errorf("failed to generate random amount billed: %w", err)
+		}
+
 		for j := uint64(0); j < billings; j++ {
 			billing := contract_bill_report{
 				id:                fmt.Sprintf("contract-bill-report-%d", billsStartID),
@@ -365,7 +369,7 @@ func generateNameContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 	}
 
 	if err := insertTuples(db, name_contract{}, contracts); err != nil {
-		return nil, contractsStartID, err
+		return nil, contractsStartID, fmt.Errorf("failed to insert name contracts: %w", err)
 	}
 
 	fmt.Println("name contracts generated")
@@ -378,7 +382,7 @@ func generateRentContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 	for i := uint64(1); i <= rentContractCount; i++ {
 		nl, nodeID, err := popRandom(availableRentNodesList)
 		if err != nil {
-			return nil, contractsStartID, err
+			return nil, contractsStartID, fmt.Errorf("failed to select random element from the gives slice: %w", err)
 		}
 
 		availableRentNodesList = nl
@@ -411,12 +415,12 @@ func generateRentContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 
 		billings, err := rnd(0, 10)
 		if err != nil {
-			return nil, contractsStartID, err
+			return nil, contractsStartID, fmt.Errorf("failed to generate billings count: %w", err)
 		}
 
 		amountBilled, err := rnd(0, 100000)
 		if err != nil {
-			return nil, contractsStartID, err
+			return nil, contractsStartID, fmt.Errorf("failed to generate amount billed: %w", err)
 		}
 
 		for j := uint64(0); j < billings; j++ {
@@ -437,7 +441,7 @@ func generateRentContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 	}
 
 	if err := insertTuples(db, rent_contract{}, contracts); err != nil {
-		return nil, contractsStartID, err
+		return nil, contractsStartID, fmt.Errorf("failed to insert rent contracts: %w", err)
 	}
 
 	fmt.Println("rent contracts generated")
@@ -454,38 +458,38 @@ func generateNodes(db *sql.DB) error {
 	for i := uint64(1); i <= nodeCount; i++ {
 		mru, err := rnd(4, 256)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to generate random mru: %w", err)
 		}
 		mru *= 1024 * 1024 * 1024
 
 		hru, err := rnd(100, 30*1024)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to generate random hru: %w", err)
 		}
 		hru *= 1024 * 1024 * 1024 // 100GB -> 30TB
 
 		sru, err := rnd(200, 30*1024)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to generate random sru: %w", err)
 		}
 		sru *= 1024 * 1024 * 1024 // 100GB -> 30TB
 
 		cru, err := rnd(4, 128)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to generate random cru: %w", err)
 		}
 
 		up := flip(nodeUpRatio)
 		periodFromLatestUpdate, err := rnd(60*40*3, 60*60*24*30*12)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to generate random period from latest update: %w", err)
 		}
 		updatedAt := time.Now().Unix() - int64(periodFromLatestUpdate)
 
 		if up {
 			periodFromLatestUpdate, err = rnd(0, 60*40*1)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to generate period from latest update: %w", err)
 			}
 			updatedAt = time.Now().Unix() - int64(periodFromLatestUpdate)
 		}
@@ -564,19 +568,19 @@ func generateNodes(db *sql.DB) error {
 	}
 
 	if err := insertTuples(db, location{}, locations); err != nil {
-		return err
+		return fmt.Errorf("failed to insert locations: %w", err)
 	}
 
 	if err := insertTuples(db, node{}, nodes); err != nil {
-		return err
+		return fmt.Errorf("failed to isnert nodes: %w", err)
 	}
 
 	if err := insertTuples(db, node_resources_total{}, totalResources); err != nil {
-		return err
+		return fmt.Errorf("failed to insert node resources total: %w", err)
 	}
 
 	if err := insertTuples(db, public_config{}, publicConfigs); err != nil {
-		return err
+		return fmt.Errorf("failed to insert public configs: %w", err)
 	}
 	fmt.Println("nodes generated")
 
@@ -598,7 +602,7 @@ func generateNodeGPUs(db *sql.DB) error {
 	}
 
 	if err := insertTuples(db, node_gpu{}, GPUs); err != nil {
-		return err
+		return fmt.Errorf("failed to insert node gpu: %w", err)
 	}
 
 	fmt.Println("node GPUs generated")
@@ -614,23 +618,26 @@ func generateContracts(db *sql.DB) error {
 
 	rentContractsBillReports, contractCount, err := generateRentContracts(db, 1, contractsStartID)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to generate rent contracts: %w", err)
 	}
 	billReports = append(billReports, rentContractsBillReports...)
 
 	nodeContractsBillReports, contractsStartID, err := generateNodeContracts(db, len(billReports)+1, contractCount)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to generate node contracts: %w", err)
 	}
 	billReports = append(billReports, nodeContractsBillReports...)
 
 	nameContractsBillReports, contractsStartID, err := generateNameContracts(db, len(billReports)+1, contractCount)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to generate name contracts: %w", err)
 	}
 	billReports = append(billReports, nameContractsBillReports...)
 
-	return insertTuples(db, contract_bill_report{}, billReports)
+	if err := insertTuples(db, contract_bill_report{}, billReports); err != nil {
+		return fmt.Errorf("failed to generate contract bill reports: %w", err)
+	}
+	return nil
 }
 
 func insertTuples(db *sql.DB, tupleObj interface{}, tuples []string) error {
@@ -650,7 +657,7 @@ func insertTuples(db *sql.DB, tupleObj interface{}, tuples []string) error {
 		query += strings.Join(tuples, ",")
 		query += ";"
 		if _, err := db.Exec(query); err != nil {
-			return err
+			return fmt.Errorf("failed to insert tuples: %w", err)
 		}
 
 	}
@@ -669,7 +676,7 @@ func updateNodeContractPublicIPs(db *sql.DB, nodeContracts []uint64) error {
 		query := "UPDATE node_contract set number_of_public_i_ps = number_of_public_i_ps + 1 WHERE contract_id IN ("
 		query += strings.Join(IDs, ",") + ");"
 		if _, err := db.Exec(query); err != nil {
-			return err
+			return fmt.Errorf("failed to update node contracts public ips: %w", err)
 		}
 	}
 	return nil
@@ -679,34 +686,34 @@ func updateNodeContractResourceID(db *sql.DB, min, max int) error {
 	query := fmt.Sprintf(`UPDATE node_contract SET resources_used_id = CONCAT('contract-resources-',split_part(id, '-', -1))
 		WHERE CAST(split_part(id, '-', -1) AS INTEGER) BETWEEN %d AND %d;`, min, max)
 	if _, err := db.Exec(query); err != nil {
-		return err
+		return fmt.Errorf("failed to update node contract resource id: %w", err)
 	}
 
 	return nil
 }
 func generateData(db *sql.DB) error {
 	if err := generateTwins(db); err != nil {
-		panic(err)
+		return fmt.Errorf("failed to genrate twins: %w", err)
 	}
 
 	if err := generateFarms(db); err != nil {
-		panic(err)
+		return fmt.Errorf("failed to generate farms: %w", err)
 	}
 
 	if err := generateNodes(db); err != nil {
-		panic(err)
+		return fmt.Errorf("failed to generate nodes: %w", err)
 	}
 
 	if err := generateContracts(db); err != nil {
-		panic(err)
+		return fmt.Errorf("failed to generate contracts: %w", err)
 	}
 
 	if err := generatePublicIPs(db); err != nil {
-		panic(err)
+		return fmt.Errorf("failed to generate public ips: %w", err)
 	}
 
 	if err := generateNodeGPUs(db); err != nil {
-		panic(err)
+		return fmt.Errorf("failed to generate node gpus: %w", err)
 	}
 
 	return nil

--- a/grid-proxy/tools/db/generate.go
+++ b/grid-proxy/tools/db/generate.go
@@ -71,7 +71,7 @@ func initSchema(db *sql.DB) error {
 }
 
 func generateTwins(db *sql.DB) error {
-	var twins []interface{}
+	var twins []string
 
 	for i := uint64(1); i <= twinCount; i++ {
 		twin := twin{
@@ -82,10 +82,10 @@ func generateTwins(db *sql.DB) error {
 			twin_id:      i,
 			grid_version: 3,
 		}
-		twins = append(twins, twin)
+		twins = append(twins, objectToTupleString(twin))
 	}
 
-	if err := insertTuples(db, twins); err != nil {
+	if err := insertTuples(db, twin{}, twins); err != nil {
 		return err
 	}
 	fmt.Println("twins generated")
@@ -94,7 +94,7 @@ func generateTwins(db *sql.DB) error {
 }
 
 func generatePublicIPs(db *sql.DB) error {
-	var publicIPs []interface{}
+	var publicIPs []string
 	var nodeContracts []interface{}
 
 	for i := uint64(1); i <= publicIPCount; i++ {
@@ -108,11 +108,11 @@ func generatePublicIPs(db *sql.DB) error {
 		}
 		ip := randomIPv4()
 		farmID, err := rnd(1, farmCount)
-		
+
 		if err != nil {
 			return err
 		}
-		
+
 		public_ip := public_ip{
 			id:          fmt.Sprintf("public-ip-%d", i),
 			gateway:     ip.String(),
@@ -121,12 +121,12 @@ func generatePublicIPs(db *sql.DB) error {
 			farm_id:     fmt.Sprintf("farm-%d", farmID),
 		}
 
-		publicIPs = append(publicIPs, public_ip)
+		publicIPs = append(publicIPs, objectToTupleString(public_ip))
 		nodeContracts = append(nodeContracts, contract_id)
 
 	}
 
-	if err := insertTuples(db, publicIPs); err != nil {
+	if err := insertTuples(db, public_ip{}, publicIPs); err != nil {
 		return err
 	}
 
@@ -140,7 +140,7 @@ func generatePublicIPs(db *sql.DB) error {
 }
 
 func generateFarms(db *sql.DB) error {
-	var farms []interface{}
+	var farms []string
 
 	for i := uint64(1); i <= farmCount; i++ {
 		farm := farm{
@@ -159,10 +159,10 @@ func generateFarms(db *sql.DB) error {
 			dedicatedFarms[farm.farm_id] = struct{}{}
 		}
 
-		farms = append(farms, farm)
+		farms = append(farms, objectToTupleString(farm))
 	}
 
-	if err := insertTuples(db, farms); err != nil {
+	if err := insertTuples(db, farm{}, farms); err != nil {
 		return err
 	}
 	fmt.Println("farms generated")
@@ -171,9 +171,9 @@ func generateFarms(db *sql.DB) error {
 }
 
 func generateNodeContracts(db *sql.DB, billCount *int) error {
-	var contracts []interface{}
-	var contractResources []interface{}
-	var billingReports []interface{}
+	var contracts []string
+	var contractResources []string
+	var billingReports []string
 
 	for i := uint64(1); i <= nodeContractCount; i++ {
 		nodeID, err := rnd(1, nodeCount)
@@ -258,15 +258,15 @@ func generateNodeContracts(db *sql.DB, billCount *int) error {
 			createdNodeContracts = append(createdNodeContracts, i+rentContractCount)
 		}
 
-		contracts = append(contracts, contract)
+		contracts = append(contracts, objectToTupleString(contract))
 
-		contractResources = append(contractResources, contract_resources)
+		contractResources = append(contractResources, objectToTupleString(contract_resources))
 
 		billings, err := rnd(0, 10)
 		if err != nil {
 			return err
 		}
-		
+
 		amountBilled, err := rnd(0, 100000)
 		if err != nil {
 			return err
@@ -281,15 +281,15 @@ func generateNodeContracts(db *sql.DB, billCount *int) error {
 			}
 			*billCount++
 
-			billingReports = append(billingReports, billing)
+			billingReports = append(billingReports, objectToTupleString(billing))
 		}
 	}
 
-	if err := insertTuples(db, contracts); err != nil {
+	if err := insertTuples(db, node_contract{}, contracts); err != nil {
 		return err
 	}
 
-	if err := insertTuples(db, contractResources); err != nil {
+	if err := insertTuples(db, contract_resources{}, contractResources); err != nil {
 		return err
 	}
 
@@ -297,7 +297,7 @@ func generateNodeContracts(db *sql.DB, billCount *int) error {
 		return err
 	}
 
-	if err := insertTuples(db, billingReports); err != nil {
+	if err := insertTuples(db, contract_bill_report{}, billingReports); err != nil {
 		return err
 	}
 
@@ -307,8 +307,8 @@ func generateNodeContracts(db *sql.DB, billCount *int) error {
 }
 
 func generateNameContracts(db *sql.DB, billCount *int) error {
-	var contracts []interface{}
-	var billReports []interface{}
+	var contracts []string
+	var billReports []string
 	for i := uint64(1); i <= nameContractCount; i++ {
 		nodeID, err := rnd(1, nodeCount)
 		if err != nil {
@@ -348,7 +348,7 @@ func generateNameContracts(db *sql.DB, billCount *int) error {
 			name:         uuid.NewString(),
 		}
 
-		contracts = append(contracts, contract)
+		contracts = append(contracts, objectToTupleString(contract))
 
 		billings, err := rnd(0, 10)
 		if err != nil {
@@ -365,15 +365,15 @@ func generateNameContracts(db *sql.DB, billCount *int) error {
 			}
 			*billCount++
 
-			billReports = append(billReports, billing)
+			billReports = append(billReports, objectToTupleString(billing))
 		}
 	}
 
-	if err := insertTuples(db, contracts); err != nil {
+	if err := insertTuples(db, name_contract{}, contracts); err != nil {
 		return err
 	}
 
-	if err := insertTuples(db, billReports); err != nil {
+	if err := insertTuples(db, contract_bill_report{}, billReports); err != nil {
 		return err
 	}
 
@@ -382,14 +382,14 @@ func generateNameContracts(db *sql.DB, billCount *int) error {
 	return nil
 }
 func generateRentContracts(db *sql.DB, billCount *int) error {
-	var contracts []interface{}
-	var billReports []interface{}
+	var contracts []string
+	var billReports []string
 	for i := uint64(1); i <= rentContractCount; i++ {
 		nl, nodeID, err := popRandom(availableRentNodesList)
 		if err != nil {
 			return err
 		}
-		
+
 		availableRentNodesList = nl
 		delete(availableRentNodes, nodeID)
 		state := "Deleted"
@@ -416,13 +416,13 @@ func generateRentContracts(db *sql.DB, billCount *int) error {
 			renter[nodeID] = contract.twin_id
 		}
 
-		contracts = append(contracts, contract)
+		contracts = append(contracts, objectToTupleString(contract))
 
 		billings, err := rnd(0, 10)
 		if err != nil {
 			return err
 		}
-		
+
 		amountBilled, err := rnd(0, 100000)
 		if err != nil {
 			return err
@@ -439,16 +439,16 @@ func generateRentContracts(db *sql.DB, billCount *int) error {
 
 			*billCount++
 
-			billReports = append(billReports, billing)
+			billReports = append(billReports, objectToTupleString(billing))
 
 		}
 	}
 
-	if err := insertTuples(db, contracts); err != nil {
+	if err := insertTuples(db, rent_contract{}, contracts); err != nil {
 		return err
 	}
 
-	if err := insertTuples(db, billReports); err != nil {
+	if err := insertTuples(db, contract_bill_report{}, billReports); err != nil {
 		return err
 	}
 
@@ -459,10 +459,10 @@ func generateRentContracts(db *sql.DB, billCount *int) error {
 
 func generateNodes(db *sql.DB) error {
 	powerState := []string{"Up", "Down"}
-	var locations []interface{}
-	var nodes []interface{}
-	var totalResources []interface{}
-	var publicConfigs []interface{}
+	var locations []string
+	var nodes []string
+	var totalResources []string
+	var publicConfigs []string
 	for i := uint64(1); i <= nodeCount; i++ {
 		mru, err := rnd(4, 256)
 		if err != nil {
@@ -507,7 +507,7 @@ func generateNodes(db *sql.DB) error {
 		nodesSRU[i] = sru - 100*uint64(gridtypes.Gigabyte)
 		nodesHRU[i] = hru
 		nodeUP[i] = up
-		
+
 		location := location{
 			id:        fmt.Sprintf("location-%d", i),
 			longitude: fmt.Sprintf("location--long-%d", i),
@@ -555,11 +555,11 @@ func generateNodes(db *sql.DB) error {
 			availableRentNodesList = append(availableRentNodesList, i)
 		}
 
-		locations = append(locations, location)
+		locations = append(locations, objectToTupleString(location))
 
-		nodes = append(nodes, node)
+		nodes = append(nodes, objectToTupleString(node))
 
-		totalResources = append(totalResources, total_resources)
+		totalResources = append(totalResources, objectToTupleString(total_resources))
 
 		if flip(.1) {
 			publicConfig := public_config{
@@ -571,24 +571,24 @@ func generateNodes(db *sql.DB) error {
 				domain:  "hamada.com",
 				node_id: fmt.Sprintf("node-%d", i),
 			}
-			publicConfigs = append(publicConfigs, publicConfig)
+			publicConfigs = append(publicConfigs, objectToTupleString(publicConfig))
 
 		}
 	}
 
-	if err := insertTuples(db, locations); err != nil {
+	if err := insertTuples(db, location{}, locations); err != nil {
 		return err
 	}
 
-	if err := insertTuples(db, nodes); err != nil {
+	if err := insertTuples(db, node{}, nodes); err != nil {
 		return err
 	}
 
-	if err := insertTuples(db, totalResources); err != nil {
+	if err := insertTuples(db, node_resources_total{}, totalResources); err != nil {
 		return err
 	}
 
-	if err := insertTuples(db, publicConfigs); err != nil {
+	if err := insertTuples(db, public_config{}, publicConfigs); err != nil {
 		return err
 	}
 	fmt.Println("nodes generated")
@@ -597,7 +597,7 @@ func generateNodes(db *sql.DB) error {
 }
 
 func generateNodeGPUs(db *sql.DB) error {
-	var GPUs []interface{}
+	var GPUs []string
 	for i := 0; i <= 10; i++ {
 		g := node_gpu{
 			node_twin_id: uint64(i + 100),
@@ -607,10 +607,10 @@ func generateNodeGPUs(db *sql.DB) error {
 			id:           "0000:0e:00.0/1002/744c",
 		}
 
-		GPUs = append(GPUs, g)
+		GPUs = append(GPUs, objectToTupleString(g))
 	}
 
-	if err := insertTuples(db, GPUs); err != nil {
+	if err := insertTuples(db, node_gpu{}, GPUs); err != nil {
 		return err
 	}
 
@@ -638,32 +638,26 @@ func generateContracts(db *sql.DB) error {
 	return nil
 }
 
-func insertTuples(db *sql.DB, tuples []interface{}) error {
+func insertTuples(db *sql.DB, tupleObj interface{}, tuples []string) error {
 
 	if len(tuples) != 0 {
-		query := fmt.Sprintf("INSERT INTO %s (", reflect.Indirect(reflect.ValueOf(tuples[0])).Type().Name())
-		objType := reflect.TypeOf(tuples[0])
+		query := "INSERT INTO  " + reflect.Indirect(reflect.ValueOf(tupleObj)).Type().Name() + " ("
+		objType := reflect.TypeOf(tupleObj)
 		for i := 0; i < objType.NumField(); i++ {
 			if i != 0 {
 				query += ", "
 			}
-			query = fmt.Sprintf("%s%s", query, objType.Field(i).Name)
+			query += objType.Field(i).Name
 		}
 
-		query = fmt.Sprintf("%s) VALUES ", query)
-		
-		for idx, value := range tuples {
-			if idx == 0 {
-				query = fmt.Sprintf("%s %s", query, objectToTupleString(value))
-				continue
-			}
-			query = fmt.Sprintf("%s, %s", query, objectToTupleString(value))
-		}
+		query += ") VALUES "
 
-		query = fmt.Sprintf("%s ;", query)
+		query += strings.Join(tuples, ",")
+		query += ";"
 		if _, err := db.Exec(query); err != nil {
 			return err
 		}
+
 	}
 	return nil
 }
@@ -678,7 +672,7 @@ func updateNodeContractPublicIPs(db *sql.DB, nodeContracts []interface{}) error 
 		}
 
 		query := "UPDATE node_contract set number_of_public_i_ps = number_of_public_i_ps + 1 WHERE contract_id IN ("
-		query = fmt.Sprintf("%s%s);", query, strings.Join(IDs, ","))
+		query += strings.Join(IDs, ",") + ");"
 		if _, err := db.Exec(query); err != nil {
 			return err
 		}
@@ -692,7 +686,7 @@ func updateNodeContractResourceID(db *sql.DB, min, max int) error {
 	if _, err := db.Exec(query); err != nil {
 		return err
 	}
-	
+
 	return nil
 }
 func generateData(db *sql.DB) error {

--- a/grid-proxy/tools/db/generate.go
+++ b/grid-proxy/tools/db/generate.go
@@ -167,7 +167,7 @@ func generateFarms(db *sql.DB) error {
 	return nil
 }
 
-func generateNodeContracts(db *sql.DB, billsStartID, contractsStartID int) ([]string, int, int, error) {
+func generateNodeContracts(db *sql.DB, billsStartID, contractsStartID int) ([]string, int, error) {
 	var contracts []string
 	var contractResources []string
 	var billingReports []string
@@ -175,7 +175,7 @@ func generateNodeContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 	for i := uint64(1); i <= nodeContractCount; i++ {
 		nodeID, err := rnd(1, nodeCount)
 		if err != nil {
-			return nil, billsStartID, contractsStartID, err
+			return nil, contractsStartID, err
 		}
 		state := "Deleted"
 
@@ -194,7 +194,7 @@ func generateNodeContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 
 		twinID, err := rnd(1100, 3100)
 		if err != nil {
-			return nil, billsStartID, contractsStartID, err
+			return nil, contractsStartID, err
 		}
 
 		if renter, ok := renter[nodeID]; ok {
@@ -222,22 +222,22 @@ func generateNodeContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 
 		cru, err := rnd(minContractCRU, maxContractCRU)
 		if err != nil {
-			return nil, billsStartID, contractsStartID, err
+			return nil, contractsStartID, err
 		}
 
 		hru, err := rnd(minContractHRU, min(maxContractHRU, nodesHRU[nodeID]))
 		if err != nil {
-			return nil, billsStartID, contractsStartID, err
+			return nil, contractsStartID, err
 		}
 
 		sru, err := rnd(minContractSRU, min(maxContractSRU, nodesSRU[nodeID]))
 		if err != nil {
-			return nil, billsStartID, contractsStartID, err
+			return nil, contractsStartID, err
 		}
 
 		mru, err := rnd(minContractMRU, min(maxContractMRU, nodesMRU[nodeID]))
 		if err != nil {
-			return nil, billsStartID, contractsStartID, err
+			return nil, contractsStartID, err
 		}
 
 		contract_resources := contract_resources{
@@ -261,12 +261,12 @@ func generateNodeContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 
 		billings, err := rnd(0, 10)
 		if err != nil {
-			return nil, billsStartID, contractsStartID, err
+			return nil, contractsStartID, err
 		}
 
 		amountBilled, err := rnd(0, 100000)
 		if err != nil {
-			return nil, billsStartID, contractsStartID, err
+			return nil, contractsStartID, err
 		}
 		for j := uint64(0); j < billings; j++ {
 			billing := contract_bill_report{
@@ -284,29 +284,29 @@ func generateNodeContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 	}
 
 	if err := insertTuples(db, node_contract{}, contracts); err != nil {
-		return nil, billsStartID, contractsStartID, err
+		return nil, contractsStartID, err
 	}
 
 	if err := insertTuples(db, contract_resources{}, contractResources); err != nil {
-		return nil, billsStartID, contractsStartID, err
+		return nil, contractsStartID, err
 	}
 
 	if err := updateNodeContractResourceID(db, contractsStartID-nodeContractCount, contractsStartID); err != nil {
-		return nil, billsStartID, contractsStartID, err
+		return nil, contractsStartID, err
 	}
 
 	fmt.Println("node contracts generated")
 
-	return billingReports, billsStartID, contractsStartID, nil
+	return billingReports, contractsStartID, nil
 }
 
-func generateNameContracts(db *sql.DB, billsStartID, contractsStartID int) ([]string, int, int, error) {
+func generateNameContracts(db *sql.DB, billsStartID, contractsStartID int) ([]string, int, error) {
 	var contracts []string
 	var billReports []string
 	for i := uint64(1); i <= nameContractCount; i++ {
 		nodeID, err := rnd(1, nodeCount)
 		if err != nil {
-			return nil, billsStartID, contractsStartID, err
+			return nil, contractsStartID, err
 		}
 
 		state := "Deleted"
@@ -320,7 +320,7 @@ func generateNameContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 
 		twinID, err := rnd(1100, 3100)
 		if err != nil {
-			return nil, billsStartID, contractsStartID, err
+			return nil, contractsStartID, err
 		}
 
 		if renter, ok := renter[nodeID]; ok {
@@ -346,7 +346,7 @@ func generateNameContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 
 		billings, err := rnd(0, 10)
 		if err != nil {
-			return nil, billsStartID, contractsStartID, err
+			return nil, contractsStartID, err
 		}
 		amountBilled, err := rnd(0, 100000)
 		for j := uint64(0); j < billings; j++ {
@@ -365,20 +365,20 @@ func generateNameContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 	}
 
 	if err := insertTuples(db, name_contract{}, contracts); err != nil {
-		return nil, billsStartID, contractsStartID, err
+		return nil, contractsStartID, err
 	}
 
 	fmt.Println("name contracts generated")
 
-	return billReports, billsStartID, contractsStartID, nil
+	return billReports, contractsStartID, nil
 }
-func generateRentContracts(db *sql.DB, billsStartID, contractsStartID int) ([]string, int, int, error) {
+func generateRentContracts(db *sql.DB, billsStartID, contractsStartID int) ([]string, int, error) {
 	var contracts []string
 	var billReports []string
 	for i := uint64(1); i <= rentContractCount; i++ {
 		nl, nodeID, err := popRandom(availableRentNodesList)
 		if err != nil {
-			return nil, billsStartID, contractsStartID, err
+			return nil, contractsStartID, err
 		}
 
 		availableRentNodesList = nl
@@ -411,12 +411,12 @@ func generateRentContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 
 		billings, err := rnd(0, 10)
 		if err != nil {
-			return nil, billsStartID, contractsStartID, err
+			return nil, contractsStartID, err
 		}
 
 		amountBilled, err := rnd(0, 100000)
 		if err != nil {
-			return nil, billsStartID, contractsStartID, err
+			return nil, contractsStartID, err
 		}
 
 		for j := uint64(0); j < billings; j++ {
@@ -437,12 +437,12 @@ func generateRentContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 	}
 
 	if err := insertTuples(db, rent_contract{}, contracts); err != nil {
-		return nil, billsStartID, contractsStartID, err
+		return nil, contractsStartID, err
 	}
 
 	fmt.Println("rent contracts generated")
 
-	return billReports, billsStartID, contractsStartID, nil
+	return billReports, contractsStartID, nil
 }
 
 func generateNodes(db *sql.DB) error {
@@ -608,24 +608,23 @@ func generateNodeGPUs(db *sql.DB) error {
 }
 
 func generateContracts(db *sql.DB) error {
-	billsStartID := 1
 	contractsStartID := 1
 
 	var billReports []string
 
-	rentContractsBillReports, billsStartID, contractCount, err := generateRentContracts(db, billsStartID, contractsStartID)
+	rentContractsBillReports, contractCount, err := generateRentContracts(db, 1, contractsStartID)
 	if err != nil {
 		return err
 	}
 	billReports = append(billReports, rentContractsBillReports...)
 
-	nodeContractsBillReports, billsStartID, contractsStartID, err := generateNodeContracts(db, billsStartID, contractCount)
+	nodeContractsBillReports, contractsStartID, err := generateNodeContracts(db, len(billReports)+1, contractCount)
 	if err != nil {
 		return err
 	}
 	billReports = append(billReports, nodeContractsBillReports...)
 
-	nameContractsBillReports, billsStartID, contractsStartID, err := generateNameContracts(db, billsStartID, contractCount)
+	nameContractsBillReports, contractsStartID, err := generateNameContracts(db, len(billReports)+1, contractCount)
 	if err != nil {
 		return err
 	}

--- a/grid-proxy/tools/db/generate.go
+++ b/grid-proxy/tools/db/generate.go
@@ -82,7 +82,11 @@ func generateTwins(db *sql.DB) error {
 			twin_id:      i,
 			grid_version: 3,
 		}
-		twins = append(twins, objectToTupleString(twin))
+		tuple, err := objectToTupleString(twin)
+		if err != nil {
+			return fmt.Errorf("failed to convert twin object to tuple string: %w", err)
+		}
+		twins = append(twins, tuple)
 	}
 
 	if err := insertTuples(db, twin{}, twins); err != nil {
@@ -119,7 +123,11 @@ func generatePublicIPs(db *sql.DB) error {
 			contract_id: contract_id,
 			farm_id:     fmt.Sprintf("farm-%d", farmID),
 		}
-		publicIPs = append(publicIPs, objectToTupleString(public_ip))
+		publicIpTuple, err := objectToTupleString(public_ip)
+		if err != nil {
+			return fmt.Errorf("failed to convert public ip object to tuple string: %w", err)
+		}
+		publicIPs = append(publicIPs, publicIpTuple)
 		nodeContracts = append(nodeContracts, contract_id)
 	}
 
@@ -156,7 +164,11 @@ func generateFarms(db *sql.DB) error {
 			dedicatedFarms[farm.farm_id] = struct{}{}
 		}
 
-		farms = append(farms, objectToTupleString(farm))
+		farmTuple, err := objectToTupleString(farm)
+		if err != nil {
+			return fmt.Errorf("failed to convert farm object to tuple string: %w", err)
+		}
+		farms = append(farms, farmTuple)
 	}
 
 	if err := insertTuples(db, farm{}, farms); err != nil {
@@ -255,9 +267,17 @@ func generateNodeContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 			createdNodeContracts = append(createdNodeContracts, uint64(contractsStartID))
 		}
 
-		contracts = append(contracts, objectToTupleString(contract))
+		contractTuple, err := objectToTupleString(contract)
+		if err != nil {
+			return nil, contractsStartID, fmt.Errorf("failed to convert contract object to tuple string: %w", err)
+		}
+		contracts = append(contracts, contractTuple)
 
-		contractResources = append(contractResources, objectToTupleString(contract_resources))
+		contractResourcesTuple, err := objectToTupleString(contract_resources)
+		if err != nil {
+			return nil, contractsStartID, fmt.Errorf("failed to convert contract resources object to tuple string: %w", err)
+		}
+		contractResources = append(contractResources, contractResourcesTuple)
 
 		billings, err := rnd(0, 10)
 		if err != nil {
@@ -278,7 +298,11 @@ func generateNodeContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 			}
 			billsStartID++
 
-			billingReports = append(billingReports, objectToTupleString(billing))
+			billTuple, err := objectToTupleString(billing)
+			if err != nil {
+				return nil, contractsStartID, fmt.Errorf("failed to convert contract bill report object to tuple string: %w", err)
+			}
+			billingReports = append(billingReports, billTuple)
 		}
 		contractsStartID++
 	}
@@ -342,7 +366,11 @@ func generateNameContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 			name:         uuid.NewString(),
 		}
 
-		contracts = append(contracts, objectToTupleString(contract))
+		contractTuple, err := objectToTupleString(contract)
+		if err != nil {
+			return nil, contractsStartID, fmt.Errorf("failed to convert contract object to tuple string: %w", err)
+		}
+		contracts = append(contracts, contractTuple)
 
 		billings, err := rnd(0, 10)
 		if err != nil {
@@ -363,7 +391,11 @@ func generateNameContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 			}
 			billsStartID++
 
-			billReports = append(billReports, objectToTupleString(billing))
+			billTuple, err := objectToTupleString(billing)
+			if err != nil {
+				return nil, contractsStartID, fmt.Errorf("failed to convert contract bill report object to tuple string: %w", err)
+			}
+			billReports = append(billReports, billTuple)
 		}
 		contractsStartID++
 	}
@@ -411,7 +443,11 @@ func generateRentContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 			renter[nodeID] = contract.twin_id
 		}
 
-		contracts = append(contracts, objectToTupleString(contract))
+		contractTuple, err := objectToTupleString(contract)
+		if err != nil {
+			return nil, contractsStartID, fmt.Errorf("failed to convert contract object to tuple string: %w", err)
+		}
+		contracts = append(contracts, contractTuple)
 
 		billings, err := rnd(0, 10)
 		if err != nil {
@@ -434,7 +470,11 @@ func generateRentContracts(db *sql.DB, billsStartID, contractsStartID int) ([]st
 
 			billsStartID++
 
-			billReports = append(billReports, objectToTupleString(billing))
+			billTuple, err := objectToTupleString(billing)
+			if err != nil {
+				return nil, contractsStartID, fmt.Errorf("failed to convert contract bill report object to tuple string: %w", err)
+			}
+			billReports = append(billReports, billTuple)
 
 		}
 		contractsStartID++
@@ -546,11 +586,23 @@ func generateNodes(db *sql.DB) error {
 			availableRentNodesList = append(availableRentNodesList, i)
 		}
 
-		locations = append(locations, objectToTupleString(location))
+		locationTuple, err := objectToTupleString(location)
+		if err != nil {
+			return fmt.Errorf("failed to convert location object to tuple string: %w", err)
+		}
+		locations = append(locations, locationTuple)
 
-		nodes = append(nodes, objectToTupleString(node))
+		nodeTuple, err := objectToTupleString(node)
+		if err != nil {
+			return fmt.Errorf("failed to convert node object to tuple string: %w", err)
+		}
+		nodes = append(nodes, nodeTuple)
 
-		totalResources = append(totalResources, objectToTupleString(total_resources))
+		totalResourcesTuple, err := objectToTupleString(total_resources)
+		if err != nil {
+			return fmt.Errorf("failed to convert total resources object to tuple string: %w", err)
+		}
+		totalResources = append(totalResources, totalResourcesTuple)
 
 		if flip(.1) {
 			publicConfig := public_config{
@@ -562,7 +614,11 @@ func generateNodes(db *sql.DB) error {
 				domain:  "hamada.com",
 				node_id: fmt.Sprintf("node-%d", i),
 			}
-			publicConfigs = append(publicConfigs, objectToTupleString(publicConfig))
+			publicConfigTuple, err := objectToTupleString(publicConfig)
+			if err != nil {
+				return fmt.Errorf("failed to convert public config object to tuple string: %w", err)
+			}
+			publicConfigs = append(publicConfigs, publicConfigTuple)
 
 		}
 	}
@@ -598,7 +654,11 @@ func generateNodeGPUs(db *sql.DB) error {
 			id:           "0000:0e:00.0/1002/744c",
 		}
 
-		GPUs = append(GPUs, objectToTupleString(g))
+		gpuTuple, err := objectToTupleString(g)
+		if err != nil {
+			return fmt.Errorf("failed to convert gpu object to tuple string: %w", err)
+		}
+		GPUs = append(GPUs, gpuTuple)
 	}
 
 	if err := insertTuples(db, node_gpu{}, GPUs); err != nil {
@@ -608,7 +668,6 @@ func generateNodeGPUs(db *sql.DB) error {
 	fmt.Println("node GPUs generated")
 
 	return nil
-
 }
 
 func generateContracts(db *sql.DB) error {
@@ -688,7 +747,6 @@ func updateNodeContractResourceID(db *sql.DB, min, max int) error {
 	if _, err := db.Exec(query); err != nil {
 		return fmt.Errorf("failed to update node contract resource id: %w", err)
 	}
-
 	return nil
 }
 func generateData(db *sql.DB) error {
@@ -715,6 +773,5 @@ func generateData(db *sql.DB) error {
 	if err := generateNodeGPUs(db); err != nil {
 		return fmt.Errorf("failed to generate node gpus: %w", err)
 	}
-
 	return nil
 }

--- a/grid-proxy/tools/db/types.go
+++ b/grid-proxy/tools/db/types.go
@@ -54,6 +54,9 @@ type twin struct {
 	relay        string
 	public_key   string
 }
+
+func (t twin) String() string { return "" }
+
 type public_ip struct {
 	id          string
 	gateway     string

--- a/grid-proxy/tools/db/types.go
+++ b/grid-proxy/tools/db/types.go
@@ -55,7 +55,6 @@ type twin struct {
 	public_key   string
 }
 
-
 type public_ip struct {
 	id          string
 	gateway     string

--- a/grid-proxy/tools/db/types.go
+++ b/grid-proxy/tools/db/types.go
@@ -55,7 +55,6 @@ type twin struct {
 	public_key   string
 }
 
-func (t twin) String() string { return "" }
 
 type public_ip struct {
 	id          string

--- a/grid-proxy/tools/db/utils.go
+++ b/grid-proxy/tools/db/utils.go
@@ -10,13 +10,11 @@ import (
 	"strings"
 )
 
-var errMaxMinInvalid = errors.New("min cannot be greater than max")
-
 // rnd gets a random number between min and max
 
 func rnd(min, max uint64) (uint64, error) {
 	if max-min+1 <= 0 {
-		return 0, errMaxMinInvalid
+		return 0, errors.New("min cannot be greater than max")
 	}
 	randomNumber := rand.Uint64()%(max-min+1) + min
 	return randomNumber, nil

--- a/grid-proxy/tools/db/utils.go
+++ b/grid-proxy/tools/db/utils.go
@@ -10,12 +10,16 @@ import (
 	"strings"
 )
 
+var errMaxMinInvalid = errors.New("min cannot be greater than max")
+
 // rnd gets a random number between min and max
+
 func rnd(min, max uint64) (uint64, error) {
 	if max-min+1 <= 0 {
-		return 0, errors.New("min cannot be greater than max")
+		return 0, errMaxMinInvalid
 	}
-	return uint64(rand.Intn(int(max)-int(min)+1) + int(min)), nil
+	randomNumber := rand.Uint64()%(max-min+1) + min
+	return randomNumber, nil
 }
 
 // flip simulates a coin flip with a given success probability.

--- a/grid-proxy/tools/db/utils.go
+++ b/grid-proxy/tools/db/utils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -42,6 +43,15 @@ func max(a, b uint64) uint64 {
 		return a
 	}
 	return b
+}
+
+func extractValuesFromInsertQuery(q string) (string, error) {
+
+	valuesIndex := strings.Index(q, "VALUES")
+	if valuesIndex == -1 {
+		return "", errors.New("values not found")
+	}
+	return q[valuesIndex+6 : len(q)-1], nil
 }
 
 func insertQuery(v interface{}) string {

--- a/grid-proxy/tools/db/utils.go
+++ b/grid-proxy/tools/db/utils.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -14,7 +13,7 @@ import (
 
 func rnd(min, max uint64) (uint64, error) {
 	if max-min+1 <= 0 {
-		return 0, errors.New("min cannot be greater than max")
+		return 0, fmt.Errorf("min (%d) cannot be greater than max (%d)", min, max)
 	}
 	randomNumber := rand.Uint64()%(max-min+1) + min
 	return randomNumber, nil

--- a/grid-proxy/tools/db/utils.go
+++ b/grid-proxy/tools/db/utils.go
@@ -56,7 +56,7 @@ func max(a, b uint64) uint64 {
 }
 
 // objectToTupleString converts a object into a string representation suitable for sql query
-func objectToTupleString(v interface{}) string {
+func objectToTupleString(v interface{}) (string, error) {
 	vals := "("
 	val := reflect.ValueOf(v)
 	for i := 0; i < val.NumField(); i++ {
@@ -90,14 +90,14 @@ func objectToTupleString(v interface{}) string {
 				// Marshal the power map to JSON and wrap it in quotes
 				powerJSON, err := json.Marshal(power)
 				if err != nil {
-					panic(err)
+					return "", fmt.Errorf("failed to marshal the power map to JSON: %w", err)
 				}
 				v = fmt.Sprintf("'%s'", string(powerJSON))
 			}
 			vals = fmt.Sprintf("%s, %s", vals, v)
 		}
 	}
-	return fmt.Sprintf("%s)", vals)
+	return fmt.Sprintf("%s)", vals), nil
 }
 
 // popRandom selects a random element from the given slice,

--- a/grid-proxy/tools/db/utils.go
+++ b/grid-proxy/tools/db/utils.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 )
 
+// rnd gets a random number between min and max
 func rnd(min, max uint64) (uint64, error) {
 	if max-min+1 <= 0 {
 		return 0, errors.New("min cannot be greater than max")
@@ -17,10 +18,12 @@ func rnd(min, max uint64) (uint64, error) {
 	return uint64(rand.Intn(int(max)-int(min)+1) + int(min)), nil
 }
 
+// flip simulates a coin flip with a given success probability.
 func flip(success float32) bool {
 	return rand.Float32() < success
 }
 
+// randomIPv4 gets a random IPv4
 func randomIPv4() net.IP {
 	ip := make([]byte, 4)
 	rand.Read(ip)
@@ -35,12 +38,15 @@ func IPv4Subnet(ip net.IP) *net.IPNet {
 	}
 }
 
+// min gets min between 2 numbers
 func min(a, b uint64) uint64 {
 	if a < b {
 		return a
 	}
 	return b
 }
+
+// max gets max between 2 numbers
 func max(a, b uint64) uint64 {
 	if a > b {
 		return a
@@ -48,6 +54,7 @@ func max(a, b uint64) uint64 {
 	return b
 }
 
+// objectToTupleString converts a object into a string representation suitable for sql query
 func objectToTupleString(v interface{}) string {
 	vals := "("
 	val := reflect.ValueOf(v)
@@ -91,6 +98,8 @@ func objectToTupleString(v interface{}) string {
 	}
 	return fmt.Sprintf("%s)", vals)
 }
+
+// popRandom selects a random element from the given slice,
 func popRandom(l []uint64) ([]uint64, uint64, error) {
 	idx, err := rnd(0, uint64(len(l)-1))
 	if err != nil {

--- a/grid-proxy/tools/db/utils_test.go
+++ b/grid-proxy/tools/db/utils_test.go
@@ -36,7 +36,8 @@ func TestObjectToTupleString(t *testing.T) {
 			twin_id:      1,
 			grid_version: 3,
 		}
-		got := objectToTupleString(twin)
+		got, err := objectToTupleString(twin)
+		assert.Nil(t, err)
 		want := "('twin-1', 3, 1, 'account-id-1', 'relay-1', 'public-key-1')"
 		assert.Equal(t, want, got)
 	})
@@ -57,10 +58,10 @@ func TestObjectToTupleString(t *testing.T) {
 			resources_used_id:     "",
 		}
 
-		got := objectToTupleString(contract)
+		got, err := objectToTupleString(contract)
+		assert.Nil(t, err)
 		want := fmt.Sprintf("('node-contract-1', 3, 1, 1, 1, 'deployment-data-1', 'deployment-hash-1', 0, 'Created', %d, NULL)", createdAt)
 		assert.Equal(t, want, got)
 
 	})
-
 }

--- a/grid-proxy/tools/db/utils_test.go
+++ b/grid-proxy/tools/db/utils_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -15,7 +16,7 @@ func TestMin(t *testing.T) {
 
 func TestRnd(t *testing.T) {
 	_, got := rnd(2, 1)
-	assert.Equal(t, errMaxMinInvalid, got)
+	assert.Error(t, got)
 }
 
 func TestMax(t *testing.T) {
@@ -25,15 +26,41 @@ func TestMax(t *testing.T) {
 }
 
 func TestObjectToTupleString(t *testing.T) {
-	twin := twin{
-		id:           fmt.Sprintf("twin-%d", 1),
-		account_id:   fmt.Sprintf("account-id-%d", 1),
-		relay:        fmt.Sprintf("relay-%d", 1),
-		public_key:   fmt.Sprintf("public-key-%d", 1),
-		twin_id:      1,
-		grid_version: 3,
-	}
-	got := objectToTupleString(twin)
-	want := "('twin-1', 3, 1, 'account-id-1', 'relay-1', 'public-key-1')"
-	assert.Equal(t, want, got)
+
+	t.Run("test without null values", func(t *testing.T) {
+		twin := twin{
+			id:           fmt.Sprintf("twin-%d", 1),
+			account_id:   fmt.Sprintf("account-id-%d", 1),
+			relay:        fmt.Sprintf("relay-%d", 1),
+			public_key:   fmt.Sprintf("public-key-%d", 1),
+			twin_id:      1,
+			grid_version: 3,
+		}
+		got := objectToTupleString(twin)
+		want := "('twin-1', 3, 1, 'account-id-1', 'relay-1', 'public-key-1')"
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("test with null values", func(t *testing.T) {
+		createdAt := uint64(time.Now().Unix())
+		contract := node_contract{
+			id:                    fmt.Sprintf("node-contract-%d", 1),
+			twin_id:               1,
+			contract_id:           1,
+			state:                 "Created", // Simulating a nil value
+			created_at:            createdAt,
+			node_id:               1,
+			deployment_data:       "deployment-data-1",
+			deployment_hash:       "deployment-hash-1",
+			number_of_public_i_ps: 0,
+			grid_version:          3,
+			resources_used_id:     "",
+		}
+
+		got := objectToTupleString(contract)
+		want := fmt.Sprintf("('node-contract-1', 3, 1, 1, 1, 'deployment-data-1', 'deployment-hash-1', 0, 'Created', %d, NULL)", createdAt)
+		assert.Equal(t, want, got)
+
+	})
+
 }

--- a/grid-proxy/tools/db/utils_test.go
+++ b/grid-proxy/tools/db/utils_test.go
@@ -13,6 +13,11 @@ func TestMin(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestRnd(t *testing.T) {
+	_, got := rnd(2, 1)
+	assert.Equal(t, errMaxMinInvalid, got)
+}
+
 func TestMax(t *testing.T) {
 	want := uint64(5)
 	got := max(4, 5)

--- a/grid-proxy/tools/db/utils_test.go
+++ b/grid-proxy/tools/db/utils_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMin(t *testing.T) {
+	want := uint64(4)
+	got := min(4, 5)
+	assert.Equal(t, want, got)
+}
+
+func TestMax(t *testing.T) {
+	want := uint64(5)
+	got := max(4, 5)
+	assert.Equal(t, want, got)
+}
+
+func TestObjectToTupleString(t *testing.T) {
+	twin := twin{
+		id:           fmt.Sprintf("twin-%d", 1),
+		account_id:   fmt.Sprintf("account-id-%d", 1),
+		relay:        fmt.Sprintf("relay-%d", 1),
+		public_key:   fmt.Sprintf("public-key-%d", 1),
+		twin_id:      1,
+		grid_version: 3,
+	}
+	got := objectToTupleString(twin)
+	want := "('twin-1', 3, 1, 'account-id-1', 'relay-1', 'public-key-1')"
+	assert.Equal(t, want, got)
+}


### PR DESCRIPTION
### Description

Enhanced query performance in the `generate.go` by refactoring the insertion process. Replaced individual insertions within a loop with a single insert statement.

### Changes

- Refactored all insertion and update queries to be in single SQL statement
- Added function to utils to extract the values of each statement.

### Related Issues

#358

### Checklist

- [X] Tests included
- [X] Build pass
- [X] Documentation
- [X] Code format and docstring

### Execution time comparison based on the provided constant values in the file:
- **Before:** 84.931081115 seconds
- **After:** 0.993061923 seconds

