### PR TITLE
Development set gridproxy db max open connections

### DIFF
--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -119,7 +119,9 @@ func NewPostgresDatabase(host string, port int, user, password, dbname string) (
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to configure DB connection")
 	}
+
 	sql.SetMaxIdleConns(3)
+	sql.SetMaxOpenConns(80)
 
 	err = gormDB.AutoMigrate(&NodeGPU{})
 	if err != nil {

--- a/grid-proxy/tests/queries/conn_test.go
+++ b/grid-proxy/tests/queries/conn_test.go
@@ -1,0 +1,35 @@
+package test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
+)
+
+func TestManyOpenConnections(t *testing.T) {
+	gotQueriesCnt := atomic.Int32{}
+	wg := sync.WaitGroup{}
+	wantQueriesCnt := 5000
+	for i := 0; i < wantQueriesCnt; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			_, _, err := gridProxyClient.Twins(types.TwinFilter{}, types.Limit{Size: 100})
+			if err != nil {
+				log.Err(err).Msg("twin query failed")
+				return
+			}
+
+			gotQueriesCnt.Add(1)
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, wantQueriesCnt, int(gotQueriesCnt.Load()), "some queries failed")
+}


### PR DESCRIPTION
### Description

This PR sets the limit for max open connections for gridproxy db

### Changes

Set max connections to 80

### Related Issues

- #302 