### PR TITLE
fix duplicated nodes record 

### DIFF
--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -377,7 +377,7 @@ func (d *PostgresDatabase) nodeTableQuery() *gorm.DB {
 	return d.gormDB.
 		Table("node").
 		Select(
-			"DISTINCT node.id",
+			"node.id",
 			"node.node_id",
 			"node.farm_id",
 			"node.twin_id",
@@ -429,9 +429,6 @@ func (d *PostgresDatabase) nodeTableQuery() *gorm.DB {
 		).
 		Joins(
 			"LEFT JOIN location ON node.location_id = location.id",
-		).
-		Joins(
-			"LEFT JOIN node_gpu on node_gpu.node_twin_id = node.twin_id",
 		)
 }
 
@@ -526,28 +523,44 @@ func (d *PostgresDatabase) GetNodes(filter types.NodeFilter, limit types.Limit) 
 		q = q.Where("node.certification ILIKE ?", *filter.CertificationType)
 	}
 
+	nodeGpuSubquery := d.gormDB.Table("node_gpu").
+		Select(`DISTINCT ON (node_twin_id) node_twin_id, 
+			id,
+			vendor,
+			device,
+			contract`,
+		)
+
 	if filter.HasGPU != nil {
-		q = q.Where("(COALESCE(node_gpu.id, '') != '') = ?", *filter.HasGPU)
+		nodeGpuSubquery = nodeGpuSubquery.Where("(COALESCE(node_gpu.id, '') != '') = ?", *filter.HasGPU)
 	}
 
 	if filter.GpuDeviceName != nil {
-		q = q.Where("COALESCE(node_gpu.device, '') ILIKE '%' || ? || '%'", *filter.GpuDeviceName)
+		nodeGpuSubquery = nodeGpuSubquery.Where("COALESCE(node_gpu.device, '') ILIKE '%' || ? || '%'", *filter.GpuDeviceName)
 	}
 
 	if filter.GpuVendorName != nil {
-		q = q.Where("COALESCE(node_gpu.vendor, '') ILIKE '%' || ? || '%'", *filter.GpuVendorName)
+		nodeGpuSubquery = nodeGpuSubquery.Where("COALESCE(node_gpu.vendor, '') ILIKE '%' || ? || '%'", *filter.GpuVendorName)
 	}
 
 	if filter.GpuVendorID != nil {
-		q = q.Where("COALESCE(node_gpu.id, '') ILIKE '%' || ? || '%'", *filter.GpuVendorID)
+		nodeGpuSubquery = nodeGpuSubquery.Where("COALESCE(node_gpu.id, '') ILIKE '%' || ? || '%'", *filter.GpuVendorID)
 	}
 
 	if filter.GpuDeviceID != nil {
-		q = q.Where("COALESCE(node_gpu.id, '') ILIKE '%' || ? || '%'", *filter.GpuDeviceID)
+		nodeGpuSubquery = nodeGpuSubquery.Where("COALESCE(node_gpu.id, '') ILIKE '%' || ? || '%'", *filter.GpuDeviceID)
 	}
 
 	if filter.GpuAvailable != nil {
-		q = q.Where("(COALESCE(node_gpu.contract, 0) = 0) = ?", *filter.GpuAvailable)
+		nodeGpuSubquery = nodeGpuSubquery.Where("(COALESCE(node_gpu.contract, 0) = 0) = ?", *filter.GpuAvailable)
+	}
+
+	if filter.HasGPU != nil || filter.GpuDeviceName != nil || filter.GpuVendorName != nil || filter.GpuVendorID != nil ||
+		filter.GpuDeviceID != nil || filter.GpuAvailable != nil {
+
+		q.Joins(
+			`INNER JOIN (?) AS gpu ON gpu.node_twin_id = node.twin_id`, nodeGpuSubquery,
+		)
 	}
 
 	var count int64

--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -377,7 +377,7 @@ func (d *PostgresDatabase) nodeTableQuery() *gorm.DB {
 	return d.gormDB.
 		Table("node").
 		Select(
-			"node.id",
+			"DISTINCT node.id",
 			"node.node_id",
 			"node.farm_id",
 			"node.twin_id",

--- a/grid-proxy/tests/queries/mock_client/nodes.go
+++ b/grid-proxy/tests/queries/mock_client/nodes.go
@@ -308,11 +308,11 @@ func (n *Node) satisfies(f types.NodeFilter, data *DBData) bool {
 		return false
 	}
 
-	if f.GpuVendorID != nil && !strings.Contains(gpu.ID, *f.GpuVendorID) {
+	if f.GpuVendorID != nil && !strings.Contains(strings.ToLower(gpu.ID), *f.GpuVendorID) {
 		return false
 	}
 
-	if f.GpuDeviceID != nil && !strings.Contains(gpu.ID, *f.GpuDeviceID) {
+	if f.GpuDeviceID != nil && !strings.Contains(strings.ToLower(gpu.ID), *f.GpuDeviceID) {
 		return false
 	}
 
@@ -320,5 +320,8 @@ func (n *Node) satisfies(f types.NodeFilter, data *DBData) bool {
 		return false
 	}
 
+	if !ok && (f.HasGPU != nil || f.GpuDeviceName != nil || f.GpuVendorName != nil || f.GpuVendorID != nil || f.GpuDeviceID != nil || f.GpuAvailable != nil) {
+		return false
+	}
 	return true
 }

--- a/grid-proxy/tests/queries/node_test.go
+++ b/grid-proxy/tests/queries/node_test.go
@@ -227,19 +227,19 @@ var nodeFilterRandomValueGenerator = map[string]func(agg NodesAggregate) interfa
 		return &v
 	},
 	"GpuDeviceName": func(agg NodesAggregate) interface{} {
-		deviceNames := []string{"navi", "a", "hamada", ""}
+		deviceNames := []string{"navi", "a", "hamada"}
 		return &deviceNames[rand.Intn(len(deviceNames))]
 	},
 	"GpuVendorName": func(agg NodesAggregate) interface{} {
-		vendorNames := []string{"advanced", "a", "hamada", ""}
+		vendorNames := []string{"advanced", "a", "hamada"}
 		return &vendorNames[rand.Intn(len(vendorNames))]
 	},
 	"GpuVendorID": func(agg NodesAggregate) interface{} {
-		vendorIDs := []string{"1002", "1", "a", ""}
+		vendorIDs := []string{"1002", "1", "a"}
 		return &vendorIDs[rand.Intn(len(vendorIDs))]
 	},
 	"GpuDeviceID": func(agg NodesAggregate) interface{} {
-		deviceIDs := []string{"744c", "1", "a", ""}
+		deviceIDs := []string{"744c", "1", "a"}
 		return &deviceIDs[rand.Intn(len(deviceIDs))]
 	},
 	"GpuAvailable": func(agg NodesAggregate) interface{} {


### PR DESCRIPTION
### Description
fix the nodes duplication records by applying the filters on the node_gpu table on a subquery and then inner join this query with the node table.
the join with node_gpu table will only be applied if only one of the GPU filters is applied.

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/387
- should also help in fixing https://github.com/threefoldtech/tf_operations/issues/1908
