### PR TITLE
add gridproxy http server timeouts

### DIFF
--- a/grid-proxy/cmds/proxy_server/main.go
+++ b/grid-proxy/cmds/proxy_server/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
@@ -209,7 +210,8 @@ func createServer(f flags, db db.Database, gitCommit string, relayClient rmb.Cli
 	}
 
 	return &http.Server{
-		Handler: router,
-		Addr:    f.address,
+		Handler:           http.TimeoutHandler(router, 30*time.Second, "request timed-out. server took too long to respond"), // 30 seconds for slow sql operations
+		Addr:              f.address,
+		ReadHeaderTimeout: 5 * time.Second,
 	}, nil
 }

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -1,21 +1,23 @@
 package db
 
 import (
+	"context"
+
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
 )
 
 // Database interface for storing and fetching grid info
 type Database interface {
-	GetCounters(filter types.StatsFilter) (types.Counters, error)
-	GetNode(nodeID uint32) (Node, error)
-	GetFarm(farmID uint32) (Farm, error)
-	GetNodes(filter types.NodeFilter, limit types.Limit) ([]Node, uint, error)
-	GetFarms(filter types.FarmFilter, limit types.Limit) ([]Farm, uint, error)
-	GetTwins(filter types.TwinFilter, limit types.Limit) ([]types.Twin, uint, error)
-	GetContracts(filter types.ContractFilter, limit types.Limit) ([]DBContract, uint, error)
-	GetContract(contractID uint32) (DBContract, error)
-	GetContractBills(contractID uint32, limit types.Limit) ([]ContractBilling, uint, error)
-	UpsertNodesGPU(nodesGPU []types.NodeGPU) error
+	GetCounters(ctx context.Context, filter types.StatsFilter) (types.Counters, error)
+	GetNode(ctx context.Context, nodeID uint32) (Node, error)
+	GetFarm(ctx context.Context, farmID uint32) (Farm, error)
+	GetNodes(ctx context.Context, filter types.NodeFilter, limit types.Limit) ([]Node, uint, error)
+	GetFarms(ctx context.Context, filter types.FarmFilter, limit types.Limit) ([]Farm, uint, error)
+	GetTwins(ctx context.Context, filter types.TwinFilter, limit types.Limit) ([]types.Twin, uint, error)
+	GetContracts(ctx context.Context, filter types.ContractFilter, limit types.Limit) ([]DBContract, uint, error)
+	GetContract(ctx context.Context, contractID uint32) (DBContract, error)
+	GetContractBills(ctx context.Context, contractID uint32, limit types.Limit) ([]ContractBilling, uint, error)
+	UpsertNodesGPU(ctx context.Context, nodesGPU []types.NodeGPU) error
 }
 
 type ContractBilling types.ContractBilling

--- a/grid-proxy/internal/explorer/helpers.go
+++ b/grid-proxy/internal/explorer/helpers.go
@@ -1,6 +1,7 @@
 package explorer
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"net/http"
@@ -305,12 +306,12 @@ func (a *App) handleStatsRequestsQueryParams(r *http.Request) (types.StatsFilter
 
 // getNodeData is a helper function that wraps fetch node data
 // it caches the results in redis to save time
-func (a *App) getNodeData(nodeIDStr string) (types.NodeWithNestedCapacity, error) {
+func (a *App) getNodeData(ctx context.Context, nodeIDStr string) (types.NodeWithNestedCapacity, error) {
 	nodeID, err := strconv.Atoi(nodeIDStr)
 	if err != nil {
 		return types.NodeWithNestedCapacity{}, errors.Wrap(ErrBadGateway, fmt.Sprintf("invalid node id %d: %s", nodeID, err.Error()))
 	}
-	info, err := a.db.GetNode(uint32(nodeID))
+	info, err := a.db.GetNode(ctx, uint32(nodeID))
 	if errors.Is(err, db.ErrNodeNotFound) {
 		return types.NodeWithNestedCapacity{}, ErrNodeNotFound
 	} else if err != nil {
@@ -322,13 +323,13 @@ func (a *App) getNodeData(nodeIDStr string) (types.NodeWithNestedCapacity, error
 }
 
 // getContractData is a helper function that wraps fetch contract data
-func (a *App) getContractData(contractIDStr string) (types.Contract, error) {
+func (a *App) getContractData(ctx context.Context, contractIDStr string) (types.Contract, error) {
 	contractID, err := strconv.Atoi(contractIDStr)
 	if err != nil {
 		return types.Contract{}, errors.Wrapf(err, "invalid contract id: %s", contractIDStr)
 	}
 
-	info, err := a.db.GetContract(uint32(contractID))
+	info, err := a.db.GetContract(ctx, uint32(contractID))
 
 	if errors.Is(err, db.ErrContractNotFound) {
 		return types.Contract{}, ErrContractNotFound
@@ -345,13 +346,13 @@ func (a *App) getContractData(contractIDStr string) (types.Contract, error) {
 }
 
 // getContractBillsData is a helper function that gets bills reports for a single contract data
-func (a *App) getContractBillsData(contractIDStr string, limit types.Limit) ([]types.ContractBilling, uint, error) {
+func (a *App) getContractBillsData(ctx context.Context, contractIDStr string, limit types.Limit) ([]types.ContractBilling, uint, error) {
 	contractID, err := strconv.Atoi(contractIDStr)
 	if err != nil {
 		return []types.ContractBilling{}, 0, errors.Wrapf(err, "invalid contract id: %s", contractIDStr)
 	}
 
-	info, billsCount, err := a.db.GetContractBills(uint32(contractID), limit)
+	info, billsCount, err := a.db.GetContractBills(ctx, uint32(contractID), limit)
 	if err != nil {
 		return []types.ContractBilling{}, 0, errors.Wrapf(err, "contract not found with id: %d", contractID)
 	}

--- a/grid-proxy/internal/explorer/server.go
+++ b/grid-proxy/internal/explorer/server.go
@@ -62,7 +62,7 @@ func (a *App) listFarms(r *http.Request) (interface{}, mw.Response) {
 	if err != nil {
 		return nil, mw.BadRequest(err)
 	}
-	dbFarms, farmsCount, err := a.db.GetFarms(filter, limit)
+	dbFarms, farmsCount, err := a.db.GetFarms(r.Context(), filter, limit)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to query farm")
 		return nil, mw.Error(err)
@@ -98,7 +98,7 @@ func (a *App) getStats(r *http.Request) (interface{}, mw.Response) {
 	if err != nil {
 		return nil, mw.BadRequest(err)
 	}
-	counters, err := a.db.GetCounters(filter)
+	counters, err := a.db.GetCounters(r.Context(), filter)
 	if err != nil {
 		return nil, mw.Error(err)
 	}
@@ -190,7 +190,7 @@ func (a *App) listNodes(r *http.Request) (interface{}, mw.Response) {
 	if err != nil {
 		return nil, mw.BadRequest(err)
 	}
-	dbNodes, nodesCount, err := a.db.GetNodes(filter, limit)
+	dbNodes, nodesCount, err := a.db.GetNodes(r.Context(), filter, limit)
 	if err != nil {
 		return nil, mw.Error(err)
 	}
@@ -245,7 +245,7 @@ func (a *App) getGateway(r *http.Request) (interface{}, mw.Response) {
 
 func (a *App) _getNode(r *http.Request) (interface{}, mw.Response) {
 	nodeID := mux.Vars(r)["node_id"]
-	nodeData, err := a.getNodeData(nodeID)
+	nodeData, err := a.getNodeData(r.Context(), nodeID)
 	if err != nil {
 		return nil, errorReply(err)
 	}
@@ -256,7 +256,7 @@ func (a *App) getNodeStatus(r *http.Request) (interface{}, mw.Response) {
 	response := types.NodeStatus{}
 	nodeID := mux.Vars(r)["node_id"]
 
-	nodeData, err := a.getNodeData(nodeID)
+	nodeData, err := a.getNodeData(r.Context(), nodeID)
 	if err != nil {
 		return nil, errorReply(err)
 	}
@@ -284,7 +284,7 @@ func (a *App) listTwins(r *http.Request) (interface{}, mw.Response) {
 	if err != nil {
 		return nil, mw.BadRequest(err)
 	}
-	twins, twinsCount, err := a.db.GetTwins(filter, limit)
+	twins, twinsCount, err := a.db.GetTwins(r.Context(), filter, limit)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to query twin")
 		return nil, mw.Error(err)
@@ -321,7 +321,7 @@ func (a *App) listContracts(r *http.Request) (interface{}, mw.Response) {
 	if err != nil {
 		return nil, mw.BadRequest(err)
 	}
-	dbContracts, contractsCount, err := a.db.GetContracts(filter, limit)
+	dbContracts, contractsCount, err := a.db.GetContracts(r.Context(), filter, limit)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to query contract")
 		return nil, mw.Error(err)
@@ -391,7 +391,7 @@ func (a *App) version(r *http.Request) (interface{}, mw.Response) {
 // @Router /nodes/{node_id}/statistics  [get]
 func (a *App) getNodeStatistics(r *http.Request) (interface{}, mw.Response) {
 	nodeID := mux.Vars(r)["node_id"]
-	node, err := a.getNodeData(nodeID)
+	node, err := a.getNodeData(r.Context(), nodeID)
 	if err != nil {
 		return nil, errorReply(err)
 	}
@@ -422,7 +422,7 @@ func (a *App) getNodeStatistics(r *http.Request) (interface{}, mw.Response) {
 // @Router /nodes/{node_id}/gpu  [get]
 func (a *App) getNodeGpus(r *http.Request) (interface{}, mw.Response) {
 	nodeID := mux.Vars(r)["node_id"]
-	node, err := a.getNodeData(nodeID)
+	node, err := a.getNodeData(r.Context(), nodeID)
 	if err != nil {
 		return nil, errorReply(err)
 	}
@@ -454,7 +454,7 @@ func (a *App) getNodeGpus(r *http.Request) (interface{}, mw.Response) {
 func (a *App) getContract(r *http.Request) (interface{}, mw.Response) {
 	contractID := mux.Vars(r)["contract_id"]
 
-	contractData, err := a.getContractData(contractID)
+	contractData, err := a.getContractData(r.Context(), contractID)
 	if err != nil {
 		return nil, errorReply(err)
 	}
@@ -485,7 +485,7 @@ func (a *App) getContractBills(r *http.Request) (interface{}, mw.Response) {
 		return []types.ContractBilling{}, nil
 	}
 
-	contractBillsData, totalCount, err := a.getContractBillsData(contractID, limit)
+	contractBillsData, totalCount, err := a.getContractBillsData(r.Context(), contractID, limit)
 	if err != nil {
 		return nil, errorReply(err)
 	}

--- a/grid-proxy/pkg/client/grid_client.go
+++ b/grid-proxy/pkg/client/grid_client.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
@@ -70,150 +72,228 @@ func (g *Clientimpl) url(sub string, args ...interface{}) string {
 
 // Ping makes sure the server is up
 func (g *Clientimpl) Ping() error {
-	req, err := http.Get(g.url("version"))
+	client := g.newHTTPClient()
+	req, err := http.NewRequest(http.MethodGet, g.url("version"), nil)
 	if err != nil {
 		return err
 	}
-	if req.StatusCode != http.StatusOK {
-		return fmt.Errorf("non ok return status code from the the grid proxy home page: %s", http.StatusText(req.StatusCode))
+
+	res, err := client.Do(req)
+	if res != nil {
+		defer res.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("non ok return status code from the the grid proxy home page: %s", http.StatusText(res.StatusCode))
 	}
 	return nil
 }
 
 // Nodes returns nodes with the given filters and pagination parameters
-func (g *Clientimpl) Nodes(filter types.NodeFilter, limit types.Limit) (res []types.Node, totalCount int, err error) {
+func (g *Clientimpl) Nodes(filter types.NodeFilter, limit types.Limit) (nodes []types.Node, totalCount int, err error) {
 	query := nodeParams(filter, limit)
-	req, err := http.Get(g.url("nodes%s", query))
+	client := g.newHTTPClient()
+	req, err := http.NewRequest(http.MethodGet, g.url("nodes%s", query), nil)
 	if err != nil {
 		return
 	}
-	if req.StatusCode != http.StatusOK {
-		err = parseError(req.Body)
+
+	res, err := client.Do(req)
+	if res != nil {
+		defer res.Body.Close()
+	}
+	if err != nil {
 		return
 	}
-	if err := json.NewDecoder(req.Body).Decode(&res); err != nil {
-		return res, 0, err
+
+	if res.StatusCode != http.StatusOK {
+		err = parseError(res.Body)
+		return
 	}
-	totalCount, err = requestCounters(req)
+
+	if err := json.NewDecoder(res.Body).Decode(&nodes); err != nil {
+		return nodes, 0, err
+	}
+	totalCount, err = requestCounters(res)
 	return
 }
 
 // Farms returns farms with the given filters and pagination parameters
-func (g *Clientimpl) Farms(filter types.FarmFilter, limit types.Limit) (res []types.Farm, totalCount int, err error) {
+func (g *Clientimpl) Farms(filter types.FarmFilter, limit types.Limit) (farms []types.Farm, totalCount int, err error) {
 	query := farmParams(filter, limit)
-	req, err := http.Get(g.url("farms%s", query))
+	client := g.newHTTPClient()
+	req, err := http.NewRequest(http.MethodGet, g.url("farms%s", query), nil)
 	if err != nil {
 		return
 	}
-	if req.StatusCode != http.StatusOK {
-		err = parseError(req.Body)
-		return
+
+	res, err := client.Do(req)
+	if res != nil {
+		defer res.Body.Close()
 	}
-	data, err := io.ReadAll(req.Body)
 	if err != nil {
 		return
 	}
-	err = json.Unmarshal(data, &res)
+
+	if res.StatusCode != http.StatusOK {
+		err = parseError(res.Body)
+		return
+	}
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return
 	}
-	totalCount, err = requestCounters(req)
+	err = json.Unmarshal(data, &farms)
+	if err != nil {
+		return
+	}
+	totalCount, err = requestCounters(res)
 	return
 }
 
 // Twins returns twins with the given filters and pagination parameters
-func (g *Clientimpl) Twins(filter types.TwinFilter, limit types.Limit) (res []types.Twin, totalCount int, err error) {
+func (g *Clientimpl) Twins(filter types.TwinFilter, limit types.Limit) (twins []types.Twin, totalCount int, err error) {
 	query := twinParams(filter, limit)
-	req, err := http.Get(g.url("twins%s", query))
+	client := g.newHTTPClient()
+	req, err := http.NewRequest(http.MethodGet, g.url("twins%s", query), nil)
 	if err != nil {
 		return
 	}
-	if req.StatusCode != http.StatusOK {
-		err = parseError(req.Body)
-		return
+
+	res, err := client.Do(req)
+	if res != nil {
+		defer res.Body.Close()
 	}
-	data, err := io.ReadAll(req.Body)
 	if err != nil {
 		return
 	}
-	err = json.Unmarshal(data, &res)
+
+	if res.StatusCode != http.StatusOK {
+		err = parseError(res.Body)
+		return
+	}
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return
 	}
-	totalCount, err = requestCounters(req)
+	err = json.Unmarshal(data, &twins)
+	if err != nil {
+		return
+	}
+	totalCount, err = requestCounters(res)
 	return
 }
 
 // Contracts returns contracts with the given filters and pagination parameters
-func (g *Clientimpl) Contracts(filter types.ContractFilter, limit types.Limit) (res []types.Contract, totalCount int, err error) {
+func (g *Clientimpl) Contracts(filter types.ContractFilter, limit types.Limit) (contracts []types.Contract, totalCount int, err error) {
 	query := contractParams(filter, limit)
-	req, err := http.Get(g.url("contracts%s", query))
+	client := g.newHTTPClient()
+	req, err := http.NewRequest(http.MethodGet, g.url("contracts%s", query), nil)
 	if err != nil {
 		return
 	}
-	if req.StatusCode != http.StatusOK {
-		err = parseError(req.Body)
-		return
+
+	res, err := client.Do(req)
+	if res != nil {
+		defer res.Body.Close()
 	}
-	data, err := io.ReadAll(req.Body)
 	if err != nil {
 		return
 	}
-	res, err = decodeMultipleContracts(data)
+
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return
 	}
-	totalCount, err = requestCounters(req)
+
+	contracts, err = decodeMultipleContracts(data)
+	if err != nil {
+		return
+	}
+	totalCount, err = requestCounters(res)
 	return
 }
 
 // Node returns the node with the give id
-func (g *Clientimpl) Node(nodeID uint32) (res types.NodeWithNestedCapacity, err error) {
-	req, err := http.Get(g.url("nodes/%d", nodeID))
+func (g *Clientimpl) Node(nodeID uint32) (node types.NodeWithNestedCapacity, err error) {
+	client := g.newHTTPClient()
+	req, err := http.NewRequest(http.MethodGet, g.url("nodes/%d", nodeID), nil)
+	if err != nil {
+		return types.NodeWithNestedCapacity{}, fmt.Errorf("failed to create node request: %w", err)
+	}
+
+	res, err := client.Do(req)
+	if res != nil {
+		defer res.Body.Close()
+	}
+	if err != nil {
+		return types.NodeWithNestedCapacity{}, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		err = parseError(res.Body)
+		return
+	}
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return
 	}
-	if req.StatusCode != http.StatusOK {
-		err = parseError(req.Body)
-		return
-	}
-	data, err := io.ReadAll(req.Body)
-	if err != nil {
-		return
-	}
-	err = json.Unmarshal(data, &res)
+	err = json.Unmarshal(data, &node)
 	return
 }
 
 // NodeStatus returns the node status up/down
-func (g *Clientimpl) NodeStatus(nodeID uint32) (res types.NodeStatus, err error) {
-	req, err := http.Get(g.url("nodes/%d/status", nodeID))
+func (g *Clientimpl) NodeStatus(nodeID uint32) (status types.NodeStatus, err error) {
+	client := g.newHTTPClient()
+	req, err := http.NewRequest(http.MethodGet, g.url("nodes/%d/status", nodeID), nil)
 	if err != nil {
+		return types.NodeStatus{}, fmt.Errorf("failed to create nodes request: %w", err)
+	}
+
+	res, err := client.Do(req)
+	if res != nil {
+		defer res.Body.Close()
+	}
+	if err != nil {
+		return types.NodeStatus{}, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		err = parseError(res.Body)
 		return
 	}
-	if req.StatusCode != http.StatusOK {
-		err = parseError(req.Body)
-		return
-	}
-	if err := json.NewDecoder(req.Body).Decode(&res); err != nil {
-		return res, err
+	if err := json.NewDecoder(res.Body).Decode(&status); err != nil {
+		return status, err
 	}
 	return
 }
 
 // Counters return statistics about the grid
-func (g *Clientimpl) Counters(filter types.StatsFilter) (res types.Counters, err error) {
+func (g *Clientimpl) Counters(filter types.StatsFilter) (counters types.Counters, err error) {
 	query := statsParams(filter)
-	req, err := http.Get(g.url("stats%s", query))
+	client := g.newHTTPClient()
+	req, err := http.NewRequest(http.MethodGet, g.url("stats%s", query), nil)
 	if err != nil {
+		return types.Counters{}, fmt.Errorf("failed to create stats request: %w", err)
+	}
+
+	res, err := client.Do(req)
+	if res != nil {
+		defer res.Body.Close()
+	}
+	if err != nil {
+		return types.Counters{}, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		err = parseError(res.Body)
 		return
 	}
-	if req.StatusCode != http.StatusOK {
-		err = parseError(req.Body)
-		return
-	}
-	if err := json.NewDecoder(req.Body).Decode(&res); err != nil {
-		return res, err
+	if err := json.NewDecoder(res.Body).Decode(&counters); err != nil {
+		return counters, err
 	}
 	return
 }
@@ -267,4 +347,16 @@ func (g *Clientimpl) ContractBills(contractID uint32, limit types.Limit) (res []
 
 	totalCount = uint(count)
 	return
+}
+func (g *Clientimpl) newHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: time.Second * 30,
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout: time.Second,
+			}).DialContext,
+			TLSHandshakeTimeout:   time.Second,
+			ResponseHeaderTimeout: 5 * time.Second,
+		},
+	}
 }

--- a/grid-proxy/tests/queries/conn_test.go
+++ b/grid-proxy/tests/queries/conn_test.go
@@ -1,25 +1,35 @@
 package test
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	db "github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/explorer/db"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
 )
 
-func TestManyOpenConnections(t *testing.T) {
+func TestDBManyOpenConnections(t *testing.T) {
+	p, err := db.NewPostgresDatabase(POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PASSSWORD, POSTGRES_DB, 80)
+	require.NoError(t, err)
+
 	gotQueriesCnt := atomic.Int32{}
 	wg := sync.WaitGroup{}
 	wantQueriesCnt := 5000
+	wg.Add(wantQueriesCnt)
 	for i := 0; i < wantQueriesCnt; i++ {
-		wg.Add(1)
 		go func() {
 			defer wg.Done()
 
-			_, _, err := gridProxyClient.Twins(types.TwinFilter{}, types.Limit{Size: 100})
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+			defer cancel()
+
+			_, _, err := p.GetTwins(ctx, types.TwinFilter{}, types.Limit{Size: 100})
 			if err != nil {
 				log.Err(err).Msg("twin query failed")
 				return

--- a/grid-proxy/tools/db/generate.go
+++ b/grid-proxy/tools/db/generate.go
@@ -671,23 +671,23 @@ func generateNodeGPUs(db *sql.DB) error {
 }
 
 func generateContracts(db *sql.DB) error {
-	contractsStartID := 1
+	rentContractIDStart := 1
 
 	var billReports []string
 
-	rentContractsBillReports, contractCount, err := generateRentContracts(db, 1, contractsStartID)
+	rentContractsBillReports, nodeContractIDStart, err := generateRentContracts(db, 1, rentContractIDStart)
 	if err != nil {
 		return fmt.Errorf("failed to generate rent contracts: %w", err)
 	}
 	billReports = append(billReports, rentContractsBillReports...)
 
-	nodeContractsBillReports, contractsStartID, err := generateNodeContracts(db, len(billReports)+1, contractCount)
+	nodeContractsBillReports, nameContractIDStart, err := generateNodeContracts(db, len(billReports)+1, nodeContractIDStart)
 	if err != nil {
 		return fmt.Errorf("failed to generate node contracts: %w", err)
 	}
 	billReports = append(billReports, nodeContractsBillReports...)
 
-	nameContractsBillReports, contractsStartID, err := generateNameContracts(db, len(billReports)+1, contractCount)
+	nameContractsBillReports, _, err := generateNameContracts(db, len(billReports)+1, nameContractIDStart)
 	if err != nil {
 		return fmt.Errorf("failed to generate name contracts: %w", err)
 	}


### PR DESCRIPTION
### Description

This pr adds timeouts to gridproxy http server and client

### Changes

- add timeout (30 seconds) for any route handler
- add timeout (5 seconds) for reading request headers
- configure timeouts for gridproxy http client.
- update db calls to be context aware
- update test for db many open connections was to directly query the db instead of using the http client. this is because the test failed as the CI machine failed to read some of the 5000 request headers sent in 5 seconds, and the purpose of the test is just to check if the db would correctly handle a number of queries more than the number of max open connections concurrently.

### Related Issues

- #398 