### PR TITLE
remove deprecated rand.Seed()

### DIFF
--- a/grid-proxy/tools/db/db.go
+++ b/grid-proxy/tools/db/db.go
@@ -12,6 +12,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+var (
+	r *rand.Rand
+)
+
 type flags struct {
 	postgresHost     string
 	postgresPort     int
@@ -37,9 +41,8 @@ func parseCmdline() flags {
 
 func main() {
 	f := parseCmdline()
-	if f.seed != 0 {
-		rand.Seed(int64(f.seed))
-	}
+	r = rand.New(rand.NewSource(int64(f.seed)))
+
 	psqlInfo := fmt.Sprintf("host=%s port=%d user=%s "+
 		"password=%s dbname=%s sslmode=disable",
 		f.postgresHost, f.postgresPort, f.postgresUser, f.postgresPassword, f.postgresDB)

--- a/grid-proxy/tools/db/generate.go
+++ b/grid-proxy/tools/db/generate.go
@@ -3,7 +3,6 @@ package main
 import (
 	"database/sql"
 	"fmt"
-	"math/rand"
 	"os"
 	"reflect"
 	"strings"
@@ -553,8 +552,8 @@ func generateNodes(db *sql.DB) error {
 			latitude:  fmt.Sprintf("location-lat-%d", i),
 		}
 
-		countryIndex := rand.Intn(len(countries))
-		cityIndex := rand.Intn(len(cities[countries[countryIndex]]))
+		countryIndex := r.Intn(len(countries))
+		cityIndex := r.Intn(len(cities[countries[countryIndex]]))
 		node := node{
 			id:                fmt.Sprintf("node-%d", i),
 			location_id:       fmt.Sprintf("location-%d", i),
@@ -574,8 +573,8 @@ func generateNodes(db *sql.DB) error {
 			virtualized:       false,
 			serial_number:     "",
 			power: nodePower{
-				State:  powerState[rand.Intn(len(powerState))],
-				Target: powerState[rand.Intn(len(powerState))],
+				State:  powerState[r.Intn(len(powerState))],
+				Target: powerState[r.Intn(len(powerState))],
 			},
 			extra_fee: 0,
 		}

--- a/grid-proxy/tools/db/utils.go
+++ b/grid-proxy/tools/db/utils.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"net"
 	"reflect"
 	"strings"
@@ -16,19 +15,19 @@ func rnd(min, max uint64) (uint64, error) {
 	if max-min+1 <= 0 {
 		return 0, fmt.Errorf("min (%d) cannot be greater than max (%d)", min, max)
 	}
-	randomNumber := rand.Uint64()%(max-min+1) + min
+	randomNumber := r.Uint64()%(max-min+1) + min
 	return randomNumber, nil
 }
 
 // flip simulates a coin flip with a given success probability.
 func flip(success float32) bool {
-	return rand.Float32() < success
+	return r.Float32() < success
 }
 
 // randomIPv4 gets a random IPv4
 func randomIPv4() net.IP {
 	ip := make([]byte, 4)
-	rand.Read(ip)
+	r.Read(ip)
 	return net.IP(ip)
 }
 


### PR DESCRIPTION
### Description

This pr removes the deprecated `rand.Seed()` function

### Related Issues

- #422