### PR TITLE
modify the node dedicated field/filter

### DIFF
--- a/grid-proxy/internal/explorer/converters.go
+++ b/grid-proxy/internal/explorer/converters.go
@@ -58,7 +58,7 @@ func nodeFromDBNode(info db.Node) types.Node {
 		ExtraFee:          info.ExtraFee,
 	}
 	node.Status = nodestatus.DecideNodeStatus(node.Power, node.UpdatedAt)
-	node.Dedicated = info.FarmDedicated || info.NodeContractCount == 0 || info.RentContractID != 0
+	node.Dedicated = info.FarmDedicated || !info.HasNodeContract || info.RentContractID != 0
 	return node
 }
 
@@ -129,7 +129,7 @@ func nodeWithNestedCapacityFromDBNode(info db.Node) types.NodeWithNestedCapacity
 		ExtraFee:          info.ExtraFee,
 	}
 	node.Status = nodestatus.DecideNodeStatus(node.Power, node.UpdatedAt)
-	node.Dedicated = info.FarmDedicated || info.NodeContractCount == 0 || info.RentContractID != 0
+	node.Dedicated = info.FarmDedicated || !info.HasNodeContract || info.RentContractID != 0
 	return node
 }
 

--- a/grid-proxy/internal/explorer/converters.go
+++ b/grid-proxy/internal/explorer/converters.go
@@ -50,7 +50,6 @@ func nodeFromDBNode(info db.Node) types.Node {
 			Ipv6:   info.Ipv6,
 		},
 		CertificationType: info.Certification,
-		Dedicated:         info.Dedicated,
 		RentContractID:    uint(info.RentContractID),
 		RentedByTwinID:    uint(info.RentedByTwinID),
 		SerialNumber:      info.SerialNumber,
@@ -59,6 +58,7 @@ func nodeFromDBNode(info db.Node) types.Node {
 		ExtraFee:          info.ExtraFee,
 	}
 	node.Status = nodestatus.DecideNodeStatus(node.Power, node.UpdatedAt)
+	node.Dedicated = info.FarmDedicated || info.NodeContractCount == 0 || info.RentContractID != 0
 	return node
 }
 
@@ -121,7 +121,6 @@ func nodeWithNestedCapacityFromDBNode(info db.Node) types.NodeWithNestedCapacity
 			Ipv6:   info.Ipv6,
 		},
 		CertificationType: info.Certification,
-		Dedicated:         info.Dedicated,
 		RentContractID:    uint(info.RentContractID),
 		RentedByTwinID:    uint(info.RentedByTwinID),
 		SerialNumber:      info.SerialNumber,
@@ -130,6 +129,7 @@ func nodeWithNestedCapacityFromDBNode(info db.Node) types.NodeWithNestedCapacity
 		ExtraFee:          info.ExtraFee,
 	}
 	node.Status = nodestatus.DecideNodeStatus(node.Power, node.UpdatedAt)
+	node.Dedicated = info.FarmDedicated || info.NodeContractCount == 0 || info.RentContractID != 0
 	return node
 }
 

--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -455,7 +455,7 @@ func (d *PostgresDatabase) nodeTableQuery() *gorm.DB {
 			"convert_to_decimal(location.latitude) as latitude",
 			"node.power",
 			"node.extra_fee",
-			"node_contract.contract_id AS node_contract_count",
+			"CASE WHEN node_contract.contract_id IS NOT NULL THEN 1 ELSE 0 END AS has_node_contract",
 			nodeGPUQuery,
 		).
 		Joins(

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -39,41 +39,41 @@ type DBContract struct {
 
 // Node data about a node which is calculated from the chain
 type Node struct {
-	ID                string
-	NodeID            int64
-	FarmID            int64
-	TwinID            int64
-	Country           string
-	GridVersion       int64
-	City              string
-	Uptime            int64
-	Created           int64
-	FarmingPolicyID   int64
-	UpdatedAt         int64
-	TotalCru          int64
-	TotalMru          int64
-	TotalSru          int64
-	TotalHru          int64
-	UsedCru           int64
-	UsedMru           int64
-	UsedSru           int64
-	UsedHru           int64
-	Domain            string
-	Gw4               string
-	Gw6               string
-	Ipv4              string
-	Ipv6              string
-	Certification     string
-	FarmDedicated     bool `gorm:"farm_dedicated"`
-	RentContractID    int64
-	RentedByTwinID    int64
-	SerialNumber      string
-	Longitude         *float64
-	Latitude          *float64
-	Power             NodePower `gorm:"type:jsonb"`
-	NumGPU            int       `gorm:"num_gpu"`
-	ExtraFee          uint64
-	NodeContractCount uint64 `gorm:"node_contract_count"`
+	ID              string
+	NodeID          int64
+	FarmID          int64
+	TwinID          int64
+	Country         string
+	GridVersion     int64
+	City            string
+	Uptime          int64
+	Created         int64
+	FarmingPolicyID int64
+	UpdatedAt       int64
+	TotalCru        int64
+	TotalMru        int64
+	TotalSru        int64
+	TotalHru        int64
+	UsedCru         int64
+	UsedMru         int64
+	UsedSru         int64
+	UsedHru         int64
+	Domain          string
+	Gw4             string
+	Gw6             string
+	Ipv4            string
+	Ipv6            string
+	Certification   string
+	FarmDedicated   bool `gorm:"farm_dedicated"`
+	RentContractID  int64
+	RentedByTwinID  int64
+	SerialNumber    string
+	Longitude       *float64
+	Latitude        *float64
+	Power           NodePower `gorm:"type:jsonb"`
+	NumGPU          int       `gorm:"num_gpu"`
+	ExtraFee        uint64
+	HasNodeContract bool `gorm:"has_node_contract"`
 }
 
 // NodePower struct is the farmerbot report for node status

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -39,40 +39,41 @@ type DBContract struct {
 
 // Node data about a node which is calculated from the chain
 type Node struct {
-	ID              string
-	NodeID          int64
-	FarmID          int64
-	TwinID          int64
-	Country         string
-	GridVersion     int64
-	City            string
-	Uptime          int64
-	Created         int64
-	FarmingPolicyID int64
-	UpdatedAt       int64
-	TotalCru        int64
-	TotalMru        int64
-	TotalSru        int64
-	TotalHru        int64
-	UsedCru         int64
-	UsedMru         int64
-	UsedSru         int64
-	UsedHru         int64
-	Domain          string
-	Gw4             string
-	Gw6             string
-	Ipv4            string
-	Ipv6            string
-	Certification   string
-	Dedicated       bool
-	RentContractID  int64
-	RentedByTwinID  int64
-	SerialNumber    string
-	Longitude       *float64
-	Latitude        *float64
-	Power           NodePower `gorm:"type:jsonb"`
-	NumGPU          int       `gorm:"num_gpu"`
-	ExtraFee        uint64
+	ID                string
+	NodeID            int64
+	FarmID            int64
+	TwinID            int64
+	Country           string
+	GridVersion       int64
+	City              string
+	Uptime            int64
+	Created           int64
+	FarmingPolicyID   int64
+	UpdatedAt         int64
+	TotalCru          int64
+	TotalMru          int64
+	TotalSru          int64
+	TotalHru          int64
+	UsedCru           int64
+	UsedMru           int64
+	UsedSru           int64
+	UsedHru           int64
+	Domain            string
+	Gw4               string
+	Gw6               string
+	Ipv4              string
+	Ipv6              string
+	Certification     string
+	FarmDedicated     bool `gorm:"farm_dedicated"`
+	RentContractID    int64
+	RentedByTwinID    int64
+	SerialNumber      string
+	Longitude         *float64
+	Latitude          *float64
+	Power             NodePower `gorm:"type:jsonb"`
+	NumGPU            int       `gorm:"num_gpu"`
+	ExtraFee          uint64
+	NodeContractCount uint64 `gorm:"node_contract_count"`
 }
 
 // NodePower struct is the farmerbot report for node status

--- a/grid-proxy/pkg/types/types.go
+++ b/grid-proxy/pkg/types/types.go
@@ -30,6 +30,7 @@ type Counters struct {
 	Contracts         int64            `json:"contracts"`
 	NodesDistribution map[string]int64 `json:"nodesDistribution" gorm:"-:all"`
 	GPUs              int64            `json:"gpus"`
+	DedicatedNodes    int64            `json:"dedicatedNodes"`
 }
 
 // PublicConfig node public config

--- a/grid-proxy/tests/queries/mock_client/counters.go
+++ b/grid-proxy/tests/queries/mock_client/counters.go
@@ -13,6 +13,7 @@ func (g *GridProxyMockClient) Counters(filter types.StatsFilter) (res types.Coun
 	res.Contracts += int64(len(g.data.NodeContracts))
 	res.Contracts += int64(len(g.data.NameContracts))
 	distribution := map[string]int64{}
+	dedicatedNodesCount := int64(0)
 	var gpus int64
 	for _, node := range g.data.Nodes {
 		nodePower := types.NodePower{
@@ -35,11 +36,15 @@ func (g *GridProxyMockClient) Counters(filter types.StatsFilter) (res types.Coun
 			if _, ok := g.data.GPUs[node.TwinID]; ok {
 				gpus++
 			}
+			if isDedicatedNode(g.data, node) {
+				dedicatedNodesCount++
+			}
 		}
 	}
 	res.Countries = int64(len(distribution))
 	res.NodesDistribution = distribution
 	res.GPUs = gpus
+	res.DedicatedNodes = dedicatedNodesCount
 
 	return
 }

--- a/grid-proxy/tests/queries/mock_client/nodes.go
+++ b/grid-proxy/tests/queries/mock_client/nodes.go
@@ -10,6 +10,12 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+func isDedicatedNode(db DBData, node Node) bool {
+	return db.Farms[node.FarmID].DedicatedFarm ||
+		len(db.NonDeletedContracts[node.NodeID]) == 0 ||
+		db.NodeRentedBy[node.NodeID] != 0
+}
+
 // Nodes returns nodes with the given filters and pagination parameters
 func (g *GridProxyMockClient) Nodes(filter types.NodeFilter, limit types.Limit) (res []types.Node, totalCount int, err error) {
 	res = []types.Node{}
@@ -68,7 +74,7 @@ func (g *GridProxyMockClient) Nodes(filter types.NodeFilter, limit types.Limit) 
 				Status:            status,
 				CertificationType: node.Certification,
 				UpdatedAt:         int64(node.UpdatedAt),
-				Dedicated:         g.data.Farms[node.FarmID].DedicatedFarm,
+				Dedicated:         isDedicatedNode(g.data, node),
 				RentedByTwinID:    uint(g.data.NodeRentedBy[node.NodeID]),
 				RentContractID:    uint(g.data.NodeRentContractID[node.NodeID]),
 				SerialNumber:      node.SerialNumber,
@@ -147,7 +153,7 @@ func (g *GridProxyMockClient) Node(nodeID uint32) (res types.NodeWithNestedCapac
 		Status:            status,
 		CertificationType: node.Certification,
 		UpdatedAt:         int64(node.UpdatedAt),
-		Dedicated:         g.data.Farms[node.FarmID].DedicatedFarm,
+		Dedicated:         isDedicatedNode(g.data, node),
 		RentedByTwinID:    uint(g.data.NodeRentedBy[node.NodeID]),
 		RentContractID:    uint(g.data.NodeRentContractID[node.NodeID]),
 		SerialNumber:      node.SerialNumber,
@@ -257,7 +263,7 @@ func (n *Node) satisfies(f types.NodeFilter, data *DBData) bool {
 		return false
 	}
 
-	if f.Dedicated != nil && *f.Dedicated != data.Farms[n.FarmID].DedicatedFarm {
+	if f.Dedicated != nil && *f.Dedicated != isDedicatedNode(*data, *n) {
 		return false
 	}
 


### PR DESCRIPTION
### Description
1. modify the dedicated node filter/field. node will be dedicated if one of three conditions is true:
- belongs to dedicated farm
- have no node contract
- have a rent contract (either have or don't have node contract)

2. added dedicated nodes count to the `/stats` endpoint

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/420
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/421

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
