### PR TITLE
fix RMB direct client panic

### DIFF
--- a/rmb-sdk-go/direct/rpc.go
+++ b/rmb-sdk-go/direct/rpc.go
@@ -70,7 +70,14 @@ func (d *RpcCLient) Call(ctx context.Context, twin uint32, fn string, data inter
 	id := uuid.NewString()
 
 	ch := make(chan incomingEnv)
-	defer close(ch)
+	defer func() {
+		close(ch)
+
+		d.m.Lock()
+		delete(d.responses, id)
+		d.m.Unlock()
+	}()
+
 	d.m.Lock()
 	d.responses[id] = ch
 	d.m.Unlock()


### PR DESCRIPTION
### Description

delete response object from response map after its channel was closed  

### Related Issues

- #489 
