### PR TITLE
add optional limit as parameter to FilterNodes

### DIFF
--- a/grid-client/deployer/node_filter.go
+++ b/grid-client/deployer/node_filter.go
@@ -18,8 +18,14 @@ import (
 )
 
 // FilterNodes filters nodes using proxy
-func FilterNodes(ctx context.Context, tfPlugin TFPluginClient, options types.NodeFilter, ssdDisks, hddDisks []uint64, rootfs []uint64) ([]types.Node, error) {
-	nodes, _, err := tfPlugin.GridProxyClient.Nodes(ctx, options, types.Limit{})
+func FilterNodes(ctx context.Context, tfPlugin TFPluginClient, options types.NodeFilter, ssdDisks, hddDisks []uint64, rootfs []uint64, optionalLimit ...uint64) ([]types.Node, error) {
+	limit := types.Limit{}
+
+	if len(optionalLimit) > 0 {
+		limit = types.Limit{Size: optionalLimit[0]}
+	}
+
+	nodes, _, err := tfPlugin.GridProxyClient.Nodes(ctx, options, limit)
 	if err != nil {
 		return []types.Node{}, errors.Wrap(err, "could not fetch nodes from the rmb proxy")
 	}


### PR DESCRIPTION
### Description

add optional parameter to FilterNodes function to allow it to filter a given number of nodes with default 50

### Related Issues
- #492 
