### PR TITLE
Fix cli panic and add --all option and docs

### DIFF
--- a/grid-cli/cmd/cancel_contracts.go
+++ b/grid-cli/cmd/cancel_contracts.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-cli/internal/config"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/deployer"
+	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/graphql"
 )
 
 // cancelContracts represents the cancel contracts command
@@ -14,6 +16,15 @@ var cancelContracts = &cobra.Command{
 	Use:   "contracts",
 	Short: "Cancel twin contracts",
 	Run: func(cmd *cobra.Command, args []string) {
+		all, err := cmd.Flags().GetBool("all")
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+		if len(args) == 0 && !all {
+			log.Info().Msg("please specify contracts to cancel or use -a to cancel all")
+			return
+		}
+
 		cfg, err := config.GetUserConfig()
 		if err != nil {
 			log.Fatal().Err(err).Send()
@@ -22,14 +33,17 @@ var cancelContracts = &cobra.Command{
 		if err != nil {
 			log.Fatal().Err(err).Send()
 		}
+
 		var contracts []uint64
-		for _, arg := range args {
-			contract, err := strconv.ParseUint(arg, 10, 64)
-			if err != nil {
-				log.Fatal().Err(err).Msgf("%s not a valid contract id", arg)
-			}
-			contracts = append(contracts, contract)
+		if all {
+			contracts, err = getAllContracts(t.ContractsGetter)
+		} else {
+			contracts, err = getContractsFromCLI(args)
 		}
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+
 		err = t.BatchCancelContract(contracts)
 		if err != nil {
 			log.Fatal().Err(err).Msg("failed to cancel contracts")
@@ -41,4 +55,35 @@ var cancelContracts = &cobra.Command{
 func init() {
 	cancelCmd.AddCommand(cancelContracts)
 
+	cancelContracts.Flags().BoolP("all", "a", false, "delete all contracts")
+}
+
+func getAllContracts(getter graphql.ContractsGetter) ([]uint64, error) {
+	var contractIDs []uint64
+	cs, err := getter.ListContractsByTwinID([]string{"Created"})
+	if err != nil {
+		return nil, err
+	}
+	contracts := append(cs.NameContracts, cs.NodeContracts...)
+	contracts = append(contracts, cs.RentContracts...)
+	for _, contract := range contracts {
+		contractID, err := strconv.ParseUint(contract.ContractID, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("%s not a valid contract id: %w", contract.ContractID, err)
+		}
+		contractIDs = append(contractIDs, contractID)
+	}
+	return contractIDs, nil
+}
+
+func getContractsFromCLI(args []string) ([]uint64, error) {
+	var contractIDs []uint64
+	for _, arg := range args {
+		contract, err := strconv.ParseUint(arg, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("%s not a valid contract id: %w", arg, err)
+		}
+		contractIDs = append(contractIDs, contract)
+	}
+	return contractIDs, nil
 }

--- a/grid-cli/cmd/get_contract.go
+++ b/grid-cli/cmd/get_contract.go
@@ -25,6 +25,10 @@ var getContractCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal().Err(err).Send()
 		}
+		if len(args) == 0 {
+			log.Info().Msg("please specify a contract")
+			return
+		}
 		contractID, err := strconv.ParseUint(args[0], 10, 32)
 		if err != nil {
 			log.Fatal().Err(err).Msg("not a valid contract id")

--- a/grid-cli/docs/contracts.md
+++ b/grid-cli/docs/contracts.md
@@ -1,0 +1,78 @@
+# Contracts
+
+This document explains Contracts related commands using tf-grid-cli.
+
+## Get
+
+### Get Contracts
+
+Get all contracts
+
+```bash
+tf-grid-cli get contracts
+```
+
+Example:
+
+```console
+$ tf-grid-cli get contracts
+5:13PM INF starting peer session=tf-1184566 twin=81
+Node contracts:
+ID       Node ID    Type            Name           Project Name
+50977    21         network         vm1network     vm1
+50978    21         vm              vm1            vm1
+50980    14         Gateway Name    gatewaytest    gatewaytest
+
+Name contracts:
+ID       Name
+50979    gatewaytest
+```
+
+### Get Contract
+
+Get specific contract
+
+```bash
+tf-grid-cli get contract <contract-id>
+```
+
+Example:
+
+```console
+$ tf-grid-cli get contract 50977
+5:14PM INF starting peer session=tf-1185180 twin=81
+5:14PM INF contract:
+{
+        "contract_id": 50977,
+        "twin_id": 81,
+        "state": "Created",
+        "created_at": 1702480020,
+        "type": "node",
+        "details": {
+                "nodeId": 21,
+                "deployment_data": "{\"type\":\"network\",\"name\":\"vm1network\",\"projectName\":\"vm1\"}",
+                "deployment_hash": "21adc91ef6cdc915d5580b3f12732ac9",
+                "number_of_public_ips": 0
+        }
+}
+```
+
+## Cancel
+
+Cancel specified contracts or all contracts.
+
+```bash
+tf-grid-cli cancel contracts <contract-id>... [Flags]
+```
+
+### Optional Flags
+
+- all: cancel all twin's contracts.
+
+Example:
+
+```console
+$ tf-grid-cli cancel contracts 50856 50857
+5:17PM INF starting peer session=tf-1185964 twin=81
+5:17PM INF contracts canceled successfully
+```


### PR DESCRIPTION
### Description

Fix cli panic and add --all option and docs

### Changes

- cli no longer panics when no contracts is given to `get contract`
- add --all option to cancel all contracts created
- document new contract commands

### Related Issues

- #534 

### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstring
