### PR TITLE
add more information to deployment error message

### DIFF
--- a/grid-client/deployer/deployer.go
+++ b/grid-client/deployer/deployer.go
@@ -24,7 +24,7 @@ import (
 )
 
 // MockDeployer to be used for any deployer in mock testing
-type MockDeployer interface { //TODO: Change Name && separate them
+type MockDeployer interface { // TODO: Change Name && separate them
 	Deploy(ctx context.Context,
 		oldDeploymentIDs map[uint32]uint64,
 		newDeployments map[uint32]gridtypes.Deployment,
@@ -57,7 +57,6 @@ func NewDeployer(
 	tfPluginClient TFPluginClient,
 	revertOnFailure bool,
 ) Deployer {
-
 	return Deployer{
 		tfPluginClient.Identity,
 		tfPluginClient.TwinID,
@@ -158,6 +157,9 @@ func (d *Deployer) deploy(
 			contractID, err := d.substrateConn.CreateNodeContract(d.identity, node, dl.Metadata, hashHex, publicIPCount, newDeploymentSolutionProvider[node])
 			log.Debug().Uint64("CreateNodeContract returned id", contractID)
 			if err != nil {
+				if strings.Contains(err.Error(), "NodeNotAvailableToDeploy") {
+					err = errors.Wrap(err, "tring to deploy on a rented node")
+				}
 				return currentDeployments, errors.Wrapf(err, "failed to create contract on node %d", node)
 			}
 

--- a/grid-client/deployer/deployer.go
+++ b/grid-client/deployer/deployer.go
@@ -24,7 +24,7 @@ import (
 )
 
 // MockDeployer to be used for any deployer in mock testing
-type MockDeployer interface { // TODO: Change Name && separate them
+type MockDeployer interface { //TODO: Change Name && separate them
 	Deploy(ctx context.Context,
 		oldDeploymentIDs map[uint32]uint64,
 		newDeployments map[uint32]gridtypes.Deployment,
@@ -57,6 +57,7 @@ func NewDeployer(
 	tfPluginClient TFPluginClient,
 	revertOnFailure bool,
 ) Deployer {
+
 	return Deployer{
 		tfPluginClient.Identity,
 		tfPluginClient.TwinID,
@@ -157,9 +158,6 @@ func (d *Deployer) deploy(
 			contractID, err := d.substrateConn.CreateNodeContract(d.identity, node, dl.Metadata, hashHex, publicIPCount, newDeploymentSolutionProvider[node])
 			log.Debug().Uint64("CreateNodeContract returned id", contractID)
 			if err != nil {
-				if strings.Contains(err.Error(), "NodeNotAvailableToDeploy") {
-					err = errors.Wrap(err, "tring to deploy on a rented node")
-				}
 				return currentDeployments, errors.Wrapf(err, "failed to create contract on node %d", node)
 			}
 

--- a/grid-client/deployer/node_filter.go
+++ b/grid-client/deployer/node_filter.go
@@ -3,9 +3,10 @@ package deployer
 
 import (
 	"context"
-	"encoding/json"
+	"fmt"
 	"net"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/gorilla/schema"
@@ -246,11 +247,17 @@ func serializeOptions(options types.NodeFilter) (string, error) {
 	if err != nil {
 		return "", nil
 	}
-	filterString, err := json.Marshal(params)
-	if err != nil {
-		return "", nil
+
+	var filterStringBuilder strings.Builder
+	for key, val := range params {
+		fmt.Fprintf(&filterStringBuilder, "%s: %v, ", key, val)
 	}
-	return string(filterString), nil
+
+	filterString := filterStringBuilder.String()
+	if len(filterString) > 2 {
+		filterString = filterString[:len(filterString)-2]
+	}
+	return filterString, nil
 }
 
 func convertBytesToGB(bytes uint64) uint64 {

--- a/grid-client/deployer/node_filter.go
+++ b/grid-client/deployer/node_filter.go
@@ -26,6 +26,11 @@ func FilterNodes(ctx context.Context, tfPlugin TFPluginClient, options types.Nod
 		limit = types.Limit{Size: optionalLimit[0]}
 	}
 
+	if options.AvailableFor == nil {
+		twinID := uint64(tfPlugin.TwinID)
+		options.AvailableFor = &twinID
+	}
+
 	nodes, _, err := tfPlugin.GridProxyClient.Nodes(ctx, options, limit)
 	if err != nil {
 		return []types.Node{}, errors.Wrap(err, "could not fetch nodes from the rmb proxy")

--- a/grid-client/deployer/node_filter.go
+++ b/grid-client/deployer/node_filter.go
@@ -241,6 +241,8 @@ func hasEnoughStorage(pools []client.PoolMetrics, storages []uint64, poolType zo
 	return true
 }
 
+// serializeOptions used to encode a struct of NodeFilter type and convert it to string
+// with only non-zero values and drop any field with zero-value
 func serializeOptions(options types.NodeFilter) (string, error) {
 	params := make(map[string][]string)
 	err := schema.NewEncoder().Encode(options, params)
@@ -248,16 +250,21 @@ func serializeOptions(options types.NodeFilter) (string, error) {
 		return "", nil
 	}
 
-	var filterStringBuilder strings.Builder
+	// convert the map to string with `key: value` format
+	//
+	// example:
+	//
+	// map[string][]string{Status: [up]} -> "Status: [up]"
+	var sb strings.Builder
 	for key, val := range params {
-		fmt.Fprintf(&filterStringBuilder, "%s: %v, ", key, val)
+		fmt.Fprintf(&sb, "%s: %v, ", key, val[0])
 	}
 
-	filterString := filterStringBuilder.String()
-	if len(filterString) > 2 {
-		filterString = filterString[:len(filterString)-2]
+	filter := sb.String()
+	if len(filter) > 2 {
+		filter = filter[:len(filter)-2]
 	}
-	return filterString, nil
+	return filter, nil
 }
 
 func convertBytesToGB(bytes uint64) uint64 {

--- a/grid-client/deployer/node_filter.go
+++ b/grid-client/deployer/node_filter.go
@@ -262,8 +262,12 @@ func serializeOptions(options types.NodeFilter) string {
 	if options.IPv4 != nil {
 		fmt.Fprintf(&filterStringBuilder, "ipv4: %t, ", *options.IPv4)
 	}
+
 	filterString := filterStringBuilder.String()
-	return filterString[:len(filterString)-2]
+	if len(filterString) >= 2 {
+		filterString = filterString[:len(filterString)-2]
+	}
+	return filterString
 }
 
 func convertBytesToGB(bytes uint64) uint64 {


### PR DESCRIPTION
### Description

- Deployments on rented nodes return error `NodeNotAvailableToDeploy` with no other information about why it's not available

### Changes
- set AvailableFor filter default value to user TwinID to make sure the nodes are available to the user to deploy on and prevent the NodeNotAvailableToDeploy form happening 

### Related Issues

- #506 
