### PR TITLE
always power on dedicated nodes in farm (if they have a rent contract)

### DIFF
--- a/farmerbot/internal/farmerbot.go
+++ b/farmerbot/internal/farmerbot.go
@@ -367,6 +367,9 @@ func (f *FarmerBot) shouldWakeUp(sub Substrate, node node, roundStart time.Time)
 	if node.powerState != off {
 		return false
 	}
+	if node.hasActiveRentContract {
+		return true
+	}
 
 	periodicWakeUpStart := f.config.Power.PeriodicWakeUpStart.PeriodicWakeUpTime()
 	if periodicWakeUpStart.Before(roundStart) && node.lastTimeAwake.Before(periodicWakeUpStart) {
@@ -378,7 +381,7 @@ func (f *FarmerBot) shouldWakeUp(sub Substrate, node node, roundStart time.Time)
 
 	nodesLen := len(f.nodes)
 
-	// TODO:
+	// TODO
 	if node.timesRandomWakeUps < defaultRandomWakeUpsAMonth &&
 		int(rand.Int31())%((8460-(defaultRandomWakeUpsAMonth*6)-
 			(defaultRandomWakeUpsAMonth*(nodesLen-1))/int(math.Min(float64(f.config.Power.PeriodicWakeUpLimit), float64(nodesLen))))/


### PR DESCRIPTION
update canShutDown function to exclude if the node is dedicated condtion, and hook into shouldWakeup function to always return true in case of dedicdated nodes to be powered on as soon as the node is known to be dedicated

### Description

will make sure any node with rent contract to be powered on as soon as possible


### Changes

List of changes this PR includes

### Related Issues

- #585 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
