### PR TITLE
sort nodes by status

### DIFF
--- a/grid-proxy/docs/docs.go
+++ b/grid-proxy/docs/docs.go
@@ -825,6 +825,7 @@ const docTemplate = `{
                     },
                     {
                         "enum": [
+                            "status",
                             "node_id",
                             "farm_id",
                             "twin_id",
@@ -1605,7 +1606,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
-                    "description": "added node status field for up or down",
                     "type": "string"
                 },
                 "total_resources": {

--- a/grid-proxy/docs/swagger.json
+++ b/grid-proxy/docs/swagger.json
@@ -817,6 +817,7 @@
                     },
                     {
                         "enum": [
+                            "status",
                             "node_id",
                             "farm_id",
                             "twin_id",
@@ -1597,7 +1598,6 @@
                     "type": "string"
                 },
                 "status": {
-                    "description": "added node status field for up or down",
                     "type": "string"
                 },
                 "total_resources": {

--- a/grid-proxy/docs/swagger.yaml
+++ b/grid-proxy/docs/swagger.yaml
@@ -132,7 +132,6 @@ definitions:
       serialNumber:
         type: string
       status:
-        description: added node status field for up or down
         type: string
       total_resources:
         $ref: '#/definitions/types.Capacity'
@@ -878,6 +877,7 @@ paths:
         type: boolean
       - description: Sort by specific node filed
         enum:
+        - status
         - node_id
         - farm_id
         - twin_id

--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -635,7 +635,12 @@ func (d *PostgresDatabase) GetNodes(ctx context.Context, filter types.NodeFilter
 			if strings.EqualFold(string(limit.SortOrder), string(types.SortOrderDesc)) {
 				order = types.SortOrderDesc
 			}
-			q = q.Order(fmt.Sprintf("%s %s", limit.SortBy, order))
+
+			if limit.SortBy == "status" {
+				q.Order(nodestatus.DecideNodeStatusOrdering(order))
+			} else {
+				q = q.Order(fmt.Sprintf("%s %s", limit.SortBy, order))
+			}
 		} else {
 			q = q.Order("node.node_id")
 		}

--- a/grid-proxy/internal/explorer/server.go
+++ b/grid-proxy/internal/explorer/server.go
@@ -118,7 +118,7 @@ func (a *App) getStats(r *http.Request) (interface{}, mw.Response) {
 // @Param size query int false "Max result per page"
 // @Param ret_count query bool false "Set nodes' count on headers based on filter"
 // @Param randomize query bool false "Get random patch of nodes"
-// @Param sort_by query string false "Sort by specific node filed" Enums(node_id, farm_id, twin_id, uptime, created, updated_at, country, city, dedicated_farm, rent_contract_id, total_cru, total_mru, total_hru, total_sru, used_cru, used_mru, used_hru, used_sru, num_gpu, extra_fee)
+// @Param sort_by query string false "Sort by specific node filed" Enums(status, node_id, farm_id, twin_id, uptime, created, updated_at, country, city, dedicated_farm, rent_contract_id, total_cru, total_mru, total_hru, total_sru, used_cru, used_mru, used_hru, used_sru, num_gpu, extra_fee)
 // @Param sort_order query string false "The sorting order, default is 'asc'" Enums(desc, asc)
 // @Param free_mru query int false "Min free reservable mru in bytes"
 // @Param free_hru query int false "Min free reservable hru in bytes"

--- a/grid-proxy/pkg/nodestatus/nodestatus.go
+++ b/grid-proxy/pkg/nodestatus/nodestatus.go
@@ -14,24 +14,26 @@ const (
 	nodeStandbyReportInterval = time.Hour * 24   // the interval to report for the standby node
 )
 
+var (
+	nilPower = "node.power IS NULL"
+
+	poweredOn   = "node.power->> 'state' = 'Up' AND node.power->> 'target' = 'Up'"
+	poweredOff  = "node.power->> 'state' = 'Down' AND node.power->> 'target' = 'Down'"
+	poweringOff = "node.power->> 'state' = 'Up' AND node.power->> 'target' = 'Down'"
+	poweringOn  = "node.power->> 'state' = 'Down' AND node.power->> 'target' = 'Up'"
+
+	nodeUpInterval      = time.Now().Unix() - int64(nodeUpStateFactor)*int64(nodeUpReportInterval.Seconds())
+	nodeStandbyInterval = time.Now().Unix() - int64(nodeStandbyStateFactor)*int64(nodeStandbyReportInterval.Seconds())
+
+	inUpInterval       = fmt.Sprintf("node.updated_at >= %d", nodeUpInterval)
+	outUpInterval      = fmt.Sprintf("node.updated_at < %d", nodeUpInterval)
+	inStandbyInterval  = fmt.Sprintf("node.updated_at >= %d", nodeStandbyInterval)
+	outStandbyInterval = fmt.Sprintf("node.updated_at < %d", nodeStandbyInterval)
+)
+
 // return the condition to be used in the SQL query to get the nodes with the given status.
 func DecideNodeStatusCondition(status string) string {
 	condition := "TRUE"
-
-	nilPower := "node.power IS NULL"
-
-	poweredOn := "node.power->> 'state' = 'Up' AND node.power->> 'target' = 'Up'"
-	poweredOff := "node.power->> 'state' = 'Down' AND node.power->> 'target' = 'Down'"
-	poweringOff := "node.power->> 'state' = 'Up' AND node.power->> 'target' = 'Down'"
-	poweringOn := "node.power->> 'state' = 'Down' AND node.power->> 'target' = 'Up'"
-
-	nodeUpInterval := time.Now().Unix() - int64(nodeUpStateFactor)*int64(nodeUpReportInterval.Seconds())
-	nodeStandbyInterval := time.Now().Unix() - int64(nodeStandbyStateFactor)*int64(nodeStandbyReportInterval.Seconds())
-
-	inUpInterval := fmt.Sprintf("node.updated_at >= %d", nodeUpInterval)
-	outUpInterval := fmt.Sprintf("node.updated_at < %d", nodeUpInterval)
-	inStandbyInterval := fmt.Sprintf("node.updated_at >= %d", nodeStandbyInterval)
-	outStandbyInterval := fmt.Sprintf("node.updated_at < %d", nodeStandbyInterval)
 
 	if status == "up" {
 		condition = fmt.Sprintf(`%s AND (%s OR (%s))`, inUpInterval, nilPower, poweredOn)
@@ -42,6 +44,26 @@ func DecideNodeStatusCondition(status string) string {
 	}
 
 	return condition
+}
+
+func DecideNodeStatusOrdering(order types.SortOrder) string {
+	upNodesOrder := 1
+	standbyNodesOrder := 2
+	downNodesOrder := 3
+
+	if order == types.SortOrderDesc {
+		upNodesOrder = 3
+		downNodesOrder = 1
+	}
+
+	orderBy := "CASE "
+	orderBy += fmt.Sprintf(`WHEN %s AND (%s OR (%s)) THEN %d `, inUpInterval, nilPower, poweredOn, upNodesOrder)
+	orderBy += fmt.Sprintf(`WHEN ((%s) OR (%s) OR (%s)) AND %s THEN %d `, poweredOff, poweringOff, poweringOn, inStandbyInterval, standbyNodesOrder)
+	orderBy += fmt.Sprintf(`WHEN (%s AND (%s OR (%s))) OR %s THEN %d `, outUpInterval, nilPower, poweredOn, outStandbyInterval, downNodesOrder)
+	orderBy += "ELSE 4 END "
+	orderBy += ", node.node_id "
+
+	return orderBy
 }
 
 // return the status of the node based on the power status and the last update time.

--- a/grid-proxy/pkg/nodestatus/nodestatus.go
+++ b/grid-proxy/pkg/nodestatus/nodestatus.go
@@ -46,6 +46,7 @@ func DecideNodeStatusCondition(status string) string {
 	return condition
 }
 
+// DecideNodeStatusOrdering returns an sql ordering condition
 func DecideNodeStatusOrdering(order types.SortOrder) string {
 	upNodesOrder := 1
 	standbyNodesOrder := 2

--- a/grid-proxy/pkg/types/nodes.go
+++ b/grid-proxy/pkg/types/nodes.go
@@ -33,7 +33,7 @@ type Node struct {
 	UsedResources     Capacity     `json:"used_resources" sort:"used_"`
 	Location          Location     `json:"location"`
 	PublicConfig      PublicConfig `json:"publicConfig"`
-	Status            string       `json:"status"` // added node status field for up or down
+	Status            string       `json:"status" sort:"status"`
 	CertificationType string       `json:"certificationType"`
 	Dedicated         bool         `json:"dedicated"`
 	InDedicatedFarm   bool         `json:"inDedicatedFarm" sort:"dedicated_farm"`


### PR DESCRIPTION
add new ordering on node table by the node status.
by default, nodes are ordered like (up, standby, down) and this can be reversed with the `sort_order=desc` param
also an extra ordering on `node_id` is applied

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/566

### Checklist

- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstring
