### PR TITLE
add health indexer

### DIFF
--- a/grid-proxy/cmds/proxy_server/main.go
+++ b/grid-proxy/cmds/proxy_server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/explorer"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/explorer/db"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/gpuindexer"
+	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/healthchecker"
 	logging "github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg"
 	rmb "github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go"
 	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go/peer"
@@ -56,6 +57,8 @@ type flags struct {
 	indexerResultWorkers     int
 	indexerBatchWorkers      int
 	maxPoolOpenConnections   int
+	healthCheckerWorkers     int
+	healthCheckingInterval   int
 }
 
 func main() {
@@ -82,6 +85,8 @@ func main() {
 	flag.IntVar(&f.indexerResultWorkers, "indexer-results-workers", 2, "number of workers to process indexer GPU info")
 	flag.IntVar(&f.indexerBatchWorkers, "indexer-batch-workers", 2, "number of workers to process batch GPU info")
 	flag.IntVar(&f.maxPoolOpenConnections, "max-open-conns", 80, "max number of db connection pool open connections")
+	flag.IntVar(&f.healthCheckerWorkers, "health-worker", 10, "number of workers checking on node health")
+	flag.IntVar(&f.healthCheckingInterval, "health-interval", 5, "node health check interval in min")
 	flag.Parse()
 
 	// shows version and exit
@@ -137,6 +142,12 @@ func main() {
 	}
 
 	indexer.Start(ctx)
+
+	healthChecker, err := healthchecker.NewNodeHealthChecker(ctx, &db, subManager, f.mnemonics, f.relayURL, f.healthCheckerWorkers, f.healthCheckingInterval)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to create health checker")
+	}
+	healthChecker.Start(ctx)
 
 	s, err := createServer(f, dbClient, GitCommit, relayRPCClient)
 	if err != nil {

--- a/grid-proxy/cmds/proxy_server/main.go
+++ b/grid-proxy/cmds/proxy_server/main.go
@@ -35,30 +35,30 @@ const (
 var GitCommit string
 
 type flags struct {
-	debug                    string
-	postgresHost             string
-	postgresPort             int
-	postgresDB               string
-	postgresUser             string
-	postgresPassword         string
-	sqlLogLevel              int
-	address                  string
-	version                  bool
-	nocert                   bool
-	domain                   string
-	TLSEmail                 string
-	CA                       string
-	certCacheDir             string
-	tfChainURL               string
-	relayURL                 string
-	mnemonics                string
-	indexerCheckIntervalMins int
-	indexerBatchSize         int
-	indexerResultWorkers     int
-	indexerBatchWorkers      int
-	maxPoolOpenConnections   int
-	healthCheckerWorkers     uint
-	healthCheckingInterval   uint
+	debug                       string
+	postgresHost                string
+	postgresPort                int
+	postgresDB                  string
+	postgresUser                string
+	postgresPassword            string
+	sqlLogLevel                 int
+	address                     string
+	version                     bool
+	nocert                      bool
+	domain                      string
+	TLSEmail                    string
+	CA                          string
+	certCacheDir                string
+	tfChainURL                  string
+	relayURL                    string
+	mnemonics                   string
+	gpuIndexerCheckIntervalMins uint
+	gpuIndexerBatchSize         uint
+	gpuIndexerResultWorkers     uint
+	gpuIndexerBatchWorkers      uint
+	maxPoolOpenConnections      int
+	healthIndexerWorkers        uint
+	healthIndexerInterval       uint
 }
 
 func main() {
@@ -80,13 +80,13 @@ func main() {
 	flag.StringVar(&f.tfChainURL, "tfchain-url", DefaultTFChainURL, "TF chain url")
 	flag.StringVar(&f.relayURL, "relay-url", DefaultRelayURL, "RMB relay url")
 	flag.StringVar(&f.mnemonics, "mnemonics", "", "Dummy user mnemonics for relay calls")
-	flag.IntVar(&f.indexerCheckIntervalMins, "indexer-interval-min", 60, "the interval that the GPU indexer will run")
-	flag.IntVar(&f.indexerBatchSize, "indexer-batch-size", 20, "batch size for the GPU indexer worker batch")
-	flag.IntVar(&f.indexerResultWorkers, "indexer-results-workers", 2, "number of workers to process indexer GPU info")
-	flag.IntVar(&f.indexerBatchWorkers, "indexer-batch-workers", 2, "number of workers to process batch GPU info")
+	flag.UintVar(&f.gpuIndexerCheckIntervalMins, "indexer-interval-min", 60, "the interval that the GPU indexer will run")
+	flag.UintVar(&f.gpuIndexerBatchSize, "indexer-batch-size", 20, "batch size for the GPU indexer worker batch")
+	flag.UintVar(&f.gpuIndexerResultWorkers, "indexer-results-workers", 2, "number of workers to process indexer GPU info")
+	flag.UintVar(&f.gpuIndexerBatchWorkers, "indexer-batch-workers", 2, "number of workers to process batch GPU info")
 	flag.IntVar(&f.maxPoolOpenConnections, "max-open-conns", 80, "max number of db connection pool open connections")
-	flag.UintVar(&f.healthCheckerWorkers, "health-worker", 10, "number of workers checking on node health")
-	flag.UintVar(&f.healthCheckingInterval, "health-interval", 5, "node health check interval in min")
+	flag.UintVar(&f.healthIndexerWorkers, "health-indexer-workers", 10, "number of workers checking on node health")
+	flag.UintVar(&f.healthIndexerInterval, "health-indexer-interval", 5, "node health check interval in min")
 	flag.Parse()
 
 	// shows version and exit
@@ -132,10 +132,10 @@ func main() {
 		f.relayURL,
 		f.mnemonics,
 		subManager, &db,
-		f.indexerCheckIntervalMins,
-		f.indexerBatchSize,
-		f.indexerResultWorkers,
-		f.indexerBatchWorkers,
+		f.gpuIndexerCheckIntervalMins,
+		f.gpuIndexerBatchSize,
+		f.gpuIndexerResultWorkers,
+		f.gpuIndexerBatchWorkers,
 	)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to create GPU indexer")
@@ -143,9 +143,9 @@ func main() {
 
 	indexer.Start(ctx)
 
-	healthIndexer, err := healthindexer.NewNodeHealthIndexer(ctx, &db, subManager, f.mnemonics, f.relayURL, f.healthCheckerWorkers, f.healthCheckingInterval)
+	healthIndexer, err := healthindexer.NewNodeHealthIndexer(ctx, &db, subManager, f.mnemonics, f.relayURL, f.healthIndexerWorkers, f.healthIndexerInterval)
 	if err != nil {
-		log.Fatal().Err(err).Msg("failed to create health checker")
+		log.Fatal().Err(err).Msg("failed to create health indexer")
 	}
 	healthIndexer.Start(ctx)
 

--- a/grid-proxy/cmds/proxy_server/main.go
+++ b/grid-proxy/cmds/proxy_server/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/explorer"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/explorer/db"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/gpuindexer"
-	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/healthchecker"
+	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/healthindexer"
 	logging "github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg"
 	rmb "github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go"
 	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go/peer"
@@ -57,8 +57,8 @@ type flags struct {
 	indexerResultWorkers     int
 	indexerBatchWorkers      int
 	maxPoolOpenConnections   int
-	healthCheckerWorkers     int
-	healthCheckingInterval   int
+	healthCheckerWorkers     uint
+	healthCheckingInterval   uint
 }
 
 func main() {
@@ -85,8 +85,8 @@ func main() {
 	flag.IntVar(&f.indexerResultWorkers, "indexer-results-workers", 2, "number of workers to process indexer GPU info")
 	flag.IntVar(&f.indexerBatchWorkers, "indexer-batch-workers", 2, "number of workers to process batch GPU info")
 	flag.IntVar(&f.maxPoolOpenConnections, "max-open-conns", 80, "max number of db connection pool open connections")
-	flag.IntVar(&f.healthCheckerWorkers, "health-worker", 10, "number of workers checking on node health")
-	flag.IntVar(&f.healthCheckingInterval, "health-interval", 5, "node health check interval in min")
+	flag.UintVar(&f.healthCheckerWorkers, "health-worker", 10, "number of workers checking on node health")
+	flag.UintVar(&f.healthCheckingInterval, "health-interval", 5, "node health check interval in min")
 	flag.Parse()
 
 	// shows version and exit
@@ -143,11 +143,11 @@ func main() {
 
 	indexer.Start(ctx)
 
-	healthChecker, err := healthchecker.NewNodeHealthChecker(ctx, &db, subManager, f.mnemonics, f.relayURL, f.healthCheckerWorkers, f.healthCheckingInterval)
+	healthIndexer, err := healthindexer.NewNodeHealthIndexer(ctx, &db, subManager, f.mnemonics, f.relayURL, f.healthCheckerWorkers, f.healthCheckingInterval)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to create health checker")
 	}
-	healthChecker.Start(ctx)
+	healthIndexer.Start(ctx)
 
 	s, err := createServer(f, dbClient, GitCommit, relayRPCClient)
 	if err != nil {

--- a/grid-proxy/internal/explorer/converters.go
+++ b/grid-proxy/internal/explorer/converters.go
@@ -57,6 +57,7 @@ func nodeFromDBNode(info db.Node) types.Node {
 		Power:             types.NodePower(info.Power),
 		NumGPU:            info.NumGPU,
 		ExtraFee:          info.ExtraFee,
+		Healthy:           info.Healthy,
 	}
 	node.Status = nodestatus.DecideNodeStatus(node.Power, node.UpdatedAt)
 	node.Dedicated = info.FarmDedicated || info.NodeContractsCount == 0 || info.Renter != 0
@@ -129,6 +130,7 @@ func nodeWithNestedCapacityFromDBNode(info db.Node) types.NodeWithNestedCapacity
 		Power:             types.NodePower(info.Power),
 		NumGPU:            info.NumGPU,
 		ExtraFee:          info.ExtraFee,
+		Healthy:           info.Healthy,
 	}
 	node.Status = nodestatus.DecideNodeStatus(node.Power, node.UpdatedAt)
 	node.Dedicated = info.FarmDedicated || info.NodeContractsCount == 0 || info.Renter != 0

--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -66,6 +66,10 @@ func NewPostgresDatabase(host string, port int, user, password, dbname string, m
 	if err != nil {
 		return PostgresDatabase{}, errors.Wrap(err, "failed to migrate node_gpu table")
 	}
+	err = gormDB.AutoMigrate(&HealthReport{})
+	if err != nil {
+		return PostgresDatabase{}, errors.Wrap(err, "failed to migrate health_report table")
+	}
 	sql.SetMaxIdleConns(3)
 	sql.SetMaxOpenConns(maxConns)
 

--- a/grid-proxy/internal/explorer/db/setup.sql
+++ b/grid-proxy/internal/explorer/db/setup.sql
@@ -35,7 +35,6 @@ CREATE OR REPLACE VIEW resources_cache_view AS
 SELECT
     node.node_id as node_id,
     node.farm_id as farm_id,
-    node.twin_id as node_twin_id,
     COALESCE(node_resources_total.hru, 0) as total_hru,
     COALESCE(node_resources_total.mru, 0) as total_mru,
     COALESCE(node_resources_total.sru, 0) as total_sru,
@@ -69,7 +68,6 @@ FROM node
     LEFT JOIN country ON LOWER(node.country) = LOWER(country.name)
 GROUP BY
     node.node_id,
-    node.twin_id,
     node_resources_total.mru,
     node_resources_total.sru,
     node_resources_total.hru,
@@ -85,7 +83,6 @@ DROP TABLE IF EXISTS resources_cache;
 CREATE TABLE IF NOT EXISTS resources_cache(
     node_id INTEGER PRIMARY KEY,
     farm_id INTEGER NOT NULL,
-    node_twin_id INTEGER NOT NULL,
     total_hru NUMERIC NOT NULL,
     total_mru NUMERIC NOT NULL,
     total_sru NUMERIC NOT NULL,
@@ -102,13 +99,21 @@ CREATE TABLE IF NOT EXISTS resources_cache(
     node_contracts_count INTEGER NOT NULL,
     node_gpu_count INTEGER NOT NULL,
     country TEXT,
-    region TEXT,
-    healthy BOOLEAN DEFAULT false
+    region TEXT
     );
 
 INSERT INTO resources_cache 
 SELECT * 
 FROM resources_cache_view;
+
+----
+-- Health report table
+---
+DROP TABLE IF EXISTS health_report;
+CREATE TABLE health_report (
+    node_twin_id bigint PRIMARY KEY,
+    healthy boolean
+);
 
 ----
 -- PublicIpsCache table

--- a/grid-proxy/internal/explorer/db/setup.sql
+++ b/grid-proxy/internal/explorer/db/setup.sql
@@ -106,14 +106,6 @@ INSERT INTO resources_cache
 SELECT * 
 FROM resources_cache_view;
 
-----
--- Health report table
----
-DROP TABLE IF EXISTS health_report;
-CREATE TABLE health_report (
-    node_twin_id bigint PRIMARY KEY,
-    healthy boolean
-);
 
 ----
 -- PublicIpsCache table

--- a/grid-proxy/internal/explorer/db/setup.sql
+++ b/grid-proxy/internal/explorer/db/setup.sql
@@ -35,6 +35,7 @@ CREATE OR REPLACE VIEW resources_cache_view AS
 SELECT
     node.node_id as node_id,
     node.farm_id as farm_id,
+    node.twin_id as node_twin_id,
     COALESCE(node_resources_total.hru, 0) as total_hru,
     COALESCE(node_resources_total.mru, 0) as total_mru,
     COALESCE(node_resources_total.sru, 0) as total_sru,
@@ -68,6 +69,7 @@ FROM node
     LEFT JOIN country ON LOWER(node.country) = LOWER(country.name)
 GROUP BY
     node.node_id,
+    node.twin_id,
     node_resources_total.mru,
     node_resources_total.sru,
     node_resources_total.hru,
@@ -83,6 +85,7 @@ DROP TABLE IF EXISTS resources_cache;
 CREATE TABLE IF NOT EXISTS resources_cache(
     node_id INTEGER PRIMARY KEY,
     farm_id INTEGER NOT NULL,
+    node_twin_id INTEGER NOT NULL,
     total_hru NUMERIC NOT NULL,
     total_mru NUMERIC NOT NULL,
     total_sru NUMERIC NOT NULL,
@@ -99,7 +102,8 @@ CREATE TABLE IF NOT EXISTS resources_cache(
     node_contracts_count INTEGER NOT NULL,
     node_gpu_count INTEGER NOT NULL,
     country TEXT,
-    region TEXT
+    region TEXT,
+    healthy BOOLEAN DEFAULT false
     );
 
 INSERT INTO resources_cache 

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -20,6 +20,7 @@ type Database interface {
 	UpsertNodesGPU(ctx context.Context, nodesGPU []types.NodeGPU) error
 	GetLastNodeTwinID(ctx context.Context) (int64, error)
 	GetNodeTwinIDsAfter(ctx context.Context, twinID int64) ([]int64, error)
+	MarkNodeAsHealthy(ctx context.Context, twinID int64) error
 	GetConnectionString() string
 }
 
@@ -76,6 +77,7 @@ type Node struct {
 	NumGPU             int       `gorm:"num_gpu"`
 	ExtraFee           uint64
 	NodeContractsCount uint64 `gorm:"node_contracts_count"`
+	Healthy            bool
 }
 
 // NodePower struct is the farmerbot report for node status

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -115,3 +115,12 @@ type NodeGPU struct {
 func (NodeGPU) TableName() string {
 	return "node_gpu"
 }
+
+type HealthReport struct {
+	NodeTwinId int
+	Healthy    bool
+}
+
+func (HealthReport) TableName() string {
+	return "health_report"
+}

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -20,7 +20,7 @@ type Database interface {
 	UpsertNodesGPU(ctx context.Context, nodesGPU []types.NodeGPU) error
 	GetLastNodeTwinID(ctx context.Context) (int64, error)
 	GetNodeTwinIDsAfter(ctx context.Context, twinID int64) ([]int64, error)
-	MarkNodeAsHealthy(ctx context.Context, twinID int64) error
+	UpsertNodeHealth(ctx context.Context, healthReport types.HealthReport) error
 	GetConnectionString() string
 }
 

--- a/grid-proxy/internal/healthchecker/healthchecker.go
+++ b/grid-proxy/internal/healthchecker/healthchecker.go
@@ -1,0 +1,132 @@
+package healthchecker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	substrate "github.com/threefoldtech/tfchain/clients/tfchain-client-go"
+	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/explorer/db"
+	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
+	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go"
+	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go/peer"
+)
+
+const (
+	checkCallTimeout = 10 * time.Second
+	checkCommand     = "zos.system.version"
+)
+
+type NodeHealthChecker struct {
+	db              db.Database
+	relayClient     rmb.Client
+	nodeTwinIdsChan chan int64
+	checkInterval   time.Duration
+	checkWorkers    int
+}
+
+func NewNodeHealthChecker(
+	ctx context.Context,
+	db db.Database,
+	subManager substrate.Manager,
+	mnemonic string,
+	relayUrl string,
+	checkWorkers int,
+	checkInterval int,
+) (*NodeHealthChecker, error) {
+	sessionId := fmt.Sprintf("node-health-checker-%s", strings.Split(uuid.NewString(), "-")[0])
+	rpcClient, err := peer.NewRpcClient(ctx, peer.KeyTypeSr25519, mnemonic, relayUrl, sessionId, subManager, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create rmb client: %w", err)
+	}
+
+	return &NodeHealthChecker{
+		db:              db,
+		relayClient:     rpcClient,
+		nodeTwinIdsChan: make(chan int64),
+		checkWorkers:    checkWorkers,
+		checkInterval:   time.Duration(checkInterval) * time.Minute,
+	}, nil
+}
+
+func (c *NodeHealthChecker) Start(ctx context.Context) {
+
+	// start the node querier, push twin-ids into chan
+	go c.startNodeQuerier(ctx)
+
+	// start the health checkers, pop from twin-ids chan and update the db
+	for i := 0; i < c.checkWorkers; i++ {
+		go c.checkNodeHealth(ctx)
+	}
+
+	log.Info().Msg("Node health checker started")
+
+}
+
+func (c *NodeHealthChecker) startNodeQuerier(ctx context.Context) {
+	ticker := time.NewTicker(c.checkInterval)
+	c.queryGridNodes(ctx)
+	for {
+		select {
+		case <-ticker.C:
+			c.queryGridNodes(ctx)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (c *NodeHealthChecker) queryGridNodes(ctx context.Context) {
+	status := "up"
+	filter := types.NodeFilter{
+		Status: &status,
+	}
+
+	limit := types.Limit{
+		Size:     100,
+		RetCount: true,
+		Page:     1,
+	}
+
+	hasNext := true
+	for hasNext {
+		nodes, _, err := c.db.GetNodes(ctx, filter, limit)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to query grid nodes")
+		}
+
+		if len(nodes) < int(limit.Size) {
+			hasNext = false
+		}
+
+		for _, node := range nodes {
+			// fmt.Printf("push node: %d\n", node.TwinID)
+			c.nodeTwinIdsChan <- node.TwinID
+		}
+	}
+
+}
+
+func (c *NodeHealthChecker) checkNodeHealth(ctx context.Context) {
+	var result interface{}
+	for twinId := range c.nodeTwinIdsChan {
+		ctx, cancel := context.WithTimeout(ctx, checkCallTimeout)
+
+		err := c.relayClient.Call(ctx, uint32(twinId), checkCommand, nil, &result)
+		if isHealthy(err) {
+			err := c.db.MarkNodeAsHealthy(ctx, twinId)
+			if err != nil {
+				log.Error().Err(err).Msgf("failed to mark node with twin id %d as healthy", twinId)
+			}
+		}
+		// fmt.Printf("pop node: %d -> %v, worker: %d\n", twinId, isHealthy(err), num)
+		cancel()
+	}
+}
+
+func isHealthy(err error) bool {
+	return err == nil
+}

--- a/grid-proxy/pkg/types/nodes.go
+++ b/grid-proxy/pkg/types/nodes.go
@@ -43,6 +43,7 @@ type Node struct {
 	Power             NodePower    `json:"power"`
 	NumGPU            int          `json:"num_gpu" sort:"num_gpu"`
 	ExtraFee          uint64       `json:"extraFee" sort:"extra_fee"`
+	Healthy           bool         `json:"healthy"`
 }
 
 // CapacityResult is the NodeData capacity results to unmarshal json in it
@@ -77,6 +78,7 @@ type NodeWithNestedCapacity struct {
 	Power             NodePower      `json:"power"`
 	NumGPU            int            `json:"num_gpu"`
 	ExtraFee          uint64         `json:"extraFee"`
+	Healthy           bool           `json:"healthy"`
 }
 
 // PublicConfig node public config
@@ -134,6 +136,7 @@ type NodeFilter struct {
 	GpuVendorID       *string  `schema:"gpu_vendor_id,omitempty"`
 	GpuVendorName     *string  `schema:"gpu_vendor_name,omitempty"`
 	GpuAvailable      *bool    `schema:"gpu_available,omitempty"`
+	Healthy           *bool    `schema:"healthy,omitempty"`
 }
 
 // NodeGPU holds the info about gpu card

--- a/grid-proxy/pkg/types/nodes.go
+++ b/grid-proxy/pkg/types/nodes.go
@@ -147,3 +147,9 @@ type NodeGPU struct {
 	Device     string `json:"device"`
 	Contract   int    `json:"contract"`
 }
+
+// HeathReport holds the info of node health
+type HealthReport struct {
+	NodeTwinId uint64
+	Healthy    bool
+}

--- a/grid-proxy/pkg/types/nodes.go
+++ b/grid-proxy/pkg/types/nodes.go
@@ -150,6 +150,6 @@ type NodeGPU struct {
 
 // HeathReport holds the info of node health
 type HealthReport struct {
-	NodeTwinId uint64
+	NodeTwinId uint32
 	Healthy    bool
 }

--- a/grid-proxy/tests/queries/main_test.go
+++ b/grid-proxy/tests/queries/main_test.go
@@ -80,7 +80,6 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(err)
 	}
-	// mockClient = mock.NewGridProxyMockClient(data)
 
 	err = modifyDataToFireTriggers(db, data)
 	if err != nil {
@@ -169,15 +168,15 @@ func modifyDataToFireTriggers(db *sql.DB, data mock.DBData) error {
 		return fmt.Errorf("failed to update node node contract: %w", err)
 	}
 
-	if err := generator.UpdateRentContract(); err != nil {
-		return fmt.Errorf("failed to update rent contract: %w", err)
-	}
+	// if err := generator.UpdateRentContract(); err != nil {
+	// 	return fmt.Errorf("failed to update rent contract: %w", err)
+	// }
 
 	if err := generator.UpdatePublicIps(); err != nil {
 		return fmt.Errorf("failed to update public ips: %w", err)
 	}
 
-	// // deletions
+	// deletions
 	if err := generator.DeleteNodes(); err != nil {
 		return fmt.Errorf("failed to delete node: %w", err)
 	}

--- a/grid-proxy/tests/queries/main_test.go
+++ b/grid-proxy/tests/queries/main_test.go
@@ -168,9 +168,9 @@ func modifyDataToFireTriggers(db *sql.DB, data mock.DBData) error {
 		return fmt.Errorf("failed to update node node contract: %w", err)
 	}
 
-	// if err := generator.UpdateRentContract(); err != nil {
-	// 	return fmt.Errorf("failed to update rent contract: %w", err)
-	// }
+	if err := generator.UpdateRentContract(); err != nil {
+		return fmt.Errorf("failed to update rent contract: %w", err)
+	}
 
 	if err := generator.UpdatePublicIps(); err != nil {
 		return fmt.Errorf("failed to update public ips: %w", err)

--- a/grid-proxy/tests/queries/mock_client/loader.go
+++ b/grid-proxy/tests/queries/mock_client/loader.go
@@ -36,6 +36,7 @@ type DBData struct {
 	GPUs                map[uint64][]NodeGPU
 	Regions             map[string]string
 	Locations           map[string]Location
+	HealthReports       map[uint64]bool
 	DB                  *sql.DB
 }
 
@@ -581,6 +582,30 @@ func loadNodeGPUs(db *sql.DB, data *DBData) error {
 	return nil
 }
 
+func loadHealthReports(db *sql.DB, data *DBData) error {
+	rows, err := db.Query(`
+	SELECT
+		COALESCE(node_twin_id, 0),
+		COALESCE(healthy, false)
+	FROM
+		health_report;`)
+	if err != nil {
+		return err
+	}
+	for rows.Next() {
+		var health HealthReport
+		if err := rows.Scan(
+			&health.NodeTwinId,
+			&health.Healthy,
+		); err != nil {
+			return err
+		}
+		data.HealthReports[health.NodeTwinId] = health.Healthy
+	}
+
+	return nil
+}
+
 func Load(db *sql.DB) (DBData, error) {
 	data := DBData{
 		NodeIDMap:           make(map[string]uint64),
@@ -607,6 +632,7 @@ func Load(db *sql.DB) (DBData, error) {
 		FarmHasRentedNode:   make(map[uint64]map[uint64]bool),
 		Regions:             make(map[string]string),
 		Locations:           make(map[string]Location),
+		HealthReports:       make(map[uint64]bool),
 		DB:                  db,
 	}
 	if err := loadNodes(db, &data); err != nil {
@@ -649,6 +675,9 @@ func Load(db *sql.DB) (DBData, error) {
 		return data, err
 	}
 	if err := loadLocations(db, &data); err != nil {
+		return data, err
+	}
+	if err := loadHealthReports(db, &data); err != nil {
 		return data, err
 	}
 	if err := calcNodesUsedResources(&data); err != nil {

--- a/grid-proxy/tests/queries/mock_client/nodes.go
+++ b/grid-proxy/tests/queries/mock_client/nodes.go
@@ -86,6 +86,7 @@ func (g *GridProxyMockClient) Nodes(ctx context.Context, filter types.NodeFilter
 				},
 				NumGPU:   numGPU,
 				ExtraFee: node.ExtraFee,
+				Healthy:  g.data.HealthReports[node.TwinID],
 			})
 		}
 	}
@@ -171,6 +172,7 @@ func (g *GridProxyMockClient) Node(ctx context.Context, nodeID uint32) (res type
 		},
 		NumGPU:   numGPU,
 		ExtraFee: node.ExtraFee,
+		Healthy:  g.data.HealthReports[node.TwinID],
 	}
 	return
 }

--- a/grid-proxy/tests/queries/mock_client/nodes.go
+++ b/grid-proxy/tests/queries/mock_client/nodes.go
@@ -211,6 +211,10 @@ func (n *Node) satisfies(f types.NodeFilter, data *DBData) bool {
 		return false
 	}
 
+	if f.Healthy != nil && *f.Healthy != data.HealthReports[n.TwinID] {
+		return false
+	}
+
 	if f.FreeSRU != nil && int64(*f.FreeSRU) > int64(free.SRU) {
 		return false
 	}

--- a/grid-proxy/tests/queries/mock_client/types.go
+++ b/grid-proxy/tests/queries/mock_client/types.go
@@ -149,6 +149,11 @@ type NodeGPU struct {
 	Contract   int
 }
 
+type HealthReport struct {
+	NodeTwinId uint64
+	Healthy    bool
+}
+
 type Country struct {
 	ID        string
 	CountryID uint64

--- a/grid-proxy/tests/queries/node_test.go
+++ b/grid-proxy/tests/queries/node_test.go
@@ -55,6 +55,13 @@ var nodeFilterRandomValueGenerator = map[string]func(agg NodesAggregate) interfa
 	"Status": func(agg NodesAggregate) interface{} {
 		return &statuses[rand.Intn(3)]
 	},
+	"Healthy": func(_ NodesAggregate) interface{} {
+		v := true
+		if flip(.5) {
+			v = false
+		}
+		return &v
+	},
 	"FreeMRU": func(agg NodesAggregate) interface{} {
 		if flip(.1) {
 			return &agg.freeMRUs[rand.Intn(len(agg.freeMRUs))]

--- a/grid-proxy/tools/db/crafter/deleter.go
+++ b/grid-proxy/tools/db/crafter/deleter.go
@@ -22,6 +22,7 @@ func (g *Crafter) DeleteNodes() error {
 		query += fmt.Sprintf("DELETE FROM node_resources_total WHERE node_id = (SELECT id FROM node WHERE node_id = %d);", nodeID)
 		query += fmt.Sprintf("DELETE FROM public_config WHERE node_id = (SELECT id FROM node WHERE node_id = %d);", nodeID)
 		query += fmt.Sprintf("DELETE FROM node WHERE node_id = %d;", nodeID)
+		query += fmt.Sprintf("DELETE FROM health_report WHERE node_twin_id = (SELECT twin_id FROM node WHERE node_id = %d);", nodeID)
 	}
 
 	fmt.Println("nodes deleted")

--- a/grid-proxy/tools/db/crafter/generator.go
+++ b/grid-proxy/tools/db/crafter/generator.go
@@ -88,6 +88,7 @@ func (c *Crafter) GenerateNodes() error {
 
 	powerState := []string{"Up", "Down"}
 	var locations []string
+	var healthReports []string
 	var nodes []string
 	var totalResources []string
 	var publicConfigs []string
@@ -186,6 +187,15 @@ func (c *Crafter) GenerateNodes() error {
 			node_id: fmt.Sprintf("node-%d", i),
 		}
 
+		health := true
+		if flip(.5) {
+			health = false
+		}
+		healthReport := health_report{
+			node_twin_id: uint64(nodeTwinsStart) + i,
+			healthy:      health,
+		}
+
 		if _, ok := c.dedicatedFarms[node.farm_id]; ok {
 			c.availableRentNodes[i] = struct{}{}
 			c.availableRentNodesList = append(c.availableRentNodesList, i)
@@ -196,6 +206,12 @@ func (c *Crafter) GenerateNodes() error {
 			return fmt.Errorf("failed to convert location object to tuple string: %w", err)
 		}
 		locations = append(locations, locationTuple)
+
+		healthTuple, err := objectToTupleString(healthReport)
+		if err != nil {
+			return fmt.Errorf("failed to convert health report to tuple string: %w", err)
+		}
+		healthReports = append(healthReports, healthTuple)
 
 		nodeTuple, err := objectToTupleString(node)
 		if err != nil {
@@ -230,6 +246,10 @@ func (c *Crafter) GenerateNodes() error {
 
 	if err := c.insertTuples(location{}, locations); err != nil {
 		return fmt.Errorf("failed to insert locations: %w", err)
+	}
+
+	if err := c.insertTuples(health_report{}, healthReports); err != nil {
+		return fmt.Errorf("failed to insert health reports: %w", err)
 	}
 
 	if err := c.insertTuples(node{}, nodes); err != nil {

--- a/grid-proxy/tools/db/crafter/generator.go
+++ b/grid-proxy/tools/db/crafter/generator.go
@@ -192,7 +192,7 @@ func (c *Crafter) GenerateNodes() error {
 			health = false
 		}
 		healthReport := health_report{
-			node_twin_id: uint64(nodeTwinsStart) + i,
+			node_twin_id: node.twin_id,
 			healthy:      health,
 		}
 

--- a/grid-proxy/tools/db/crafter/modifier.go
+++ b/grid-proxy/tools/db/crafter/modifier.go
@@ -80,12 +80,10 @@ func (g *Crafter) UpdateNodeContractState() error {
 func (g *Crafter) UpdateRentContract() error {
 	updatesCount := 10
 	query := ""
-	states := []string{"Deleted", "GracePeriod"}
+	state := "Deleted"
 
 	for i := 0; i < updatesCount; i++ {
-		// WATCH
 		contractId := r.Intn(int(g.RentContractCount)) + 1
-		state := states[r.Intn(2)]
 		query += fmt.Sprintf("UPDATE rent_contract SET state = '%s' WHERE contract_id = %d;", state, contractId)
 	}
 

--- a/grid-proxy/tools/db/crafter/types.go
+++ b/grid-proxy/tools/db/crafter/types.go
@@ -264,3 +264,8 @@ type country struct {
 	lat        string
 	long       string
 }
+
+type health_report struct {
+	node_twin_id uint64
+	healthy      bool
+}

--- a/grid-proxy/tools/db/schema.sql
+++ b/grid-proxy/tools/db/schema.sql
@@ -458,6 +458,17 @@ CREATE TABLE IF NOT EXISTS public.node_gpu (
 ALTER TABLE public.node_gpu OWNER TO postgres;
 
 --
+-- Name: health_report; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE IF NOT EXISTS public.health_report (
+    node_twin_id bigint NOT NULL,
+    healthy boolean
+);
+
+ALTER TABLE public.health_report OWNER TO postgres;
+
+--
 -- Name: refund_transaction; Type: TABLE; Schema: public; Owner: postgres
 --
 


### PR DESCRIPTION
## Description 
- add health check indexer that calls the nodes every 5 mins
- flag the nodes as `healthy` if they respond
- add a `healthy` filter on the `/nodes` endpoint
- adds the needed tests/generators
 
## Related issues
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/603