### PR TITLE
Development fix publish workflow

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v4
 
+      - name: Checkout latest release tag
+        run: |
+          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          git checkout $LATEST_TAG
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3.0.0
         with:

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -13,7 +13,7 @@ on:
   workflow_run:
     workflows: [Release]
     types: [completed]
-    workflow_dispatch:
+  workflow_dispatch:
 
 jobs:
   push-docker-images:

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -13,7 +13,7 @@ on:
   workflow_run:
     workflows: [Release]
     types: [completed]
-  workflow_dispatch:
+    workflow_dispatch:
 
 jobs:
   push-docker-images:
@@ -36,11 +36,6 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4
-
-      - name: Checkout latest release tag
-        run: |
-          LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
-          git checkout $LATEST_TAG
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3.0.0
@@ -67,7 +62,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           #  For workflows triggered by release, `github.ref_name` is the short name for the release tag created.
           build-args: |
-            version=${{ github.ref_name	 }}
+            version=${{ github.event.workflow_run.head_branch	 }}
 
       # - name: Push flist to grid hub
       #   uses: fjogeleit/http-request-action@v1

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -62,7 +62,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           #  For workflows triggered by release, `github.ref_name` is the short name for the release tag created.
           build-args: |
-            version=${{ github.event.workflow_run.head_branch	 }}
+            version=$(git describe --tags `git rev-list --tags --max-count=1`)
 
       # - name: Push flist to grid hub
       #   uses: fjogeleit/http-request-action@v1

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v4
 
+      - name: Get latest version
+        run: |
+          echo "TAG_VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+        id: version
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3.0.0
         with:
@@ -58,11 +63,11 @@ jobs:
           context: .
           file: ./${{ matrix.dir }}/Dockerfile
           push: true
-          tags: ghcr.io/threefoldtech/${{ matrix.image }}:$(git describe --tags --abbrev=0)
+          tags: ghcr.io/threefoldtech/${{ matrix.image }}:${{ steps.version.outputs.TAG_VERSION }}
           labels: ${{ steps.meta.outputs.labels }}
           #  For workflows triggered by release, `github.ref_name` is the short name for the release tag created.
           build-args: |
-            version=$(git describe --tags --abbrev=0)
+            version=${{ steps.version.outputs.TAG_VERSION }}
 
       # - name: Push flist to grid hub
       #   uses: fjogeleit/http-request-action@v1

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -58,11 +58,11 @@ jobs:
           context: .
           file: ./${{ matrix.dir }}/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ghcr.io/threefoldtech/${{ matrix.image }}:$(git describe --tags --abbrev=0)
           labels: ${{ steps.meta.outputs.labels }}
           #  For workflows triggered by release, `github.ref_name` is the short name for the release tag created.
           build-args: |
-            version=$(git describe --tags `git rev-list --tags --max-count=1`)
+            version=$(git describe --tags --abbrev=0)
 
       # - name: Push flist to grid hub
       #   uses: fjogeleit/http-request-action@v1

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v4
 
+      - run: git fetch --prune --unshallow
+
       - name: Get latest version
         run: |
           echo "TAG_VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Issues

- https://github.com/threefoldtech/tfgrid-sdk-go/issues/597

### Description

- the event of `workflow_run` doesn't have a ref to the latest tag/release, so whenever the workflow is triggered we will get the latest tag using git