### PR TITLE
add unique constraints on NodeTwinId

### DIFF
--- a/grid-proxy/charts/gridproxy/Chart.yaml
+++ b/grid-proxy/charts/gridproxy/Chart.yaml
@@ -20,4 +20,4 @@ version: 1.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.13.5
+appVersion: 0.13.6

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -118,7 +118,7 @@ func (NodeGPU) TableName() string {
 }
 
 type HealthReport struct {
-	NodeTwinId int
+	NodeTwinId int `gorm:"unique;not null"`
 	Healthy    bool
 }
 


### PR DESCRIPTION
### Description
looks tests were run on a db-dump with a unique constraint on the health-report table. but we need to explicitly add unique constraints on NodeTwinId on the HealthReport struct which migrated to the db with gorm at the startup

### Related Issues
- https://github.com/threefoldtech/tf_operations/issues/2190

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
