### PR TITLE
increase the sleeping interval on the proxy integration tests

### DIFF
--- a/.github/workflows/grid-proxy-integration.yml
+++ b/.github/workflows/grid-proxy-integration.yml
@@ -53,7 +53,7 @@ jobs:
           go run . --seed 13 --postgres-host localhost --postgres-db tfgrid-graphql --postgres-password postgres --postgres-user postgres --reset
           popd
           go run cmds/proxy_server/main.go -no-cert --address :8080 --log-level debug --postgres-host localhost --postgres-db tfgrid-graphql --postgres-password postgres --postgres-user postgres --mnemonics "$MNEMONICS" &
-          sleep 6
+          sleep 10
           pushd tests/queries
           go test -v --seed 13 --postgres-host localhost --postgres-db tfgrid-graphql --postgres-password postgres --postgres-user postgres --endpoint http://localhost:8080
           popd


### PR DESCRIPTION
### Description
Sometimes integration tests fails cause the server is not started yet, increasing the waiting interval should fix it

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
