### PR TITLE
re validate the health reports

### DIFF
--- a/.github/workflows/grid-proxy-integration.yml
+++ b/.github/workflows/grid-proxy-integration.yml
@@ -52,7 +52,7 @@ jobs:
           pushd tools/db
           go run . --seed 13 --postgres-host localhost --postgres-db tfgrid-graphql --postgres-password postgres --postgres-user postgres --reset
           popd
-          go run cmds/proxy_server/main.go -no-cert --address :8080 --log-level debug --postgres-host localhost --postgres-db tfgrid-graphql --postgres-password postgres --postgres-user postgres --mnemonics "$MNEMONICS" &
+          go run cmds/proxy_server/main.go -no-cert --address :8080 --log-level debug --postgres-host localhost --postgres-db tfgrid-graphql --postgres-password postgres --postgres-user postgres --health-indexer-workers 0 --mnemonics "$MNEMONICS" &
           sleep 10
           pushd tests/queries
           go test -v --seed 13 --postgres-host localhost --postgres-db tfgrid-graphql --postgres-password postgres --postgres-user postgres --endpoint http://localhost:8080

--- a/grid-proxy/charts/gridproxy/Chart.yaml
+++ b/grid-proxy/charts/gridproxy/Chart.yaml
@@ -20,4 +20,4 @@ version: 1.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.13.6
+appVersion: 0.13.7

--- a/grid-proxy/cmds/proxy_server/main.go
+++ b/grid-proxy/cmds/proxy_server/main.go
@@ -57,8 +57,9 @@ type flags struct {
 	gpuIndexerResultWorkers     uint
 	gpuIndexerBatchWorkers      uint
 	maxPoolOpenConnections      int
-	healthIndexerWorkers        uint
-	healthIndexerInterval       uint
+	// being 0 is helpful of making the data persistent while testing
+	healthIndexerWorkers  uint
+	healthIndexerInterval uint
 }
 
 func main() {

--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -899,3 +899,9 @@ func (p *PostgresDatabase) UpsertNodeHealth(ctx context.Context, healthReport ty
 	}
 	return p.gormDB.WithContext(ctx).Table("health_report").Clauses(conflictClause).Create(&healthReport).Error
 }
+
+func (p *PostgresDatabase) GetHealthyNodeTwinIds(ctx context.Context) ([]int64, error) {
+	nodeTwinIDs := make([]int64, 0)
+	err := p.gormDB.Table("health_report").Select("node_twin_id").Where("healthy = true").Scan(&nodeTwinIDs).Error
+	return nodeTwinIDs, err
+}

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -21,6 +21,7 @@ type Database interface {
 	GetLastNodeTwinID(ctx context.Context) (int64, error)
 	GetNodeTwinIDsAfter(ctx context.Context, twinID int64) ([]int64, error)
 	UpsertNodeHealth(ctx context.Context, healthReport types.HealthReport) error
+	GetHealthyNodeTwinIds(ctx context.Context) ([]int64, error)
 	GetConnectionString() string
 }
 


### PR DESCRIPTION
### Description
- use different contexts for rmb and database calls
- revalidate the health reports
- update the integration workflow to make health indexer workers 0, by that we ensure the indexer will not change the database from the one already loaded from `loader` in tests.

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/621

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
