### PR TITLE
gpu indexer fixes

### DIFF
--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -880,6 +880,14 @@ func (p *PostgresDatabase) UpsertNodesGPU(ctx context.Context, nodesGPU []types.
 	return nil
 }
 
+func (p *PostgresDatabase) DeleteOldGpus(ctx context.Context, nodeTwinIds []uint32) error {
+	err := p.gormDB.WithContext(ctx).Table("node_gpu").Where("node_twin_id IN (?)", nodeTwinIds).Delete(types.NodeGPU{}).Error
+	if err != nil {
+		return fmt.Errorf("failed to delete old gpus: %w", err)
+	}
+	return nil
+}
+
 func (p *PostgresDatabase) GetLastNodeTwinID(ctx context.Context) (int64, error) {
 	var node Node
 	err := p.gormDB.Table("node").Order("twin_id DESC").Limit(1).Scan(&node).Error

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -20,6 +20,7 @@ type Database interface {
 	UpsertNodesGPU(ctx context.Context, nodesGPU []types.NodeGPU) error
 	GetLastNodeTwinID(ctx context.Context) (int64, error)
 	GetNodeTwinIDsAfter(ctx context.Context, twinID int64) ([]int64, error)
+	DeleteOldGpus(ctx context.Context, nodeTwinIds []uint32) error
 	UpsertNodeHealth(ctx context.Context, healthReport types.HealthReport) error
 	GetHealthyNodeTwinIds(ctx context.Context) ([]int64, error)
 	GetConnectionString() string

--- a/grid-proxy/internal/explorer/server.go
+++ b/grid-proxy/internal/explorer/server.go
@@ -466,6 +466,12 @@ func (a *App) getNodeGpus(r *http.Request) (interface{}, mw.Response) {
 	if err != nil {
 		return nil, mw.Error(fmt.Errorf("failed to get get node GPU information from relay: %w", err))
 	}
+
+	// assign the called twin id for clearer response
+	for i := 0; i < len(res); i++ {
+		res[i].NodeTwinID = uint32(node.TwinID)
+	}
+
 	return res, mw.Ok()
 }
 

--- a/grid-proxy/tools/db/schema.sql
+++ b/grid-proxy/tools/db/schema.sql
@@ -880,8 +880,7 @@ ALTER TABLE ONLY public.node_resources_total
 --
 
 ALTER TABLE ONLY public.node_gpu
-    ADD CONSTRAINT node_gpu_pkey PRIMARY KEY (id);
-
+    ADD CONSTRAINT node_gpu_pkey PRIMARY KEY (id, node_twin_id);
 
 
 --


### PR DESCRIPTION
## Description & changes
- assign node_twin_id to the returned response of /gpu endpoint
- invalidate old indexed gpus on each new call for the same node

## Related issues
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/636
