### PR TITLE
Add key-type flag and in env file

### DIFF
--- a/farmerbot/README.md
+++ b/farmerbot/README.md
@@ -36,11 +36,12 @@ Global Flags:
 -m, --mnemonic string   the mnemonic of the account of the farmer
 -n, --network string    the grid network to use, available networks: dev, qa, test, and main (default "main")
 -s, --seed string       the hex seed of the account of the farmer
+-k, --key-type string   key type for mnemonic (default "sr25519")
 ```
 
 > Note: you should only provide **`mnemonic`** or **`seed`**
 
-> Note: If you provided **`env`** flag, you shouldn't provide **`seed`**, **`mnemonic`**, or **`network`** flags
+> Note: If you provided **`env`** flag, you shouldn't provide **`seed`**, **`key-type`**, **`mnemonic`**, or **`network`** flags
 
 ## Download
 
@@ -121,6 +122,7 @@ Global Flags:
 -m, --mnemonic string   the mnemonic of the account of the farmer
 -n, --network string    the grid network to use (default "main")
 -s, --seed string       the hex seed of the account of the farmer
+-k, --key-type string   key type for mnemonic (default "sr25519")
 ```
 
 - `start all`:  to start (power on) all nodes in a farm
@@ -140,6 +142,7 @@ Global Flags:
 -m, --mnemonic string   the mnemonic of the account of the farmer
 -n, --network string    the grid network to use (default "main")
 -s, --seed string       the hex seed of the account of the farmer
+-k, --key-type string   key type for mnemonic (default "sr25519")
 ```
 
 - `version`: to get the current version of farmerbot

--- a/farmerbot/cmd/run.go
+++ b/farmerbot/cmd/run.go
@@ -12,7 +12,7 @@ var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run farmerbot to manage your farm",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		network, mnemonicOrSeed, err := getDefaultFlags(cmd)
+		network, mnemonicOrSeed, keyType, err := getDefaultFlags(cmd)
 		if err != nil {
 			return err
 		}
@@ -32,7 +32,7 @@ var runCmd = &cobra.Command{
 			return err
 		}
 
-		farmerBot, err := internal.NewFarmerBot(cmd.Context(), config, network, mnemonicOrSeed)
+		farmerBot, err := internal.NewFarmerBot(cmd.Context(), config, network, mnemonicOrSeed, keyType)
 		if err != nil {
 			return err
 		}

--- a/farmerbot/cmd/start.go
+++ b/farmerbot/cmd/start.go
@@ -13,7 +13,7 @@ var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "start a node in your farm",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		network, mnemonicOrSeed, err := getDefaultFlags(cmd)
+		network, mnemonicOrSeed, keyType, err := getDefaultFlags(cmd)
 		if err != nil {
 			return err
 		}
@@ -23,7 +23,7 @@ var startCmd = &cobra.Command{
 			return fmt.Errorf("invalid node ID '%d'", nodeID)
 		}
 
-		identity, err := substrate.NewIdentityFromSr25519Phrase(mnemonicOrSeed)
+		identity, err := internal.GetIdentityWithKeyType(mnemonicOrSeed, keyType)
 		if err != nil {
 			return err
 		}

--- a/farmerbot/cmd/start_all.go
+++ b/farmerbot/cmd/start_all.go
@@ -13,7 +13,7 @@ var startAllCmd = &cobra.Command{
 	Use:   "all",
 	Short: "start all nodes in your farm",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		network, mnemonicOrSeed, err := getDefaultFlags(cmd)
+		network, mnemonicOrSeed, keyType, err := getDefaultFlags(cmd)
 		if err != nil {
 			return err
 		}
@@ -23,7 +23,7 @@ var startAllCmd = &cobra.Command{
 			return fmt.Errorf("invalid farm ID '%d'", farmID)
 		}
 
-		identity, err := substrate.NewIdentityFromSr25519Phrase(mnemonicOrSeed)
+		identity, err := internal.GetIdentityWithKeyType(mnemonicOrSeed, keyType)
 		if err != nil {
 			return err
 		}

--- a/farmerbot/internal/farmerbot_test.go
+++ b/farmerbot/internal/farmerbot_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	substrate "github.com/threefoldtech/tfchain/clients/tfchain-client-go"
 	"github.com/threefoldtech/tfgrid-sdk-go/farmerbot/mocks"
+	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go/peer"
 	"github.com/threefoldtech/zos/pkg/gridtypes"
 )
 
@@ -29,7 +30,7 @@ func TestFarmerbot(t *testing.T) {
 		Power:         power{WakeUpThreshold: 50},
 	}
 
-	farmerbot, err := NewFarmerBot(ctx, inputs, "dev", aliceSeed)
+	farmerbot, err := NewFarmerBot(ctx, inputs, "dev", aliceSeed, peer.KeyTypeSr25519)
 	assert.Error(t, err)
 	farmerbot.rmbNodeClient = rmb
 
@@ -52,7 +53,7 @@ func TestFarmerbot(t *testing.T) {
 	oldNode2 := farmerbot.nodes[2]
 
 	t.Run("invalid identity", func(t *testing.T) {
-		_, err := NewFarmerBot(ctx, Config{}, "dev", "invalid")
+		_, err := NewFarmerBot(ctx, Config{}, "dev", "invalid", peer.KeyTypeSr25519)
 		assert.Error(t, err)
 	})
 

--- a/farmerbot/internal/find_node_test.go
+++ b/farmerbot/internal/find_node_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	substrate "github.com/threefoldtech/tfchain/clients/tfchain-client-go"
 	"github.com/threefoldtech/tfgrid-sdk-go/farmerbot/mocks"
+	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go/peer"
 	zos "github.com/threefoldtech/zos/client"
 	"github.com/threefoldtech/zos/pkg/gridtypes"
 )
@@ -28,7 +29,7 @@ func TestFindNode(t *testing.T) {
 		Power:         power{WakeUpThreshold: 30},
 	}
 
-	farmerbot, err := NewFarmerBot(ctx, inputs, "dev", aliceSeed)
+	farmerbot, err := NewFarmerBot(ctx, inputs, "dev", aliceSeed, peer.KeyTypeSr25519)
 	assert.Error(t, err)
 
 	// mock state

--- a/farmerbot/internal/identity.go
+++ b/farmerbot/internal/identity.go
@@ -1,0 +1,21 @@
+package internal
+
+import (
+	"fmt"
+
+	substrate "github.com/threefoldtech/tfchain/clients/tfchain-client-go"
+	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go/peer"
+)
+
+// GetIdentityWithKeyType returns chain identity given a key type. key type can be "ed25519" or "sr25519"
+func GetIdentityWithKeyType(mnemonicOrSeed, keyType string) (identity substrate.Identity, err error) {
+	switch keyType {
+	case peer.KeyTypeEd25519:
+		identity, err = substrate.NewIdentityFromEd25519Phrase(mnemonicOrSeed)
+	case peer.KeyTypeSr25519:
+		identity, err = substrate.NewIdentityFromSr25519Phrase(mnemonicOrSeed)
+	default:
+		err = fmt.Errorf("invalid key type %q", keyType)
+	}
+	return
+}

--- a/farmerbot/internal/power_test.go
+++ b/farmerbot/internal/power_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	substrate "github.com/threefoldtech/tfchain/clients/tfchain-client-go"
 	"github.com/threefoldtech/tfgrid-sdk-go/farmerbot/mocks"
+	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go/peer"
 	"github.com/threefoldtech/zos/pkg/gridtypes"
 )
 
@@ -28,7 +29,7 @@ func TestPower(t *testing.T) {
 		Power:         power{WakeUpThreshold: 30},
 	}
 
-	farmerbot, err := NewFarmerBot(ctx, inputs, "dev", aliceSeed)
+	farmerbot, err := NewFarmerBot(ctx, inputs, "dev", aliceSeed, peer.KeyTypeSr25519)
 	assert.Error(t, err)
 
 	// mock state

--- a/farmerbot/parser/parser_test.go
+++ b/farmerbot/parser/parser_test.go
@@ -76,26 +76,28 @@ func TestEnvParser(t *testing.T) {
 	t.Run("test invalid env", func(t *testing.T) {
 		content := `invalid`
 
-		_, _, err := ParseEnv(content)
+		_, _, _, err := ParseEnv(content)
 		assert.Error(t, err)
 	})
 
 	t.Run("test invalid env key", func(t *testing.T) {
 		content := `invalid=invalid`
 
-		_, _, err := ParseEnv(content)
+		_, _, _, err := ParseEnv(content)
 		assert.Error(t, err)
 	})
 
 	t.Run("test valid env", func(t *testing.T) {
 		content := `
 NETWORK=dev
-MNEMONIC_OR_SEED=0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a`
+MNEMONIC_OR_SEED=0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a
+KEY_TYPE=ed25519`
 
-		net, seed, err := ParseEnv(content)
+		net, seed, keyType, err := ParseEnv(content)
 		assert.NoError(t, err)
 		assert.Equal(t, net, internal.DevNetwork)
 		assert.Equal(t, seed, "0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a")
+		assert.Equal(t, keyType, "ed25519")
 	})
 
 	t.Run("test valid env: network is missing", func(t *testing.T) {
@@ -103,10 +105,11 @@ MNEMONIC_OR_SEED=0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5
 NETWORK=
 MNEMONIC_OR_SEED=0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a`
 
-		net, seed, err := ParseEnv(content)
+		net, seed, keyType, err := ParseEnv(content)
 		assert.NoError(t, err)
 		assert.Equal(t, net, internal.MainNetwork)
 		assert.Equal(t, seed, "0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a")
+		assert.Equal(t, keyType, "sr25519")
 	})
 
 	t.Run("test invalid env: network is invalid", func(t *testing.T) {
@@ -114,7 +117,7 @@ MNEMONIC_OR_SEED=0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5
 NETWORK=qenet
 MNEMONIC_OR_SEED=0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a`
 
-		_, _, err := ParseEnv(content)
+		_, _, _, err := ParseEnv(content)
 		assert.Error(t, err)
 	})
 
@@ -123,7 +126,7 @@ MNEMONIC_OR_SEED=0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5
 NETWORK=
 MNEMONIC_OR_SEED=`
 
-		_, _, err := ParseEnv(content)
+		_, _, _, err := ParseEnv(content)
 		assert.Error(t, err)
 	})
 
@@ -132,7 +135,7 @@ MNEMONIC_OR_SEED=`
 NETWORK=
 MNEMONIC_OR_SEED=//alice`
 
-		_, _, err := ParseEnv(content)
+		_, _, _, err := ParseEnv(content)
 		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
### Description

Add the option to run farmerbot with `ed25519` encrypted key.

### Changes

- new flag `key-type` for choosing encryption type.
- new key in env file `KEY_TYPE` for choosing encryption type.

### Related Issues

- #652 

### Checklist

- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstring
