### PR TITLE
Increase port range and store used ports

### DIFF
--- a/grid-client/deployer/network_deployer_test.go
+++ b/grid-client/deployer/network_deployer_test.go
@@ -95,7 +95,7 @@ func TestNetworkDeployer(t *testing.T) {
 			Return(client.NewNodeClient(twinID, cl, d.tfPluginClient.RMBTimeout), nil).
 			AnyTimes()
 
-		dls, err := d.GenerateVersionlessDeployments(context.Background(), &znet)
+		dls, err := d.GenerateVersionlessDeployments(context.Background(), &znet, nil)
 		assert.NoError(t, err)
 
 		externalIP := ""


### PR DESCRIPTION
### Description

Increase network port range and store used ports between different networks preprocessing.

### Changes

- network wireguard port can be from 1024 to 32767
- batch deploy network won't assign the same wireguard port

### Related Issues

- #680 
- #675 

### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstring
