### PR TITLE
Add cancelation option to mass deployer

### DIFF
--- a/mass-deployer/README.md
+++ b/mass-deployer/README.md
@@ -7,6 +7,7 @@ tfrobot is tool designed to automate mass deployment of groups of VMs on ThreeFo
 ## Features
 
 -   **Mass Deployment:** Deploy groups of vms on ThreeFold Grid simultaneously.
+-   **Mass Cancelation:** cancel all vms on ThreeFold Grid defined in configuration file simultaneously.
 -   **Customizable Configurations:** Define Node groups, VMs groups and other configurations through YAML file.
 
 ## Download
@@ -50,13 +51,18 @@ You can use this [example](./example/conf.yaml) for further guidance,
 
 5.  Run the deployer with path to the config file
 ```bash
-tfrobot -c path/to/your/config.yaml
+tfrobot deploy -c path/to/your/config.yaml
+```
+
+6.  Run the canceler with path to the config file
+```bash
+tfrobot cancel -c path/to/your/config.yaml
 ```
 
 ## Using Docker
 ```bash
 docker build -t tfrobot -f Dockerfile ../
-docker run -v $(pwd)/config.yaml:/config.yaml -it tfrobot:latest -c /config.yaml
+docker run -v $(pwd)/config.yaml:/config.yaml -it tfrobot:latest deploy -c /config.yaml
 ```
 
 ## Build

--- a/mass-deployer/cmd/cancel.go
+++ b/mass-deployer/cmd/cancel.go
@@ -1,0 +1,43 @@
+// Package cmd for parsing command line arguments
+package cmd
+
+import (
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/threefoldtech/tfgrid-sdk-go/mass-deployer/internal/parser"
+	deployer "github.com/threefoldtech/tfgrid-sdk-go/mass-deployer/pkg/mass-deployer"
+)
+
+var cancelCmd = &cobra.Command{
+	Use:   "cancel",
+	Short: "cancel all deployments of configuration file",
+	Run: func(cmd *cobra.Command, args []string) {
+		configPath, err := cmd.Flags().GetString("config")
+		if err != nil || configPath == "" {
+			log.Fatal().Err(err).Msg("error in config file")
+		}
+
+		configFile, err := os.Open(configPath)
+		if err != nil {
+			log.Fatal().Err(err).Msgf("failed to open config file: %s", configPath)
+		}
+		defer configFile.Close()
+
+		cfg, err := parser.ParseConfig(configFile)
+		if err != nil {
+			log.Fatal().Err(err).Msgf("failed to parse config file: %s", configPath)
+		}
+
+		err = deployer.RunCanceler(cfg)
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to run the canceler")
+		}
+	},
+}
+
+func init() {
+	cancelCmd.Flags().StringP("config", "c", "", "path to config file")
+	rootCmd.AddCommand(cancelCmd)
+}

--- a/mass-deployer/cmd/deploy.go
+++ b/mass-deployer/cmd/deploy.go
@@ -1,0 +1,45 @@
+// Package cmd for parsing command line arguments
+package cmd
+
+import (
+	"context"
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+	"github.com/threefoldtech/tfgrid-sdk-go/mass-deployer/internal/parser"
+	deployer "github.com/threefoldtech/tfgrid-sdk-go/mass-deployer/pkg/mass-deployer"
+)
+
+var deployCmd = &cobra.Command{
+	Use:   "deploy",
+	Short: "deploy groups of vms in configuration file",
+	Run: func(cmd *cobra.Command, args []string) {
+		configPath, err := cmd.Flags().GetString("config")
+		if err != nil || configPath == "" {
+			log.Fatal().Err(err).Msg("error in config file")
+		}
+
+		configFile, err := os.Open(configPath)
+		if err != nil {
+			log.Fatal().Err(err).Msgf("failed to open config file: %s", configPath)
+		}
+		defer configFile.Close()
+
+		cfg, err := parser.ParseConfig(configFile)
+		if err != nil {
+			log.Fatal().Err(err).Msgf("failed to parse config file: %s", configPath)
+		}
+
+		ctx := context.Background()
+		err = deployer.RunDeployer(cfg, ctx)
+		if err != nil {
+			log.Fatal().Err(err).Msg("failed to run the deployer")
+		}
+	},
+}
+
+func init() {
+	deployCmd.Flags().StringP("config", "c", "", "path to config file")
+	rootCmd.AddCommand(deployCmd)
+}

--- a/mass-deployer/cmd/root.go
+++ b/mass-deployer/cmd/root.go
@@ -1,44 +1,17 @@
 package cmd
 
 import (
-	"context"
 	"os"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
 	"github.com/spf13/cobra"
-	"github.com/threefoldtech/tfgrid-sdk-go/mass-deployer/internal/parser"
-	deployer "github.com/threefoldtech/tfgrid-sdk-go/mass-deployer/pkg/mass-deployer"
 )
 
 var rootCmd = &cobra.Command{
 	Use:   "tfrobot",
 	Short: "A tool for deploying groups of vms on Threefold Grid",
-
-	Run: func(cmd *cobra.Command, args []string) {
-		configPath, err := cmd.Flags().GetString("config")
-		if err != nil || configPath == "" {
-			log.Fatal().Err(err).Msg("error in config file")
-		}
-
-		configFile, err := os.Open(configPath)
-		if err != nil {
-			log.Fatal().Err(err).Msgf("failed to open config file: %s", configPath)
-		}
-		defer configFile.Close()
-
-		cfg, err := parser.ParseConfig(configFile)
-		if err != nil {
-			log.Fatal().Err(err).Msgf("failed to parse config file: %s", configPath)
-		}
-
-		ctx := context.Background()
-		err = deployer.RunDeployer(cfg, ctx)
-		if err != nil {
-			log.Fatal().Err(err).Msg("failed to run the deployer")
-		}
-	},
 }
 
 func Execute() {
@@ -50,5 +23,4 @@ func Execute() {
 
 func init() {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
-	rootCmd.Flags().StringP("config", "c", "", "path to config file")
 }

--- a/mass-deployer/example/conf.yaml
+++ b/mass-deployer/example/conf.yaml
@@ -6,8 +6,8 @@ node_groups:
     free_ssd: 100 # amount of ssd storage in GB
     free_hdd: 50 # amount of hdd storage in GB
     dedicated: false # are nodes dedicated
-    pubip4: false # should the nodes have free ip v4
-    pubip6: false # should the nodes have free ip v6
+    public_ip4: false # should the nodes have free ip v4
+    public_ip6: false # should the nodes have free ip v6
     certified: false # should the nodes be certified(if false the nodes could be certified of diyed) 
     region: "europe" # region could be the name of the continents the nodes are located in (africa, americas, antarctic, antarctic ocean, asia, europe, oceania, polar)
 vms:

--- a/mass-deployer/internal/parser/parser_test.go
+++ b/mass-deployer/internal/parser/parser_test.go
@@ -25,7 +25,7 @@ func TestParseConfig(t *testing.T) {
 				FreeMRU:    256,
 				FreeSRU:    50,
 				FreeHRU:    50,
-				Pubip4:     true,
+				PublicIP4:     true,
 				Regions:    "Europe",
 			},
 		},

--- a/mass-deployer/internal/parser/parser_test.go
+++ b/mass-deployer/internal/parser/parser_test.go
@@ -25,7 +25,7 @@ func TestParseConfig(t *testing.T) {
 				FreeMRU:    256,
 				FreeSRU:    50,
 				FreeHRU:    50,
-				PublicIP4:     true,
+				PublicIP4:  true,
 				Regions:    "Europe",
 			},
 		},

--- a/mass-deployer/pkg/mass-deployer/cancel.go
+++ b/mass-deployer/pkg/mass-deployer/cancel.go
@@ -1,0 +1,16 @@
+package deployer
+
+func RunCanceler(cfg Config) error {
+	tfPluginClient, err := setup(cfg)
+	if err != nil {
+		return err
+	}
+
+	for _, group := range cfg.NodeGroups {
+		err = tfPluginClient.CancelByProjectName(group.Name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/mass-deployer/pkg/mass-deployer/deployer.go
+++ b/mass-deployer/pkg/mass-deployer/deployer.go
@@ -97,7 +97,7 @@ func parseGroupVMs(vms []Vms, nodeGroup string, nodesIDs []int, sshKeys map[stri
 		}
 	}
 
-	return buildDeployments(vmsOfNodeGroup, nodesIDs, sshKeys)
+	return buildDeployments(vmsOfNodeGroup, nodeGroup, nodesIDs, sshKeys)
 }
 
 func massDeploy(tfPluginClient deployer.TFPluginClient, ctx context.Context, deployments groupDeploymentsInfo) ([]string, error) {
@@ -117,7 +117,7 @@ func massDeploy(tfPluginClient deployer.TFPluginClient, ctx context.Context, dep
 	return vmsInfo, nil
 }
 
-func buildDeployments(vms []Vms, nodesIDs []int, sshKeys map[string]string) groupDeploymentsInfo {
+func buildDeployments(vms []Vms, nodeGroup string, nodesIDs []int, sshKeys map[string]string) groupDeploymentsInfo {
 	var vmDeployments []*workloads.Deployment
 	var networkDeployments []*workloads.ZNet
 	var deploymentsInfo []vmDeploymentInfo
@@ -141,7 +141,8 @@ func buildDeployments(vms []Vms, nodesIDs []int, sshKeys map[string]string) grou
 					IP:   net.IPv4(10, 20, 0, 0),
 					Mask: net.CIDRMask(16, 32),
 				}),
-				AddWGAccess: false,
+				AddWGAccess:  false,
+				SolutionType: nodeGroup,
 			}
 			w := workloads.VM{
 				Name:        fmt.Sprintf("%s%d", vmGroup.Name, i),
@@ -157,7 +158,7 @@ func buildDeployments(vms []Vms, nodesIDs []int, sshKeys map[string]string) grou
 				EnvVars:     map[string]string{"SSH_KEY": sshKeys[vmGroup.SSHKey]},
 				Mounts:      mounts,
 			}
-			deployment := workloads.NewDeployment(w.Name, nodeID, "", nil, network.Name, disks, nil, []workloads.VM{w}, nil)
+			deployment := workloads.NewDeployment(w.Name, nodeID, nodeGroup, nil, network.Name, disks, nil, []workloads.VM{w}, nil)
 
 			vmDeployments = append(vmDeployments, &deployment)
 			networkDeployments = append(networkDeployments, &network)

--- a/mass-deployer/pkg/mass-deployer/node_filter.go
+++ b/mass-deployer/pkg/mass-deployer/node_filter.go
@@ -32,11 +32,11 @@ func filterNodes(tfPluginClient deployer.TFPluginClient, group NodesGroup, ctx c
 		certified := "Certified"
 		filter.CertificationType = &certified
 	}
-	if group.Pubip4 {
-		filter.IPv4 = &group.Pubip4
+	if group.PublicIP4 {
+		filter.IPv4 = &group.PublicIP4
 	}
-	if group.Pubip6 {
-		filter.IPv6 = &group.Pubip6
+	if group.PublicIP6 {
+		filter.IPv6 = &group.PublicIP6
 	}
 	if group.Dedicated {
 		filter.Dedicated = &group.Dedicated

--- a/mass-deployer/pkg/mass-deployer/types.go
+++ b/mass-deployer/pkg/mass-deployer/types.go
@@ -20,8 +20,8 @@ type NodesGroup struct {
 	FreeSRU    uint64 `yaml:"free_ssd"`
 	FreeHRU    uint64 `yaml:"free_hdd"`
 	Dedicated  bool   `yaml:"dedicated"`
-	Pubip4     bool   `yaml:"pubip4"`
-	Pubip6     bool   `yaml:"pubip6"`
+	PublicIP4  bool   `yaml:"public_ip4"`
+	PublicIP6  bool   `yaml:"public_ip6"`
 	Certified  bool   `yaml:"certified"`
 	Regions    string `yaml:"regions"`
 }


### PR DESCRIPTION
### Description

added cancelation for vm groups created by the mass deployer 

### Changes

- change pubip4,6 to public_ip4,6 in node groups
- add cancel subcommand to allow cancelation of all vms defined in a config file
- use deploy subcommand for deployments
 
### Related Issues
- #686 
- #685 
- #683 

### Checklist

- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstring
