### PR TITLE
fix empty env vars panic

### DIFF
--- a/mass-deployer/pkg/mass-deployer/deployer.go
+++ b/mass-deployer/pkg/mass-deployer/deployer.go
@@ -141,6 +141,9 @@ func buildDeployments(vms []Vms, nodeGroup string, nodesIDs []int, sshKeys map[s
 	for _, vmGroup := range vms {
 
 		envVars := vmGroup.EnvVars
+		if envVars == nil {
+			envVars = map[string]string{}
+		}
 		envVars["SSH_KEY"] = sshKeys[vmGroup.SSHKey]
 
 		for i := 0; i < int(vmGroup.Count); i++ {


### PR DESCRIPTION
### Changes

- init env vars map to empty list if no env vars were provided.

### Related Issues

- #712 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstring
