### PR TITLE
add NO_NINJA_PROXY_URL to disable using ninja's backend gridproxy by default

### DIFF
--- a/mass-deployer/pkg/mass-deployer/setup.go
+++ b/mass-deployer/pkg/mass-deployer/setup.go
@@ -1,6 +1,9 @@
 package deployer
 
 import (
+	"os"
+	"strings"
+
 	"github.com/rs/zerolog/log"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/deployer"
 	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go/peer"
@@ -13,7 +16,14 @@ func setup(conf Config, debug bool) (deployer.TFPluginClient, error) {
 	mnemonic := conf.Mnemonic
 	log.Debug().Str("mnemonic", mnemonic).Send()
 
-	return deployer.NewTFPluginClient(mnemonic, peer.KeyTypeSr25519, network, "", "", "", 30, debug)
+	var proxyURL string
+	noNinjaProxyURL := strings.TrimSpace(strings.ToLower(os.Getenv("NO_NINJA_PROXY_URL")))
+
+	if network == "main" && noNinjaProxyURL == "" {
+		proxyURL = "https://gridproxy.bknd1.ninja.tf"
+
+	}
+	return deployer.NewTFPluginClient(mnemonic, peer.KeyTypeSr25519, network, "", "", proxyURL, 30, debug)
 }
 
 func convertGBToBytes(gb uint64) uint64 {


### PR DESCRIPTION
add `NO_NINJA_PROXY_URL` to disable using ninja's backend gridproxy by default in case of mainnet

### Description

add `NO_NINJA_PROXY_URL` to disable using ninja's backend gridproxy by default in case of mainnet

### Changes

add `NO_NINJA_PROXY_URL` to disable using ninja's backend gridproxy by default in case of mainnet

### Related Issues

- #748 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
