### PR TITLE
refactor filtering nodes

### DIFF
--- a/grid-client/deployer/node_filter.go
+++ b/grid-client/deployer/node_filter.go
@@ -63,7 +63,7 @@ func FilterNodes(ctx context.Context, tfPlugin TFPluginClient, options types.Nod
 			}
 
 			wg.Add(1)
-			go func() {
+			go func(limit types.Limit) {
 				defer wg.Done()
 				err := getNodes(ctx, tfPlugin, options, ssdDisks, hddDisks, rootfs, limit, nodesOutput)
 				if err != nil {
@@ -71,7 +71,7 @@ func FilterNodes(ctx context.Context, tfPlugin TFPluginClient, options types.Nod
 					errs = append(errs, err)
 					lock.Unlock()
 				}
-			}()
+			}(limit)
 		}
 
 		go func() {

--- a/grid-client/deployer/node_filter.go
+++ b/grid-client/deployer/node_filter.go
@@ -94,7 +94,7 @@ func FilterNodes(ctx context.Context, tfPlugin TFPluginClient, options types.Nod
 	}
 
 	if errs != nil {
-		return []types.Node{}, errors.Errorf("could not find enough nodes, found errors: %w", errs)
+		return []types.Node{}, errors.Errorf("could not find enough nodes, found errors: %v", errs)
 	}
 
 	opts, err := serializeOptions(options)

--- a/grid-client/deployer/node_filter.go
+++ b/grid-client/deployer/node_filter.go
@@ -86,7 +86,6 @@ func FilterNodes(ctx context.Context, tfPlugin TFPluginClient, options types.Nod
 		}
 
 		if len(optionalLimit) == 0 { // no limit and didn't reach default limit
-			log.Debug().Uint64("reached nodes page", limit.Page).Send()
 			return nodes, nil
 		}
 	}

--- a/grid-client/deployer/node_filter.go
+++ b/grid-client/deployer/node_filter.go
@@ -44,7 +44,7 @@ func FilterNodes(ctx context.Context, tfPlugin TFPluginClient, options types.Nod
 	if len(optionalLimit) > 0 {
 		var err error
 		nodesCount = optionalLimit[0]
-		limit := types.Limit{Size: nodesCount, RetCount: true}
+		limit = types.Limit{Size: nodesCount, RetCount: true}
 		requestedPages = requestedPagesPerIteration
 		totalPagesCount, err = getPagesCount(ctx, tfPlugin, options, limit)
 		if err != nil {
@@ -82,7 +82,7 @@ func FilterNodes(ctx context.Context, tfPlugin TFPluginClient, options types.Nod
 		for node := range nodesOutput {
 			nodes = append(nodes, node)
 			if uint64(len(nodes)) == nodesCount {
-				log.Debug().Uint64("reached nodes page", limit.Page).Send()
+				log.Debug().Uint64("reached nodes page", limit.Page).Int("total pages", totalPagesCount).Send()
 				return nodes, nil
 			}
 		}

--- a/grid-client/deployer/node_filter.go
+++ b/grid-client/deployer/node_filter.go
@@ -94,7 +94,7 @@ func FilterNodes(ctx context.Context, tfPlugin TFPluginClient, options types.Nod
 	}
 
 	if errs != nil {
-		return []types.Node{}, errors.Errorf("could not find enough nodes, found errors: %v", errs)
+		return []types.Node{}, errors.Errorf("could not find enough nodes, found errors: %w", errs)
 	}
 
 	opts, err := serializeOptions(options)

--- a/grid-client/deployer/tf_plugin_client.go
+++ b/grid-client/deployer/tf_plugin_client.go
@@ -26,11 +26,11 @@ import (
 
 var (
 	// SubstrateURLs are substrate urls
-	SubstrateURLs = map[string]string{
-		"dev":  "wss://tfchain.dev.grid.tf/ws",
-		"test": "wss://tfchain.test.grid.tf/ws",
-		"qa":   "wss://tfchain.qa.grid.tf/ws",
-		"main": "wss://tfchain.grid.tf/ws",
+	SubstrateURLs = map[string][]string{
+		"dev":  {"wss://tfchain.dev.grid.tf/ws", "wss://tfchain.dev.grid.tf:443"},
+		"test": {"wss://tfchain.test.grid.tf/ws", "wss://tfchain.test.grid.tf:443"},
+		"qa":   {"wss://tfchain.qa.grid.tf/ws", "wss://tfchain.qa.grid.tf:443"},
+		"main": {"wss://tfchain.grid.tf/ws", "wss://tfchain.grid.tf:443"},
 	}
 	// ProxyURLs are rmb proxy urls
 	ProxyURLs = map[string]string{
@@ -60,7 +60,7 @@ type TFPluginClient struct {
 	TwinID         uint32
 	mnemonicOrSeed string
 	Identity       substrate.Identity
-	substrateURL   string
+	substrateURL   []string
 	relayURL       string
 	RMBTimeout     time.Duration
 	proxyURL       string
@@ -155,10 +155,10 @@ func NewTFPluginClient(
 		if err := validateWssURL(substrateURL); err != nil {
 			return TFPluginClient{}, errors.Wrapf(err, "could not validate substrate url %s", substrateURL)
 		}
-		tfPluginClient.substrateURL = substrateURL
+		tfPluginClient.substrateURL = []string{substrateURL}
 	}
 
-	manager := subi.NewManager(tfPluginClient.substrateURL)
+	manager := subi.NewManager(tfPluginClient.substrateURL...)
 	sub, err := manager.SubstrateExt()
 	if err != nil {
 		return TFPluginClient{}, errors.Wrap(err, "could not get substrate client")

--- a/mass-deployer/pkg/mass-deployer/node_filter.go
+++ b/mass-deployer/pkg/mass-deployer/node_filter.go
@@ -50,7 +50,7 @@ func filterNodes(ctx context.Context, tfPluginClient deployer.TFPluginClient, gr
 		freeHDD = nil
 	}
 
-	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, filter, freeSSD, freeHDD, nil, int(group.NodesCount))
+	nodes, err := deployer.FilterNodes(ctx, tfPluginClient, filter, freeSSD, freeHDD, nil, group.NodesCount)
 	if err != nil {
 		return []int{}, err
 	}


### PR DESCRIPTION
# Issues

- https://github.com/threefoldtech/tfgrid-sdk-go/issues/753

# Tests

## without limit 

- case (20s for rmb timeout)

```
filtration took 5m10.051275479s 
nodes: 37

// without ssds
filtration took 10.639825816s 
nodes: 50
```

- case (30s for rmb timeout)

```
filtration took 7m22.085765311s 
nodes: 37
```

## with limit 

- case limit = 50

```
3:12PM DBG reached nodes page=5
filtration took 36.055382019s 
nodes: 50
```


- case limit = 100

```
// RMB timeout 20s
3:15PM DBG reached nodes page=5
filtration took 1m53.336723313s 
nodes: 100

// RMB timeout 30s
filtration took 2m50.425373837s 
nodes: 100

// without ssds
4:18PM DBG reached nodes page=5 total pages=19
filtration took 8.006928281s 
100
```

- case limit = 500 (timeout rmb =30s)

```
filtration took 14m42.019284436s 
could not find enough nodes with options: status: up, free_sru: 1073741824, available_for: 5778, healthy: true // I believe it went through all nodes

// without ssds
filtration took 8.465451946s 
nodes: 500
```
