### PR TITLE
use output.yaml as default output file

### DIFF
--- a/mass-deployer/cmd/root.go
+++ b/mass-deployer/cmd/root.go
@@ -32,7 +32,7 @@ func Execute() {
 func init() {
 	deployCmd.Flags().BoolP("debug", "d", false, "allow debug logs")
 	deployCmd.Flags().StringP("config", "c", "", "path to config file")
-	deployCmd.Flags().StringP("output", "o", "", "path to output file")
+	deployCmd.Flags().StringP("output", "o", "output.yaml", "path to output file")
 
 	cancelCmd.Flags().BoolP("debug", "d", false, "allow debug logs")
 	cancelCmd.Flags().StringP("config", "c", "", "path to config file")

--- a/mass-deployer/pkg/mass-deployer/deployer.go
+++ b/mass-deployer/pkg/mass-deployer/deployer.go
@@ -82,10 +82,6 @@ func RunDeployer(ctx context.Context, cfg Config, output string, debug bool) err
 
 	fmt.Println(string(outputBytes))
 
-	if output == "" {
-		output = "output.yaml"
-	}
-
 	return os.WriteFile(output, outputBytes, 0644)
 }
 

--- a/mass-deployer/pkg/mass-deployer/deployer.go
+++ b/mass-deployer/pkg/mass-deployer/deployer.go
@@ -83,7 +83,7 @@ func RunDeployer(ctx context.Context, cfg Config, output string, debug bool) err
 	fmt.Println(string(outputBytes))
 
 	if output == "" {
-		return nil
+		output = "output.yaml"
 	}
 
 	return os.WriteFile(output, outputBytes, 0644)


### PR DESCRIPTION

### Related Issues

- #747 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
