### PR TITLE
add new node filter `excluded` to exclude node id

### DIFF
--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -596,6 +596,9 @@ func (d *PostgresDatabase) GetNodes(ctx context.Context, filter types.NodeFilter
 	if filter.CertificationType != nil {
 		q = q.Where("node.certification ILIKE ?", *filter.CertificationType)
 	}
+	if filter.Excluded != nil {
+		q = q.Where("node.node_id NOT IN ?", filter.Excluded)
+	}
 
 	// Dedicated nodes filters
 	if filter.InDedicatedFarm != nil {

--- a/grid-proxy/pkg/types/nodes.go
+++ b/grid-proxy/pkg/types/nodes.go
@@ -139,6 +139,7 @@ type NodeFilter struct {
 	GpuVendorName     *string  `schema:"gpu_vendor_name,omitempty"`
 	GpuAvailable      *bool    `schema:"gpu_available,omitempty"`
 	Healthy           *bool    `schema:"healthy,omitempty"`
+	Excluded          []uint64 `schema:"excluded,omitempty"`
 }
 
 // NodeGPU holds the info about gpu card

--- a/grid-proxy/tests/queries/mock_client/nodes.go
+++ b/grid-proxy/tests/queries/mock_client/nodes.go
@@ -295,6 +295,10 @@ func (n *Node) satisfies(f types.NodeFilter, data *DBData) bool {
 		return false
 	}
 
+	if f.Excluded != nil && len(f.Excluded) != 0 && slices.Contains(f.Excluded, n.NodeID) {
+		return false
+	}
+
 	rentable := data.NodeRentedBy[n.NodeID] == 0 &&
 		(data.Farms[n.FarmID].DedicatedFarm || len(data.NonDeletedContracts[n.NodeID]) == 0)
 	if f.Rentable != nil && *f.Rentable != rentable {

--- a/grid-proxy/tests/queries/node_test.go
+++ b/grid-proxy/tests/queries/node_test.go
@@ -24,6 +24,7 @@ type NodesAggregate struct {
 	cities    []string
 	farmNames []string
 	farmIDs   []uint64
+	nodeIDs   []uint64
 	freeMRUs  []uint64
 	freeSRUs  []uint64
 	freeHRUs  []uint64
@@ -311,6 +312,17 @@ var nodeFilterRandomValueGenerator = map[string]func(agg NodesAggregate) interfa
 			v = false
 		}
 		return &v
+	},
+	"Excluded": func(agg NodesAggregate) interface{} {
+		shuffledIds := make([]uint64, len(agg.nodeIDs))
+		copy(shuffledIds, agg.nodeIDs)
+		for i := len(shuffledIds) - 1; i > 0; i-- {
+			j := rand.Intn(i + 1)
+			shuffledIds[i], shuffledIds[j] = shuffledIds[j], shuffledIds[i]
+		}
+
+		num := rand.Intn(10)
+		return shuffledIds[:num]
 	},
 }
 
@@ -618,6 +630,7 @@ func calcNodesAggregates(data *mock.DBData) (res NodesAggregate) {
 		res.freeMRUs = append(res.freeMRUs, freeMRU)
 		res.freeSRUs = append(res.freeSRUs, freeSRU)
 		res.freeHRUs = append(res.freeHRUs, freeHRU)
+		res.nodeIDs = append(res.nodeIDs, node.NodeID)
 
 		res.maxTotalMRU = max(res.maxTotalMRU, total.MRU)
 		res.totalMRUs = append(res.totalMRUs, total.MRU)


### PR DESCRIPTION

### Description
- `excluded` takes an array of node ids
- the filter will exclude the nodes while filtering first and then returns the pagination/limitation
- tests will shuffle the aggregated nodeIds and take a subslice as value for the `excluded` query

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/774

### Checklist

- [x] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstring
