### PR TITLE
Add a bounded semaphore channel to limit the number of workers at any point to maxGoroutinesToFetchState to be able to cope with high number of requests

### DIFF
--- a/mass-deployer/pkg/mass-deployer/deployer.go
+++ b/mass-deployer/pkg/mass-deployer/deployer.go
@@ -21,7 +21,7 @@ import (
 )
 
 const maxDeploymentRetries = 5
-const maxGoroutinesToFetchState = 20
+const maxGoroutinesToFetchState = 100
 
 func RunDeployer(ctx context.Context, cfg Config, output string, debug bool) error {
 	passedGroups := map[string][]vmOutput{}


### PR DESCRIPTION
### Description

Add a bounded semaphore channel to limit the number of workers at any point to maxGoroutinesToFetchState to be able to cope with high number of requests

### Changes

Add a bounded semaphore channel to limit the number of workers at any point to maxGoroutinesToFetchState to be able to cope with high number of requests


### Related Issues

- #784 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
