### PR TITLE
Fix Dockerfile to copy from root of repo

### DIFF
--- a/tools/relay-cache-warmer/Dockerfile
+++ b/tools/relay-cache-warmer/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.21-alpine as builder
 
 WORKDIR /app
 
-COPY . .
+COPY tools/relay-cache-warmer .
 
 RUN go build -o bin/cache-warmer .
 


### PR DESCRIPTION
### Description

Fix Dockerfile to copy from root of repo as the workflow uses the root of the repo as the context