### PR TITLE
don't allow subcommands to be used with each other in the farmerbot cli

### DIFF
--- a/farmerbot/cmd/run.go
+++ b/farmerbot/cmd/run.go
@@ -12,6 +12,10 @@ var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run farmerbot to manage your farm",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(cmd.Flags().Args()) != 0 {
+			return fmt.Errorf("'run' and %v cannot be used together, please use one command at a time", cmd.Flags().Args())
+		}
+
 		network, mnemonicOrSeed, keyType, err := getDefaultFlags(cmd)
 		if err != nil {
 			return err

--- a/farmerbot/cmd/start.go
+++ b/farmerbot/cmd/start.go
@@ -13,6 +13,10 @@ var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "start a node in your farm",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(cmd.Flags().Args()) != 0 {
+			return fmt.Errorf("'start' and %v cannot be used together, please use one command at a time", cmd.Flags().Args())
+		}
+
 		network, mnemonicOrSeed, keyType, err := getDefaultFlags(cmd)
 		if err != nil {
 			return err

--- a/farmerbot/cmd/start_all.go
+++ b/farmerbot/cmd/start_all.go
@@ -13,6 +13,10 @@ var startAllCmd = &cobra.Command{
 	Use:   "all",
 	Short: "start all nodes in your farm",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(cmd.Flags().Args()) != 0 {
+			return fmt.Errorf("'all' and %v cannot be used together, please use one command at a time", cmd.Flags().Args())
+		}
+
 		network, mnemonicOrSeed, keyType, err := getDefaultFlags(cmd)
 		if err != nil {
 			return err

--- a/farmerbot/cmd/version.go
+++ b/farmerbot/cmd/version.go
@@ -15,7 +15,12 @@ import (
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "get farmerbot latest version and commit",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(cmd.Flags().Args()) != 0 {
+			return fmt.Errorf("'run' and %v cannot be used together, please use one command at a time", cmd.Flags().Args())
+		}
+
 		fmt.Println(version.Version)
+		return nil
 	},
 }


### PR DESCRIPTION
### Description

don't allow subcommands to be used with each other in the farmerbot cli

### Changes

Converts all of subcommands to use RunE, and do a check on the length of the arguments before the execution and show an error message that has the command name and the other command that got passed and inform the user that they can't be used together 
### Related Issues

#823

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
