### PR TITLE
resotre tfrobot examples

### DIFF
--- a/tfrobot/example/conf.json
+++ b/tfrobot/example/conf.json
@@ -1,0 +1,48 @@
+{
+  "node_groups": [
+    {
+      "name": "group_a",
+      "nodes_count": 3,
+      "free_cpu": 2,
+      "free_mru": 16,
+      "free_ssd": 100,
+      "free_hdd": 50,
+      "dedicated": false,
+      "public_ip4": false,
+      "public_ip6": false,
+      "certified": false,
+      "region": "europe"
+    }
+  ],
+  "vms": [
+    {
+      "name": "examplevm123",
+      "vms_count": 1,
+      "node_group": "group_a",
+      "cpu": 1,
+      "mem": 2,
+      "ssd": [
+        {
+          "size": 15,
+          "mount_point": "/mnt/ssd"
+        }
+      ],
+      "public_ip4": false,
+      "public_ip6": false,
+      "flist": "https://hub.grid.tf/tf-official-apps/base:latest.flist",
+      "entry_point": "/sbin/zinit init",
+      "root_size": 0,
+      "ssh_key": "example1",
+      "env_vars": {
+        "user": "user1",
+        "pwd": "1234"
+      }
+    }
+  ],
+  "ssh_keys": {
+    "example1": "ssh_key1"
+  },
+  "mnemonic": "example-mnemonic",
+  "network": "dev",
+  "max_retries": 5
+}

--- a/tfrobot/example/conf.yaml
+++ b/tfrobot/example/conf.yaml
@@ -1,0 +1,36 @@
+node_groups:
+  - name: group_a
+    nodes_count: 3 # amount of nodes to be found
+    free_cpu: 2 # number of logical cores
+    free_mru: 16 # amount of memory in GB
+    free_ssd: 100 # amount of ssd storage in GB
+    free_hdd: 50 # amount of hdd storage in GB
+    dedicated: false # are nodes dedicated
+    public_ip4: false # should the nodes have free ip v4
+    public_ip6: false # should the nodes have free ip v6
+    certified: false # should the nodes be certified(if false the nodes could be certified or DIY) 
+    region: "europe" # region could be the name of the continents the nodes are located in (africa, americas, antarctic, antarctic ocean, asia, europe, oceania, polar)
+vms:
+  - name: examplevm
+    vms_count: 5 # amount of vms with the same configurations
+    node_group: group_a # the name of the predefined group of nodes
+    cpu: 1 # number of logical cores, min 1, max 32
+    mem: 2 # amount of memory in GB, min 0.25 GB, max 256 GB
+    ssd: # list of ssd storage needed to be mounted to the vm
+      - size: 15 # size in GB, min 15 GB
+        mount_point: /mnt/ssd
+    public_ip4: false
+    public_ip6: false
+    flist: https://hub.grid.tf/tf-official-apps/base:latest.flist
+    entry_point: /sbin/zinit init
+    root_size: 0 # root size in GB, 0 for default root size, max 10TB
+    ssh_key: example1 # the name of the predefined ssh key
+    env_vars: # env vars are passed to the newly created vms
+      user: user1
+      pwd: 1234
+
+ssh_keys: # map of ssh keys with key=name and value=the actual ssh key
+  example1: ssh_key1
+mnemonic: example-mnemonic # mnemonic of the user
+network: dev # eg: main, test, qa, dev
+max_retries: 5 # max retries for each node group (default 5)


### PR DESCRIPTION
### Description

- tfrobot examples were deleted by mistake while renaming mass deployer to tfrobot

### Changes

- restored the deleted files

### Related Issues

List of related issues

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
