### PR TITLE
Update network metadata

### DIFF
--- a/grid-client/deployer/network_deployer.go
+++ b/grid-client/deployer/network_deployer.go
@@ -168,9 +168,14 @@ func (d *NetworkDeployer) GenerateVersionlessDeployments(ctx context.Context, zn
 		externalIP = znet.ExternalIP.String()
 	}
 	metadata := workloads.NetworkMetaData{
-		UserAccessIP: externalIP,
-		PrivateKey:   znet.ExternalSK.String(),
-		PublicNodeID: znet.PublicNodeID,
+		Version: workloads.Version,
+		UserAccess: []workloads.UserAccess{
+			{
+				Subnet:     externalIP,
+				PrivateKey: znet.ExternalSK.String(),
+				NodeID:     znet.PublicNodeID,
+			},
+		},
 	}
 
 	metadataBytes, err := json.Marshal(metadata)

--- a/grid-client/deployer/network_deployer_test.go
+++ b/grid-client/deployer/network_deployer_test.go
@@ -105,9 +105,14 @@ func TestNetworkDeployer(t *testing.T) {
 		}
 
 		metadata, err := json.Marshal(workloads.NetworkMetaData{
-			UserAccessIP: externalIP,
-			PrivateKey:   znet.ExternalSK.String(),
-			PublicNodeID: znet.PublicNodeID,
+			Version: workloads.Version,
+			UserAccess: []workloads.UserAccess{
+				{
+					Subnet:     externalIP,
+					PrivateKey: znet.ExternalSK.String(),
+					NodeID:     znet.PublicNodeID,
+				},
+			},
 		})
 		assert.NoError(t, err)
 

--- a/grid-client/state/state_test.go
+++ b/grid-client/state/state_test.go
@@ -298,9 +298,14 @@ func TestLoadK8sFromGrid(t *testing.T) {
 	}
 
 	metadata, err := json.Marshal(workloads.NetworkMetaData{
-		UserAccessIP: "",
-		PrivateKey:   "",
-		PublicNodeID: 0,
+		Version: workloads.Version,
+		UserAccess: []workloads.UserAccess{
+			{
+				Subnet:     "",
+				PrivateKey: "",
+				NodeID:     0,
+			},
+		},
 	})
 	assert.NoError(t, err)
 
@@ -369,9 +374,14 @@ func TestLoadNetworkFromGrid(t *testing.T) {
 	}
 
 	metadata, err := json.Marshal(workloads.NetworkMetaData{
-		UserAccessIP: "",
-		PrivateKey:   "",
-		PublicNodeID: 0,
+		Version: workloads.Version,
+		UserAccess: []workloads.UserAccess{
+			{
+				Subnet:     "",
+				PrivateKey: "",
+				NodeID:     0,
+			},
+		},
 	})
 	assert.NoError(t, err)
 

--- a/grid-client/workloads/network.go
+++ b/grid-client/workloads/network.go
@@ -21,18 +21,41 @@ var ExternalSKZeroValue = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 
 // UserAccess struct
 type UserAccess struct {
-	UserAddress        string
-	UserSecretKey      string
-	PublicNodePK       string
-	AllowedIPs         []string
-	PublicNodeEndpoint string
+	Subnet     string `json:"subnet"`
+	PrivateKey string `json:"private_key"`
+	NodeID     uint32 `json:"node_id"`
 }
 
 // NetworkMetaData is added to network workloads to help rebuilding networks when retrieved from the grid
 type NetworkMetaData struct {
-	UserAccessIP string `json:"ip"`
-	PrivateKey   string `json:"priv_key"`
-	PublicNodeID uint32 `json:"node_id"`
+	Version    int          `json:"version"`
+	UserAccess []UserAccess `json:"user_access"`
+}
+
+func (m *NetworkMetaData) UnmarshalJSON(data []byte) error {
+	var deprecated struct {
+		Version    int          `json:"version"`
+		UserAccess []UserAccess `json:"user_access"`
+		// deprecated fields
+
+		UserAccessIP string `json:"ip"`
+		PrivateKey   string `json:"priv_key"`
+		PublicNodeID uint32 `json:"node_id"`
+	}
+	if err := json.Unmarshal(data, &deprecated); err != nil {
+		return err
+	}
+	m.Version = deprecated.Version
+	m.UserAccess = deprecated.UserAccess
+	if deprecated.UserAccessIP != "" || deprecated.PrivateKey != "" || deprecated.PublicNodeID != 0 {
+		// it must be deprecated format
+		m.UserAccess = []UserAccess{{
+			Subnet:     deprecated.UserAccessIP,
+			PrivateKey: deprecated.PrivateKey,
+			NodeID:     deprecated.PublicNodeID,
+		}}
+	}
+	return nil
 }
 
 // ZNet is zos network workload
@@ -89,9 +112,9 @@ func NewNetworkFromWorkload(wl gridtypes.Workload, nodeID uint32) (ZNet, error) 
 	}
 
 	var externalIP *gridtypes.IPNet
-	if metadata.UserAccessIP != "" {
+	if len(metadata.UserAccess) > 0 && metadata.UserAccess[0].Subnet != "" {
 
-		ipNet, err := gridtypes.ParseIPNet(metadata.UserAccessIP)
+		ipNet, err := gridtypes.ParseIPNet(metadata.UserAccess[0].Subnet)
 		if err != nil {
 			return ZNet{}, err
 		}
@@ -100,12 +123,16 @@ func NewNetworkFromWorkload(wl gridtypes.Workload, nodeID uint32) (ZNet, error) 
 	}
 
 	var externalSK wgtypes.Key
-	if metadata.PrivateKey != "" {
-		key, err := wgtypes.ParseKey(metadata.PrivateKey)
+	if len(metadata.UserAccess) > 0 && metadata.UserAccess[0].PrivateKey != "" {
+		key, err := wgtypes.ParseKey(metadata.UserAccess[0].PrivateKey)
 		if err != nil {
 			return ZNet{}, errors.Wrap(err, "failed to parse user access private key")
 		}
 		externalSK = key
+	}
+	var publicNodeID uint32
+	if len(metadata.UserAccess) > 0 {
+		publicNodeID = metadata.UserAccess[0].NodeID
 	}
 	var myceliumKey []byte
 	if data.Mycelium != nil {
@@ -121,7 +148,7 @@ func NewNetworkFromWorkload(wl gridtypes.Workload, nodeID uint32) (ZNet, error) 
 		WGPort:       wgPort,
 		Keys:         keys,
 		AddWGAccess:  externalIP != nil,
-		PublicNodeID: metadata.PublicNodeID,
+		PublicNodeID: publicNodeID,
 		ExternalIP:   externalIP,
 		ExternalSK:   externalSK,
 		MyceliumKey:  myceliumKey,


### PR DESCRIPTION
### Description

Update network metadata to match ts-client and fix a bug where ips of vms on the same network but different node didn't follow the expected sequence.

### Changes

- Update network metadata
- BatchDeploy should reserve right ips for vms

### Related Issues

- #828 
- #545 

### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstring
