### PR TITLE
fix node status ordering by using different gorm query for counting

### DIFF
--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -451,12 +451,6 @@ func (d *PostgresDatabase) GetFarms(ctx context.Context, filter types.FarmFilter
 	if filter.Dedicated != nil {
 		q = q.Where("farm.dedicated_farm = ?", *filter.Dedicated)
 	}
-	var count int64
-	if limit.Randomize || limit.RetCount {
-		if res := q.Count(&count); res.Error != nil {
-			return nil, 0, errors.Wrap(res.Error, "couldn't get farm count")
-		}
-	}
 
 	// Sorting
 	if limit.Randomize {
@@ -473,6 +467,14 @@ func (d *PostgresDatabase) GetFarms(ctx context.Context, filter types.FarmFilter
 			q = q.Order(fmt.Sprintf("%s %s", limit.SortBy, order))
 		} else {
 			q = q.Order("farm.farm_id")
+		}
+	}
+
+	var count int64
+	if limit.RetCount {
+		countQuery := q.Session(&gorm.Session{})
+		if res := countQuery.Count(&count); res.Error != nil {
+			return nil, 0, errors.Wrap(res.Error, "couldn't get farm count")
 		}
 	}
 
@@ -631,18 +633,6 @@ func (d *PostgresDatabase) GetNodes(ctx context.Context, filter types.NodeFilter
 		q = q.Where(`calc_discount(resources_cache.price_usd, ?) <= ?`, limit.Balance, *filter.PriceMax)
 	}
 
-	var count int64
-	if limit.Randomize || limit.RetCount {
-		q = q.Session(&gorm.Session{})
-		res := q.Count(&count)
-		if d.shouldRetry(res.Error) {
-			res = q.Count(&count)
-		}
-		if res.Error != nil {
-			return nil, 0, res.Error
-		}
-	}
-
 	// Sorting
 	if limit.Randomize {
 		q = q.Order("random()")
@@ -666,6 +656,15 @@ func (d *PostgresDatabase) GetNodes(ctx context.Context, filter types.NodeFilter
 			q = q.Order("node.node_id")
 		}
 	}
+
+	var count int64
+	if limit.RetCount {
+		countQuery := q.Session(&gorm.Session{})
+		if res := countQuery.Count(&count); res.Error != nil {
+			return nil, 0, errors.Wrap(res.Error, "couldn't get node count")
+		}
+	}
+
 	// Pagination
 	q = q.Limit(int(limit.Size)).Offset(int(limit.Page-1) * int(limit.Size))
 
@@ -714,12 +713,6 @@ func (d *PostgresDatabase) GetTwins(ctx context.Context, filter types.TwinFilter
 	if filter.PublicKey != nil {
 		q = q.Where("public_key = ?", *filter.PublicKey)
 	}
-	var count int64
-	if limit.Randomize || limit.RetCount {
-		if res := q.Count(&count); res.Error != nil {
-			return nil, 0, errors.Wrap(res.Error, "couldn't get twin count")
-		}
-	}
 
 	// Sorting
 	if limit.Randomize {
@@ -732,6 +725,14 @@ func (d *PostgresDatabase) GetTwins(ctx context.Context, filter types.TwinFilter
 		q = q.Order(fmt.Sprintf("%s %s", limit.SortBy, order))
 	} else {
 		q = q.Order("twin.twin_id")
+	}
+
+	var count int64
+	if limit.RetCount {
+		countQuery := q.Session(&gorm.Session{})
+		if res := countQuery.Count(&count); res.Error != nil {
+			return nil, 0, errors.Wrap(res.Error, "couldn't get twin count")
+		}
 	}
 
 	// Pagination
@@ -804,12 +805,6 @@ func (d *PostgresDatabase) GetContracts(ctx context.Context, filter types.Contra
 	if filter.DeploymentHash != nil {
 		q = q.Where("deployment_hash = ?", *filter.DeploymentHash)
 	}
-	var count int64
-	if limit.Randomize || limit.RetCount {
-		if res := q.Count(&count); res.Error != nil {
-			return nil, 0, errors.Wrap(res.Error, "couldn't get contract count")
-		}
-	}
 
 	// Sorting
 	if limit.Randomize {
@@ -822,6 +817,14 @@ func (d *PostgresDatabase) GetContracts(ctx context.Context, filter types.Contra
 		q = q.Order(fmt.Sprintf("%s %s", limit.SortBy, order))
 	} else {
 		q = q.Order("contracts.contract_id")
+	}
+
+	var count int64
+	if limit.Randomize || limit.RetCount {
+		countQuery := q.Session(&gorm.Session{})
+		if res := countQuery.Count(&count); res.Error != nil {
+			return nil, 0, errors.Wrap(res.Error, "couldn't get contract count")
+		}
 	}
 
 	// Pagination
@@ -865,7 +868,8 @@ func (d *PostgresDatabase) GetContractBills(ctx context.Context, contractID uint
 
 	var count int64
 	if limit.RetCount {
-		if res := q.Count(&count); res.Error != nil {
+		countQuery := q.Session(&gorm.Session{})
+		if res := countQuery.Count(&count); res.Error != nil {
 			return nil, 0, errors.Wrap(res.Error, "couldn't get contract bills count")
 		}
 	}


### PR DESCRIPTION
### Description
according to [gorm docs](https://gorm.io/docs/method_chaining.html#Reusability-and-Safety) the retruned `*gorm.DB` instance of a finisher method is unsafe to use.

the count query was happening before the ordering and then the same `*gorm.DB` instance is reused. so creating new instance of the query chain before executing the finisher method `.Count()` should leave the `q` instance with all the chain methods for filtering a safe to reuse.

### Changes
- rearrange the counting code after the ordering part
- use a different query instance for the finisher method count.


### Related Issues
 - https://github.com/threefoldtech/tfgrid-sdk-go/issues/566

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
