### PR TITLE
remove completion subcommand from the root farmerbot command

### DIFF
--- a/farmerbot/cmd/root.go
+++ b/farmerbot/cmd/root.go
@@ -31,6 +31,8 @@ var farmerBotCmd = &cobra.Command{
 func Execute() {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 
+	farmerBotCmd.Root().CompletionOptions.DisableDefaultCmd = true
+
 	farmerBotCmd.AddCommand(versionCmd)
 	farmerBotCmd.AddCommand(runCmd)
 	farmerBotCmd.AddCommand(startCmd)


### PR DESCRIPTION
### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-go/issues/812

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring

### command result

![image](https://github.com/threefoldtech/tfgrid-sdk-go/assets/47260239/0ee27329-9824-4fa4-8ec3-96c9dc8eb746)
