### PR TITLE
Process nodes concurrently in network deployment

### DIFF
--- a/grid-client/deployer/network_deployer.go
+++ b/grid-client/deployer/network_deployer.go
@@ -122,6 +122,10 @@ func (d *NetworkDeployer) GenerateVersionlessDeployments(ctx context.Context, zn
 			)
 		}
 	}
+	// here we check that the we managed to get a public node
+	// and that public node wasn't already processed. if we got
+	// an error while getting public node, then node id will be 0
+	// and we will skip getting its data.
 	if _, ok := endpoints[publicNode]; !ok && publicNode != 0 {
 		endpoint, usedPorts, err := d.getNodeEndpointAndPorts(ctx, publicNode)
 		if err != nil {

--- a/grid-client/deployer/network_deployer.go
+++ b/grid-client/deployer/network_deployer.go
@@ -153,6 +153,10 @@ func (d *NetworkDeployer) getNodeEndpointAndPorts(ctx context.Context, nodeID ui
 
 func needPublicNode(znets []*workloads.ZNet) bool {
 	// entering here means all nodes for all networks are either hidden or ipv6 only
+	// we need an extra public node in two cases:
+	// - the user asked for WireGuard access
+	// - there are multiple nodes in the network and none of them have ipv4.
+	//   because networks must communicate through ipv4
 	for _, znet := range znets {
 		if znet.AddWGAccess {
 			return true

--- a/grid-client/deployer/network_deployer_test.go
+++ b/grid-client/deployer/network_deployer_test.go
@@ -96,7 +96,7 @@ func TestNetworkDeployer(t *testing.T) {
 			Return(client.NewNodeClient(twinID, cl, d.tfPluginClient.RMBTimeout), nil).
 			AnyTimes()
 
-		dls, err := d.GenerateVersionlessDeployments(context.Background(), &znet, nil)
+		dls, err := d.GenerateVersionlessDeployments(context.Background(), []*workloads.ZNet{&znet})
 		assert.NoError(t, err)
 
 		externalIP := ""
@@ -121,10 +121,10 @@ func TestNetworkDeployer(t *testing.T) {
 
 		networkDl.Metadata = "{\"version\":3,\"type\":\"network\",\"name\":\"network\",\"projectName\":\"Network\"}"
 
-		assert.Equal(t, len(networkDl.Workloads), len(dls[znet.Nodes[0]].Workloads))
-		assert.Equal(t, networkDl.Workloads, dls[znet.Nodes[0]].Workloads)
-		assert.Equal(t, dls, map[uint32]gridtypes.Deployment{
-			nodeID: networkDl,
+		assert.Equal(t, len(networkDl.Workloads), len(dls[znet.Nodes[0]][0].Workloads))
+		assert.Equal(t, networkDl.Workloads, dls[znet.Nodes[0]][0].Workloads)
+		assert.Equal(t, dls, map[uint32][]gridtypes.Deployment{
+			nodeID: {networkDl},
 		})
 	})
 }

--- a/grid-client/deployer/network_deployer_test.go
+++ b/grid-client/deployer/network_deployer_test.go
@@ -64,10 +64,12 @@ func TestNetworkDeployer(t *testing.T) {
 		d, _, _, _ := constructTestNetworkDeployer(t, tfPluginClient, false)
 
 		znet.IPRange.Mask = net.CIDRMask(20, 32)
-		assert.Error(t, d.Validate(context.Background(), &znet))
+		_, err := d.Validate(context.Background(), []*workloads.ZNet{&znet})
+		assert.Error(t, err)
 
 		znet.IPRange.Mask = net.CIDRMask(16, 32)
-		assert.NoError(t, d.Validate(context.Background(), &znet))
+		_, err = d.Validate(context.Background(), []*workloads.ZNet{&znet})
+		assert.NoError(t, err)
 	})
 
 	d, cl, sub, ncPool := constructTestNetworkDeployer(t, tfPluginClient, true)


### PR DESCRIPTION
### Description

Separate node and chain requests from building deployments, that way we can process nodes concurrently and avoid unneeded extra calls. This results in a huge difference in network batch deployment where it went from 10 minutes to 2 minutes for 1000 network.

### Changes

- Way faster network deployment

### Related Issues

- #676 

### Checklist

- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstring
