### PR TITLE
add node_gpu trigger to update the node_gpu_count

### DIFF
--- a/grid-proxy/internal/explorer/db/setup.sql
+++ b/grid-proxy/internal/explorer/db/setup.sql
@@ -440,7 +440,7 @@ BEGIN
             CASE 
             WHEN TG_OP = 'INSERT' 
                 THEN 1 
-            WHEn TG_OP = 'DELETE'
+            WHEN TG_OP = 'DELETE'
                 THEN -1
             ELSE 0
             END

--- a/grid-proxy/internal/explorer/db/setup.sql
+++ b/grid-proxy/internal/explorer/db/setup.sql
@@ -427,6 +427,40 @@ CREATE OR REPLACE TRIGGER tg_node_contract
     EXECUTE PROCEDURE reflect_node_contract_changes();
 
 /*
+ Gpu trigger
+    - Insert new node_gpu > increase the gpu_num in resources cache
+    - Delete node_gpu > decrease the gpu_num in resources cache
+*/
+CREATE OR REPLACE FUNCTION reflect_node_gpu_count_change() RETURNS TRIGGER AS
+$$
+BEGIN
+    BEGIN
+        UPDATE resources_cache
+        SET node_gpu_count = node_gpu_count + (
+            CASE 
+            WHEN TG_OP = 'INSERT' 
+                THEN 1 
+            WHEn TG_OP = 'DELETE'
+                THEN -1
+            ELSE 0
+            END
+        )
+        WHERE resources_cache.node_id = (
+            SELECT node_id from node where node.twin_id = COALESCE(NEW.node_twin_id, OLD.node_twin_id)
+        );
+    EXCEPTION
+        WHEN OTHERS THEN
+            RAISE NOTICE 'Error updating resources_cache gpu fields %', SQLERRM;
+    END;
+RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER tg_node_gpu_count
+    AFTER INSERT OR DELETE ON node_gpu FOR EACH ROW
+    EXECUTE PROCEDURE reflect_node_gpu_count_change();
+
+/*
  Rent contract trigger
     - Insert new rent contract > Update resources_cache renter/rent_contract_id
     - Update (state to 'Deleted') > nullify resources_cache renter/rent_contract_id


### PR DESCRIPTION
### Description
add node_gpu trigger to update the node_gpu_count field on the resouces_cache table:

trigger will work by increment/decrement the node_gpu_count by one each time there is a delete/insert operation on the node_gpu table

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-go/issues/636

### Checklist

- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstring
