### PR TITLE
update k8s cluster to have default projectName of "kubernetes/<name>"

### DIFF
--- a/grid-cli/cmd/cancel.go
+++ b/grid-cli/cmd/cancel.go
@@ -25,8 +25,12 @@ var cancelCmd = &cobra.Command{
 			log.Fatal().Err(err).Send()
 		}
 
-		projectName := fmt.Sprintf("vm/%s", args[0])
-		err = t.CancelByProjectName(projectName)
+		err = t.CancelByProjectName(fmt.Sprintf("vm/%s", args[0]))
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+
+		err = t.CancelByProjectName(fmt.Sprintf("kubernetes/%s", args[0]))
 		if err != nil {
 			log.Fatal().Err(err).Send()
 		}

--- a/grid-cli/docs/kubernetes.md
+++ b/grid-cli/docs/kubernetes.md
@@ -108,7 +108,7 @@ $ tfcmd get kubernetes examplevm
         ],
         "Token": "",
         "NetworkName": "",
-        "SolutionType": "kube",
+        "SolutionType": "kubernetes/kube",
         "SSHKey": "",
         "NodesIPRange": null,
         "NodeDeploymentID": {

--- a/grid-cli/docs/vm.md
+++ b/grid-cli/docs/vm.md
@@ -63,7 +63,7 @@ $ tfcmd get vm examplevm
 {
         "Name": "examplevm",
         "NodeID": 15,
-        "SolutionType": "examplevm",
+        "SolutionType": "vm/examplevm",
         "SolutionProvider": null,
         "NetworkName": "examplevmnetwork",
         "Disks": [

--- a/grid-cli/internal/cmd/deploy.go
+++ b/grid-cli/internal/cmd/deploy.go
@@ -63,7 +63,7 @@ func DeployKubernetesCluster(ctx context.Context, t deployer.TFPluginClient, mas
 		Workers: workers,
 		// TODO: should be randomized
 		Token:        "securetoken",
-		SolutionType: master.Name,
+		SolutionType: fmt.Sprintf("kubernetes/%s", master.Name),
 		SSHKey:       sshKey,
 		NetworkName:  networkName,
 	}

--- a/grid-client/deployer/k8s_deployer_test.go
+++ b/grid-client/deployer/k8s_deployer_test.go
@@ -172,7 +172,7 @@ func TestK8sDeployer(t *testing.T) {
 
 		wl := nodeWorkloads[nodeID]
 		testDl := workloads.NewGridDeployment(d.tfPluginClient.TwinID, wl)
-		testDl.Metadata = "{\"version\":3,\"type\":\"kubernetes\",\"name\":\"K8sForTesting\",\"projectName\":\"K8sForTesting\"}"
+		testDl.Metadata = "{\"version\":3,\"type\":\"kubernetes\",\"name\":\"K8sForTesting\",\"projectName\":\"kubernetes/K8sForTesting\"}"
 
 		assert.Equal(t, dls, map[uint32]gridtypes.Deployment{
 			nodeID: testDl,

--- a/grid-client/workloads/k8s.go
+++ b/grid-client/workloads/k8s.go
@@ -122,7 +122,7 @@ func (k *K8sCluster) ZosWorkloads() ([]gridtypes.Workload, error) {
 // GenerateMetadata generates deployment metadata
 func (k *K8sCluster) GenerateMetadata() (string, error) {
 	if len(k.SolutionType) == 0 {
-		k.SolutionType = k.Master.Name
+		k.SolutionType = fmt.Sprintf("kubernetes/%s", k.Master.Name)
 	}
 
 	deploymentData := DeploymentData{


### PR DESCRIPTION
### Description

update k8s cluster to have default projectName of "kubernetes/<name>"

### Changes

update k8s default projectName to "kubernetes/<name>"
update grid-cli to use the new format

### Related Issues

- #828

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
