### PR TITLE
use twin cache in tfrobot

### DIFF
--- a/tfrobot/cmd/setup.go
+++ b/tfrobot/cmd/setup.go
@@ -24,9 +24,10 @@ func setup(conf tfrobot.Config, debug bool) (deployer.TFPluginClient, error) {
 	}
 
 	opts := []deployer.PluginOpt{
-		deployer.WithProxyURL(proxyURL),
+		deployer.WithTwinCache(),
 		deployer.WithRMBTimeout(30),
 		deployer.WithNetwork(network),
+		deployer.WithProxyURL(proxyURL),
 	}
 	if debug {
 		opts = append(opts, deployer.WithLogs())


### PR DESCRIPTION
### Description

update tfrobot to use twin cache instead of in memory cache

### Changes

- add option `deployer.WithTwinCache()` to the plugin in tfrobot

### Related Issues

- #799 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
