### PR TITLE
Integrate Mycelium with tfcmd

### DIFF
--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -65,15 +65,28 @@ var deployKubernetesCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		mycelium, err := cmd.Flags().GetBool("mycelium")
+		if err != nil {
+			return err
+		}
+		var seed []byte
+		if mycelium {
+			seed, err = workloads.RandomMyceliumIPSeed()
+			if err != nil {
+				log.Fatal().Err(err).Send()
+			}
+		}
 		master := workloads.K8sNode{
-			Name:      name,
-			CPU:       masterCPU,
-			Memory:    masterMemory * 1024,
-			DiskSize:  masterDisk,
-			Flist:     k8sFlist,
-			PublicIP:  ipv4,
-			PublicIP6: ipv6,
-			Planetary: ygg,
+			Name:           name,
+			CPU:            masterCPU,
+			Memory:         masterMemory * 1024,
+			DiskSize:       masterDisk,
+			Flist:          k8sFlist,
+			PublicIP:       ipv4,
+			PublicIP6:      ipv6,
+			Planetary:      ygg,
+			MyceliumIPSeed: seed,
 		}
 
 		workerNumber, err := cmd.Flags().GetInt("workers-number")
@@ -113,18 +126,30 @@ var deployKubernetesCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		workersMycelium, err := cmd.Flags().GetBool("workers-mycelium")
+		if err != nil {
+			return err
+		}
 		var workers []workloads.K8sNode
 		for i := 0; i < workerNumber; i++ {
+			var seed []byte
+			if workersMycelium {
+				seed, err = workloads.RandomMyceliumIPSeed()
+				if err != nil {
+					log.Fatal().Err(err).Send()
+				}
+			}
 			workerName := fmt.Sprintf("worker%d", i)
 			worker := workloads.K8sNode{
-				Name:      workerName,
-				Flist:     k8sFlist,
-				CPU:       workersCPU,
-				Memory:    workersMemory * 1024,
-				DiskSize:  workersDisk,
-				PublicIP:  workersIPV4,
-				PublicIP6: workersIPV6,
-				Planetary: workersYgg,
+				Name:           workerName,
+				Flist:          k8sFlist,
+				CPU:            workersCPU,
+				Memory:         workersMemory * 1024,
+				DiskSize:       workersDisk,
+				PublicIP:       workersIPV4,
+				PublicIP6:      workersIPV6,
+				Planetary:      workersYgg,
+				MyceliumIPSeed: seed,
 			}
 			workers = append(workers, worker)
 		}
@@ -199,6 +224,9 @@ var deployKubernetesCmd = &cobra.Command{
 		if ygg {
 			log.Info().Msgf("master planetary ip: %s", cluster.Master.PlanetaryIP)
 		}
+		if mycelium {
+			log.Info().Msgf("master mycelium ip: %s", cluster.Master.MyceliumIP)
+		}
 
 		for _, worker := range cluster.Workers {
 			log.Info().Msgf("%s wireguard ip: %s", worker.Name, worker.IP)
@@ -216,6 +244,11 @@ var deployKubernetesCmd = &cobra.Command{
 		if workersYgg {
 			for _, worker := range cluster.Workers {
 				log.Info().Msgf("%s planetary ip: %s", worker.Name, worker.PlanetaryIP)
+			}
+		}
+		if workersMycelium {
+			for _, worker := range cluster.Workers {
+				log.Info().Msgf("%s mycelium ip: %s", worker.Name, worker.MyceliumIP)
 			}
 		}
 		return nil
@@ -252,8 +285,11 @@ func init() {
 	deployKubernetesCmd.Flags().Bool("workers-ipv4", false, "assign public ipv4 for workers")
 	deployKubernetesCmd.Flags().Bool("workers-ipv6", false, "assign public ipv6 for workers")
 	deployKubernetesCmd.Flags().Bool("workers-ygg", true, "assign yggdrasil ip for workers")
+	deployKubernetesCmd.Flags().Bool("workers-mycelium", true, "assign mycelium ip for workers")
 
 	deployKubernetesCmd.Flags().Bool("ipv4", false, "assign public ipv4 for master")
 	deployKubernetesCmd.Flags().Bool("ipv6", false, "assign public ipv6 for master")
 	deployKubernetesCmd.Flags().Bool("ygg", true, "assign yggdrasil ip for master")
+	deployKubernetesCmd.Flags().Bool("mycelium", true, "assign mycelium ip for master")
+
 }

--- a/grid-cli/cmd/deploy_vm.go
+++ b/grid-cli/cmd/deploy_vm.go
@@ -96,18 +96,30 @@ var deployVMCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		mycelium, err := cmd.Flags().GetBool("mycelium")
+		if err != nil {
+			return err
+		}
+		var seed []byte
+		if mycelium {
+			seed, err = workloads.RandomMyceliumIPSeed()
+			if err != nil {
+				log.Fatal().Err(err).Send()
+			}
+		}
 		vm := workloads.VM{
-			Name:       name,
-			EnvVars:    map[string]string{"SSH_KEY": string(sshKey)},
-			CPU:        cpu,
-			Memory:     memory * 1024,
-			GPUs:       convertGPUsToZosGPUs(gpus),
-			RootfsSize: rootfs * 1024,
-			Flist:      flist,
-			Entrypoint: entrypoint,
-			PublicIP:   ipv4,
-			PublicIP6:  ipv6,
-			Planetary:  ygg,
+			Name:           name,
+			EnvVars:        map[string]string{"SSH_KEY": string(sshKey)},
+			CPU:            cpu,
+			Memory:         memory * 1024,
+			GPUs:           convertGPUsToZosGPUs(gpus),
+			RootfsSize:     rootfs * 1024,
+			Flist:          flist,
+			Entrypoint:     entrypoint,
+			PublicIP:       ipv4,
+			PublicIP6:      ipv6,
+			MyceliumIPSeed: seed,
+			Planetary:      ygg,
 		}
 		var mount workloads.Disk
 		if disk != 0 {
@@ -155,6 +167,9 @@ var deployVMCmd = &cobra.Command{
 		if ygg {
 			log.Info().Msgf("vm planetary ip: %s", resVM.PlanetaryIP)
 		}
+		if mycelium {
+			log.Info().Msgf("vm mycelium ip: %s", resVM.MyceliumIP)
+		}
 		return nil
 	},
 }
@@ -192,4 +207,5 @@ func init() {
 	deployVMCmd.Flags().Bool("ipv4", false, "assign public ipv4 for vm")
 	deployVMCmd.Flags().Bool("ipv6", false, "assign public ipv6 for vm")
 	deployVMCmd.Flags().Bool("ygg", true, "assign yggdrasil ip for vm")
+	deployVMCmd.Flags().Bool("mycelium", true, "assign mycelium ip for vm")
 }

--- a/grid-cli/docs/kubernetes.md
+++ b/grid-cli/docs/kubernetes.md
@@ -22,6 +22,7 @@ tfcmd deploy kubernetes [flags]
 - ipv4: assign public ipv4 for master node (default false).
 - ipv6: assign public ipv6 for master node (default false).
 - ygg: assign yggdrasil ip for master node (default true).
+- mycelium: assign mycelium ip for master node (default true).
 - master-cpu: number of cpu units for master node (default 1).
 - master-memory: master node memory size in GB (default 1).
 - master-disk: master node disk size in GB (default 2).
@@ -29,6 +30,7 @@ tfcmd deploy kubernetes [flags]
 - workers-ipv4: assign public ipv4 for each worker node (default false)
 - workers-ipv6: assign public ipv6 for each worker node (default false)
 - workers-ygg: assign yggdrasil ip for each worker node (default true)
+- workers-mycelium: assign mycelium ip for each worker node (default true)
 - workers-cpu: number of cpu units for each worker node (default 1).
 - workers-memory: memory size for each worker node in GB (default 1).
 - workers-disk: disk size in GB for each worker node (default 2).
@@ -37,9 +39,18 @@ Example:
 
 ```console
 $ tfcmd deploy kubernetes -n kube --ssh ~/.ssh/id_rsa.pub --master-node 14 --workers-number 2 --workers-node 14
-4:21PM INF deploying network
-4:22PM INF deploying cluster
-4:22PM INF master planetary ip: 300:e9c4:9048:57cf:504f:c86c:9014:d02d
+11:43AM INF starting peer session=tf-1510734 twin=192
+11:43AM INF deploying network
+11:43AM INF deploying cluster
+11:43AM INF master wireguard ip: 10.20.2.2
+11:43AM INF master planetary ip: 300:e9c4:9048:57cf:d73d:eb4c:7a6d:503
+11:43AM INF master mycelium ip: 423:16f5:ca74:b600:ff0f:9ee:d57e:827a
+11:43AM INF worker1 wireguard ip: 10.20.2.3
+11:43AM INF worker0 wireguard ip: 10.20.2.3
+11:43AM INF worker1 planetary ip: 300:e9c4:9048:57cf:3c4f:d477:b4a5:890b
+11:43AM INF worker0 planetary ip: 300:e9c4:9048:57cf:77ca:5424:21da:4fff
+11:43AM INF worker1 mycelium ip: 423:16f5:ca74:b600:ff0f:e02f:1ad7:d74e
+11:43AM INF worker0 mycelium ip: 423:16f5:ca74:b600:ff0f:bb5a:6036:56f6
 ```
 
 ## Get
@@ -53,66 +64,87 @@ kubernetes is the name used when deploying kubernetes cluster using tfcmd.
 Example:
 
 ```console
-$ tfcmd get kubernetes examplevm
-3:14PM INF k8s cluster:
+$ tfcmd get kubernetes kube
+11:44AM INF starting peer session=tf-1511628 twin=192
+11:44AM INF k8s cluster:
 {
         "Master": {
-                "Name": "kube",
-                "Node": 14,
-                "DiskSize": 2,
-                "PublicIP": false,
-                "PublicIP6": false,
-                "Planetary": true,
-                "Flist": "https://hub.grid.tf/tf-official-apps/threefoldtech-k3s-latest.flist",
-                "FlistChecksum": "c87cf57e1067d21a3e74332a64ef9723",
-                "ComputedIP": "",
-                "ComputedIP6": "",
-                "PlanetaryIP": "300:e9c4:9048:57cf:e8a0:662b:4e66:8faa",
-                "IP": "10.20.2.2",
-                "CPU": 1,
-                "Memory": 1024
+                "name": "kube",
+                "node": 14,
+                "disk_size": 10,
+                "publicip": false,
+                "publicip6": false,
+                "planetary": true,
+                "flist": "https://hub.grid.tf/tf-official-apps/threefoldtech-k3s-latest.flist",
+                "flist_checksum": "c87cf57e1067d21a3e74332a64ef9723",
+                "computedip": "",
+                "computedip6": "",
+                "planetary_ip": "300:e9c4:9048:57cf:d73d:eb4c:7a6d:503",
+                "mycelium_ip": "423:16f5:ca74:b600:ff0f:9ee:d57e:827a",
+                "mycelium_ip_seed": "Ce7VfoJ6",
+                "ip": "10.20.2.2",
+                "cpu": 2,
+                "memory": 4096,
+                "network_name": "kubenetwork",
+                "token": "securetoken",
+                "ssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDcGrS1RT36rHAGLK3/4FMazGXjIYgWVnZ4bCvxxg8KosEEbs/DeUKT2T2LYV91jUq3yibTWwK0nc6O+K5kdShV4qsQlPmIbdur6x2zWHPeaGXqejbbACEJcQMCj8szSbG8aKwH8Nbi8BNytgzJ20Ysaaj2QpjObCZ4Ncp+89pFahzDEIJx2HjXe6njbp6eCduoA+IE2H9vgwbIDVMQz6y/TzjdQjgbMOJRTlP+CzfbDBb6Ux+ed8F184bMPwkFrpHs9MSfQVbqfIz8wuq/wjewcnb3wK9dmIot6CxV2f2xuOZHgNQmVGratK8TyBnOd5x4oZKLIh3qM9Bi7r81xCkXyxAZbWYu3gGdvo3h85zeCPGK8OEPdYWMmIAIiANE42xPmY9HslPz8PAYq6v0WwdkBlDWrG3DD3GX6qTt9lbSHEgpUP2UOnqGL4O1+g5Rm9x16HWefZWMjJsP6OV70PnMjo9MPnH+yrBkXISw4CGEEXryTvupfaO5sL01mn+UOyE= abdulrahman@AElawady-PC\n",
+                "console_url": "10.20.2.0:20002"
         },
         "Workers": [
                 {
-                        "Name": "worker1",
-                        "Node": 14,
-                        "DiskSize": 2,
-                        "PublicIP": false,
-                        "PublicIP6": false,
-                        "Planetary": true,
-                        "Flist": "https://hub.grid.tf/tf-official-apps/threefoldtech-k3s-latest.flist",
-                        "FlistChecksum": "c87cf57e1067d21a3e74332a64ef9723",
-                        "ComputedIP": "",
-                        "ComputedIP6": "",
-                        "PlanetaryIP": "300:e9c4:9048:57cf:66d0:3ee4:294e:d134",
-                        "IP": "10.20.2.2",
-                        "CPU": 1,
-                        "Memory": 1024
+                        "name": "worker1",
+                        "node": 14,
+                        "disk_size": 10,
+                        "publicip": false,
+                        "publicip6": false,
+                        "planetary": true,
+                        "flist": "https://hub.grid.tf/tf-official-apps/threefoldtech-k3s-latest.flist",
+                        "flist_checksum": "c87cf57e1067d21a3e74332a64ef9723",
+                        "computedip": "",
+                        "computedip6": "",
+                        "planetary_ip": "300:e9c4:9048:57cf:3c4f:d477:b4a5:890b",
+                        "mycelium_ip": "423:16f5:ca74:b600:ff0f:e02f:1ad7:d74e",
+                        "mycelium_ip_seed": "4C8a19dO",
+                        "ip": "10.20.2.3",
+                        "cpu": 2,
+                        "memory": 4096,
+                        "network_name": "kubenetwork",
+                        "token": "securetoken",
+                        "ssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDcGrS1RT36rHAGLK3/4FMazGXjIYgWVnZ4bCvxxg8KosEEbs/DeUKT2T2LYV91jUq3yibTWwK0nc6O+K5kdShV4qsQlPmIbdur6x2zWHPeaGXqejbbACEJcQMCj8szSbG8aKwH8Nbi8BNytgzJ20Ysaaj2QpjObCZ4Ncp+89pFahzDEIJx2HjXe6njbp6eCduoA+IE2H9vgwbIDVMQz6y/TzjdQjgbMOJRTlP+CzfbDBb6Ux+ed8F184bMPwkFrpHs9MSfQVbqfIz8wuq/wjewcnb3wK9dmIot6CxV2f2xuOZHgNQmVGratK8TyBnOd5x4oZKLIh3qM9Bi7r81xCkXyxAZbWYu3gGdvo3h85zeCPGK8OEPdYWMmIAIiANE42xPmY9HslPz8PAYq6v0WwdkBlDWrG3DD3GX6qTt9lbSHEgpUP2UOnqGL4O1+g5Rm9x16HWefZWMjJsP6OV70PnMjo9MPnH+yrBkXISw4CGEEXryTvupfaO5sL01mn+UOyE= abdulrahman@AElawady-PC\n",
+                        "console_url": "10.20.2.0:20003"
                 },
                 {
-                        "Name": "worker0",
-                        "Node": 14,
-                        "DiskSize": 2,
-                        "PublicIP": false,
-                        "PublicIP6": false,
-                        "Planetary": true,
-                        "Flist": "https://hub.grid.tf/tf-official-apps/threefoldtech-k3s-latest.flist",
-                        "FlistChecksum": "c87cf57e1067d21a3e74332a64ef9723",
-                        "ComputedIP": "",
-                        "ComputedIP6": "",
-                        "PlanetaryIP": "300:e9c4:9048:57cf:1ae5:cc51:3ffc:81e",
-                        "IP": "10.20.2.2",
-                        "CPU": 1,
-                        "Memory": 1024
+                        "name": "worker0",
+                        "node": 14,
+                        "disk_size": 10,
+                        "publicip": false,
+                        "publicip6": false,
+                        "planetary": true,
+                        "flist": "https://hub.grid.tf/tf-official-apps/threefoldtech-k3s-latest.flist",
+                        "flist_checksum": "c87cf57e1067d21a3e74332a64ef9723",
+                        "computedip": "",
+                        "computedip6": "",
+                        "planetary_ip": "300:e9c4:9048:57cf:77ca:5424:21da:4fff",
+                        "mycelium_ip": "423:16f5:ca74:b600:ff0f:bb5a:6036:56f6",
+                        "mycelium_ip_seed": "u1pgNlb2",
+                        "ip": "10.20.2.3",
+                        "cpu": 2,
+                        "memory": 4096,
+                        "network_name": "kubenetwork",
+                        "token": "securetoken",
+                        "ssh_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDcGrS1RT36rHAGLK3/4FMazGXjIYgWVnZ4bCvxxg8KosEEbs/DeUKT2T2LYV91jUq3yibTWwK0nc6O+K5kdShV4qsQlPmIbdur6x2zWHPeaGXqejbbACEJcQMCj8szSbG8aKwH8Nbi8BNytgzJ20Ysaaj2QpjObCZ4Ncp+89pFahzDEIJx2HjXe6njbp6eCduoA+IE2H9vgwbIDVMQz6y/TzjdQjgbMOJRTlP+CzfbDBb6Ux+ed8F184bMPwkFrpHs9MSfQVbqfIz8wuq/wjewcnb3wK9dmIot6CxV2f2xuOZHgNQmVGratK8TyBnOd5x4oZKLIh3qM9Bi7r81xCkXyxAZbWYu3gGdvo3h85zeCPGK8OEPdYWMmIAIiANE42xPmY9HslPz8PAYq6v0WwdkBlDWrG3DD3GX6qTt9lbSHEgpUP2UOnqGL4O1+g5Rm9x16HWefZWMjJsP6OV70PnMjo9MPnH+yrBkXISw4CGEEXryTvupfaO5sL01mn+UOyE= abdulrahman@AElawady-PC\n",
+                        "console_url": "10.20.2.0:20003"
                 }
         ],
-        "Token": "",
-        "NetworkName": "",
+        "Token": "securetoken",
+        "NetworkName": "kubenetwork",
         "SolutionType": "kubernetes/kube",
-        "SSHKey": "",
-        "NodesIPRange": null,
+        "SSHKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDcGrS1RT36rHAGLK3/4FMazGXjIYgWVnZ4bCvxxg8KosEEbs/DeUKT2T2LYV91jUq3yibTWwK0nc6O+K5kdShV4qsQlPmIbdur6x2zWHPeaGXqejbbACEJcQMCj8szSbG8aKwH8Nbi8BNytgzJ20Ysaaj2QpjObCZ4Ncp+89pFahzDEIJx2HjXe6njbp6eCduoA+IE2H9vgwbIDVMQz6y/TzjdQjgbMOJRTlP+CzfbDBb6Ux+ed8F184bMPwkFrpHs9MSfQVbqfIz8wuq/wjewcnb3wK9dmIot6CxV2f2xuOZHgNQmVGratK8TyBnOd5x4oZKLIh3qM9Bi7r81xCkXyxAZbWYu3gGdvo3h85zeCPGK8OEPdYWMmIAIiANE42xPmY9HslPz8PAYq6v0WwdkBlDWrG3DD3GX6qTt9lbSHEgpUP2UOnqGL4O1+g5Rm9x16HWefZWMjJsP6OV70PnMjo9MPnH+yrBkXISw4CGEEXryTvupfaO5sL01mn+UOyE= abdulrahman@AElawady-PC\n",
+        "NodesIPRange": {
+                "14": "10.20.2.0/24"
+        },
         "NodeDeploymentID": {
-                "14": 22743
+                "14": 100050
         }
 }
 ```

--- a/grid-cli/docs/vm.md
+++ b/grid-cli/docs/vm.md
@@ -26,6 +26,7 @@ tfcmd deploy vm [flags]
 - memory: memory size in GB (default 1).
 - rootfs: root filesystem size in GB (default 2).
 - ygg: assign yggdrasil ip for VM (default true).
+- mycelium: assign mycelium ip for VM (default true).
 - gpus: assign a list of gpus' ids to the VM. note: setting this without the node option will fail.
 
 Example:
@@ -34,17 +35,22 @@ Example:
 
 ```console
 $ tfcmd deploy vm --name examplevm --ssh ~/.ssh/id_rsa.pub --cpu 2 --memory 4 --disk 10
+12:06PM INF starting peer session=tf-1508255 twin=192
 12:06PM INF deploying network
 12:06PM INF deploying vm
 12:07PM INF vm planetary ip: 300:e9c4:9048:57cf:7da2:ac99:99db:8821
+12:07PM INF vm mycelium ip: 544:b74f:ceef:cc7e:ff0f:6b18:921f:8031
 ```
+
 - Deploying VM with GPU
 
 ```console
 $ tfcmd deploy vm --name examplevm --ssh ~/.ssh/id_rsa.pub --cpu 2 --memory 4 --disk 10 --gpus '0000:0e:00.0/1882/543f' --gpus '0000:0e:00.0/1887/593f' --node 12
+12:06PM INF starting peer session=tf-1508255 twin=192
 12:06PM INF deploying network
 12:06PM INF deploying vm
 12:07PM INF vm planetary ip: 300:e9c4:9048:57cf:7da2:ac99:99db:8821
+12:07PM INF vm mycelium ip: 544:b74f:ceef:cc7e:ff0f:6b18:921f:8031
 ```
 
 ## Get
@@ -59,57 +65,63 @@ Example:
 
 ```console
 $ tfcmd get vm examplevm
-3:20PM INF vm:
+11:56AM INF starting peer session=tf-1522837 twin=192
+11:56AM INF vm:
 {
         "Name": "examplevm",
-        "NodeID": 15,
+        "NodeID": 11,
         "SolutionType": "vm/examplevm",
         "SolutionProvider": null,
         "NetworkName": "examplevmnetwork",
         "Disks": [
                 {
-                        "Name": "examplevmdisk",
-                        "SizeGB": 10,
-                        "Description": ""
+                        "name": "examplevmdisk",
+                        "size": 10,
+                        "description": ""
                 }
         ],
         "Zdbs": [],
         "Vms": [
                 {
-                        "Name": "examplevm",
-                        "Flist": "https://hub.grid.tf/tf-official-apps/threefoldtech-ubuntu-22.04.flist",
-                        "FlistChecksum": "",
-                        "PublicIP": false,
-                        "PublicIP6": false,
-                        "Planetary": true,
-                        "Corex": false,
-                        "ComputedIP": "",
-                        "ComputedIP6": "",
-                        "PlanetaryIP": "301:ad3a:9c52:98d1:cd05:1595:9abb:e2f1",
-                        "IP": "10.20.2.2",
-                        "Description": "",
-                        "CPU": 2,
-                        "Memory": 4096,
-                        "RootfsSize": 2048,
-                        "Entrypoint": "/sbin/zinit init",
-                        "Mounts": [
+                        "name": "examplevm",
+                        "flist": "https://hub.grid.tf/tf-official-apps/threefoldtech-ubuntu-22.04.flist",
+                        "flist_checksum": "",
+                        "publicip": false,
+                        "publicip6": false,
+                        "planetary": true,
+                        "corex": false,
+                        "computedip": "",
+                        "computedip6": "",
+                        "planetary_ip": "302:9e63:7d43:b742:c2e0:ab69:e101:8032",
+                        "mycelium_ip": "45f:6cd6:8c6d:6c73:ff0f:6c97:11e3:4e84",
+                        "ip": "10.20.2.2",
+                        "mycelium_ip_seed": "bJcR406E",
+                        "description": "",
+                        "gpus": null,
+                        "cpu": 2,
+                        "memory": 4096,
+                        "rootfs_size": 2048,
+                        "entrypoint": "/sbin/zinit init",
+                        "mounts": [
                                 {
-                                        "DiskName": "examplevmdisk",
-                                        "MountPoint": "/data"
+                                        "disk_name": "examplevmdisk",
+                                        "mount_point": "/data"
                                 }
                         ],
-                        "Zlogs": null,
-                        "EnvVars": {
+                        "zlogs": null,
+                        "env_vars": {
                                 "SSH_KEY": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDcGrS1RT36rHAGLK3/4FMazGXjIYgWVnZ4bCvxxg8KosEEbs/DeUKT2T2LYV91jUq3yibTWwK0nc6O+K5kdShV4qsQlPmIbdur6x2zWHPeaGXqejbbACEJcQMCj8szSbG8aKwH8Nbi8BNytgzJ20Ysaaj2QpjObCZ4Ncp+89pFahzDEIJx2HjXe6njbp6eCduoA+IE2H9vgwbIDVMQz6y/TzjdQjgbMOJRTlP+CzfbDBb6Ux+ed8F184bMPwkFrpHs9MSfQVbqfIz8wuq/wjewcnb3wK9dmIot6CxV2f2xuOZHgNQmVGratK8TyBnOd5x4oZKLIh3qM9Bi7r81xCkXyxAZbWYu3gGdvo3h85zeCPGK8OEPdYWMmIAIiANE42xPmY9HslPz8PAYq6v0WwdkBlDWrG3DD3GX6qTt9lbSHEgpUP2UOnqGL4O1+g5Rm9x16HWefZWMjJsP6OV70PnMjo9MPnH+yrBkXISw4CGEEXryTvupfaO5sL01mn+UOyE= abdulrahman@AElawady-PC\n"
                         },
-                        "NetworkName": "examplevmnetwork"
+                        "network_name": "examplevmnetwork",
+                        "console_url": "10.20.2.0:20002"
                 }
         ],
         "QSFS": [],
         "NodeDeploymentID": {
-                "15": 22748
+                "11": 100063
         },
-        "ContractID": 22748
+        "ContractID": 100063,
+        "IPrange": "10.20.2.0/24"
 }
 ```
 

--- a/grid-cli/internal/cmd/deploy.go
+++ b/grid-cli/internal/cmd/deploy.go
@@ -17,7 +17,10 @@ import (
 func DeployVM(ctx context.Context, t deployer.TFPluginClient, vm workloads.VM, mount workloads.Disk, node uint32) (workloads.VM, error) {
 	networkName := fmt.Sprintf("%snetwork", vm.Name)
 	projectName := fmt.Sprintf("vm/%s", vm.Name)
-	network := buildNetwork(networkName, projectName, []uint32{node})
+	network, err := buildNetwork(networkName, projectName, []uint32{node}, len(vm.MyceliumIPSeed) != 0)
+	if err != nil {
+		return workloads.VM{}, err
+	}
 
 	mounts := []workloads.Disk{}
 	if mount.SizeGB != 0 {
@@ -27,7 +30,7 @@ func DeployVM(ctx context.Context, t deployer.TFPluginClient, vm workloads.VM, m
 	dl := workloads.NewDeployment(vm.Name, node, projectName, nil, networkName, mounts, nil, []workloads.VM{vm}, nil)
 
 	log.Info().Msg("deploying network")
-	err := t.NetworkDeployer.Deploy(ctx, &network)
+	err = t.NetworkDeployer.Deploy(ctx, &network)
 	if err != nil {
 		return workloads.VM{}, errors.Wrapf(err, "failed to deploy network on node %d", node)
 	}
@@ -57,7 +60,10 @@ func DeployKubernetesCluster(ctx context.Context, t deployer.TFPluginClient, mas
 	if len(workers) > 0 && workers[0].Node != master.Node {
 		networkNodes = append(networkNodes, workers[0].Node)
 	}
-	network := buildNetwork(networkName, projectName, networkNodes)
+	network, err := buildNetwork(networkName, projectName, networkNodes, len(master.MyceliumIPSeed) != 0)
+	if err != nil {
+		return workloads.K8sCluster{}, err
+	}
 
 	cluster := workloads.K8sCluster{
 		Master:  &master,
@@ -69,7 +75,7 @@ func DeployKubernetesCluster(ctx context.Context, t deployer.TFPluginClient, mas
 		NetworkName:  networkName,
 	}
 	log.Info().Msg("deploying network")
-	err := t.NetworkDeployer.Deploy(ctx, &network)
+	err = t.NetworkDeployer.Deploy(ctx, &network)
 	if err != nil {
 		return workloads.K8sCluster{}, errors.Wrapf(err, "failed to deploy network on nodes %v", network.Nodes)
 	}
@@ -137,7 +143,17 @@ func DeployZDBs(ctx context.Context, t deployer.TFPluginClient, projectName stri
 	return resZDBs, nil
 }
 
-func buildNetwork(name, projectName string, nodes []uint32) workloads.ZNet {
+func buildNetwork(name, projectName string, nodes []uint32, addMycelium bool) (workloads.ZNet, error) {
+	keys := make(map[uint32][]byte)
+	if addMycelium {
+		for _, node := range nodes {
+			key, err := workloads.RandomMyceliumKey()
+			if err != nil {
+				return workloads.ZNet{}, err
+			}
+			keys[node] = key
+		}
+	}
 	return workloads.ZNet{
 		Name:  name,
 		Nodes: nodes,
@@ -145,6 +161,7 @@ func buildNetwork(name, projectName string, nodes []uint32) workloads.ZNet {
 			IP:   net.IPv4(10, 20, 0, 0),
 			Mask: net.CIDRMask(16, 32),
 		}),
+		MyceliumKeys: keys,
 		SolutionType: projectName,
-	}
+	}, nil
 }


### PR DESCRIPTION
### Description

Integrate Mycelium with tfcmd

### Changes

- VMs and K8s can be deployed with Mycelium enable by passing `--mycelium` and `--workers-mycelium`.

### Related Issues

- #907 

### Checklist

- [ ] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstring
