### PR TITLE
integrate the new LastDeploymentTimestamp field on node statistics endpoint

### DIFF
--- a/grid-proxy/pkg/types/stats.go
+++ b/grid-proxy/pkg/types/stats.go
@@ -35,8 +35,9 @@ type NodeStatisticsResources struct {
 
 // NodeStatisticsUsers users info returned on node statistics
 type NodeStatisticsUsers struct {
-	Deployments int `json:"deployments"`
-	Workloads   int `json:"workloads"`
+	Deployments             int    `json:"deployments"`
+	Workloads               int    `json:"workloads"`
+	LastDeploymentTimestamp uint64 `json:"last_deployment_timestamp"`
 }
 
 // NodeStatistics node statistics info


### PR DESCRIPTION
### Description
integrate the new LastDeploymentTimestamp field on node statistics endpoint

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/914

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
