### PR TITLE
fix empty middlewares for sub routers

### DIFF
--- a/rmb-sdk-go/peer/router.go
+++ b/rmb-sdk-go/peer/router.go
@@ -29,19 +29,19 @@ type Middleware func(ctx context.Context, payload []byte) (context.Context, erro
 
 type Router struct {
 	handlers map[string]HandlerFunc
-	routes   map[string]Router
+	routes   map[string]*Router
 	mw       []Middleware
 }
 
-func NewRouter() Router {
-	return Router{
+func NewRouter() *Router {
+	return &Router{
 		handlers: make(map[string]HandlerFunc),
-		routes:   make(map[string]Router),
+		routes:   make(map[string]*Router),
 	}
 }
 
 // SubRoute add a route prefix to include more sub routes with handler from it
-func (r *Router) SubRoute(prefix string) Router {
+func (r *Router) SubRoute(prefix string) *Router {
 	if strings.Contains(prefix, ".") {
 		panic("invalid subrouter prefix should not have '.'")
 	}


### PR DESCRIPTION
### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-go/issues/924

### Tested on farmerbot

- auth middleware for power subroutes

```console
$ cd ../poweroff && go run main.go
2024/03/07 12:44:58 you are not authorized for this action. your twin id is `81`, only the farm owner with twin id `164` is authorized
exit status 1

$ cd ../poweron && go run main.go
2024/03/07 12:45:05 you are not authorized for this action. your twin id is `81`, only the farm owner with twin id `164` is authorized
exit status 1

$ cd ../includenode && go run main.go
2024/03/07 12:45:19 you are not authorized for this action. your twin id is `81`, only the farm owner with twin id `164` is authorized
exit status 1
```

- Tried `version` sub route and worked fine without the middleware
```console
$ cd ../version && go run main.go
version: v0.14.11
``` 