### PR TITLE
Add validation for twin relays

### DIFF
--- a/tools/relay-cache-warmer/graphql.go
+++ b/tools/relay-cache-warmer/graphql.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -82,6 +83,7 @@ func warmTwins(pool *redis.Pool, graphql string) error {
 		if err != nil {
 			return err
 		}
+		invalidateTwins(gtwins)
 		twins, err := graphqlTwinsToRelayTwins(gtwins)
 		if err != nil {
 			return err
@@ -99,6 +101,40 @@ func warmTwins(pool *redis.Pool, graphql string) error {
 	}
 
 	return nil
+}
+
+func invalidateTwins(twins []graphqlTwin) {
+	for i, twin := range twins {
+		if twin.Relay == nil {
+			continue
+		}
+		if !validRelay(*twin.Relay) {
+			twins[i].Relay = nil
+		}
+	}
+}
+
+func validRelay(relay string) bool {
+	if len(relay) == 0 {
+		return false
+	}
+	relays := strings.Split(relay, "_")
+	for _, relay := range relays {
+		// it can't be an ip
+		if ip := net.ParseIP(relay); ip != nil {
+			return false
+		}
+		if !strings.Contains(relay, ".") {
+			return false
+		}
+		parts := strings.Split(relay, ".")
+		for _, part := range parts {
+			if len(part) == 0 {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func queryGraphql(graphql, body string) (paginationData, []graphqlTwin, error) {

--- a/tools/relay-cache-warmer/graphql_test.go
+++ b/tools/relay-cache-warmer/graphql_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestInvalidateTwins(t *testing.T) {
+	twins := []graphqlTwin{
+		{
+			Relay: nil,
+		},
+		{
+			Relay: strPointer("192.168.1.1"),
+		},
+		{
+			Relay: strPointer("invalid"),
+		},
+		{
+			Relay: strPointer(".."),
+		},
+		{
+			Relay: strPointer("::1_302:9e63:7d43:b742:2442:f506:5aa4:d5c5"),
+		},
+		{
+			Relay: strPointer("example.com_relay.grid.tf_relay.bknd1.ninja.com_relay.02.grid.tf"),
+		},
+	}
+	expected := []graphqlTwin{
+		{
+			Relay: nil,
+		},
+		{
+			Relay: nil,
+		},
+		{
+			Relay: nil,
+		},
+		{
+			Relay: nil,
+		},
+		{
+			Relay: nil,
+		},
+		{
+			Relay: strPointer("example.com_relay.grid.tf_relay.bknd1.ninja.com_relay.02.grid.tf"),
+		},
+	}
+	invalidateTwins(twins)
+	if !reflect.DeepEqual(twins, expected) {
+		t.Fatalf("expected %+v got %+v", expected, twins)
+	}
+}
+func strPointer(s string) *string {
+	return &s
+}


### PR DESCRIPTION
### Description

Add validation for twin relays before setting them in cache

### Changes

- twins with ips in relay field will be set to null

### Related Issues

- #932

### Checklist

- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstring
