### PR TITLE
use default proxy url and remove ninja

### DIFF
--- a/tfrobot/cmd/setup.go
+++ b/tfrobot/cmd/setup.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"os"
-	"strings"
-
 	"github.com/rs/zerolog/log"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/deployer"
 	tfrobot "github.com/threefoldtech/tfgrid-sdk-go/tfrobot/pkg/deployer"
@@ -16,18 +13,10 @@ func setup(conf tfrobot.Config, debug bool) (deployer.TFPluginClient, error) {
 	mnemonic := conf.Mnemonic
 	log.Debug().Str("mnemonic", mnemonic).Send()
 
-	var proxyURL string
-	noNinjaProxyURL := strings.TrimSpace(strings.ToLower(os.Getenv("NO_NINJA_PROXY_URL")))
-
-	if network == "main" && noNinjaProxyURL == "" {
-		proxyURL = "https://gridproxy.bknd1.ninja.tf"
-	}
-
 	opts := []deployer.PluginOpt{
 		deployer.WithTwinCache(),
 		deployer.WithRMBTimeout(30),
 		deployer.WithNetwork(network),
-		deployer.WithProxyURL(proxyURL),
 	}
 	if debug {
 		opts = append(opts, deployer.WithLogs())


### PR DESCRIPTION
### Description

remove default ninja url and the flag `NINJA_PROXY_URL` and use default proxy

### Changes

List of changes this PR includes

### Related Issues

- #751 

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [x] Code format and docstring
