### PR TITLE
add farm name/id to contract endpoint response

### DIFF
--- a/grid-proxy/internal/explorer/converters.go
+++ b/grid-proxy/internal/explorer/converters.go
@@ -154,6 +154,8 @@ func contractFromDBContract(info db.DBContract) (types.Contract, error) {
 			DeploymentData:    info.DeploymentData,
 			DeploymentHash:    info.DeploymentHash,
 			NumberOfPublicIps: info.NumberOfPublicIps,
+			FarmName:          info.FarmName,
+			FarmId:            info.FarmId,
 		}
 	case "name":
 		details = types.NameContractDetails{
@@ -161,7 +163,9 @@ func contractFromDBContract(info db.DBContract) (types.Contract, error) {
 		}
 	case "rent":
 		details = types.RentContractDetails{
-			NodeID: info.NodeID,
+			NodeID:   info.NodeID,
+			FarmName: info.FarmName,
+			FarmId:   info.FarmId,
 		}
 	}
 	contract := types.Contract{

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -40,6 +40,8 @@ type DBContract struct {
 	DeploymentHash    string
 	NumberOfPublicIps uint
 	Type              string
+	FarmName          string
+	FarmId            uint64
 }
 
 // Node data about a node which is calculated from the chain

--- a/grid-proxy/pkg/types/contracts.go
+++ b/grid-proxy/pkg/types/contracts.go
@@ -13,6 +13,8 @@ type NodeContractDetails struct {
 	DeploymentData    string `json:"deployment_data"`
 	DeploymentHash    string `json:"deployment_hash"`
 	NumberOfPublicIps uint   `json:"number_of_public_ips"`
+	FarmName          string `json:"farm_name"`
+	FarmId            uint64 `json:"farm_id"`
 }
 
 // NameContractDetails name contract details
@@ -22,7 +24,9 @@ type NameContractDetails struct {
 
 // RentContractDetails rent contract details
 type RentContractDetails struct {
-	NodeID uint `json:"nodeId"`
+	NodeID   uint   `json:"nodeId"`
+	FarmName string `json:"farm_name"`
+	FarmId   uint64 `json:"farm_id"`
 }
 
 // Contract represents a contract and its details after decoding to one of Details structs.
@@ -63,4 +67,6 @@ type ContractFilter struct {
 	NumberOfPublicIps *uint64 `schema:"number_of_public_ips,omitempty"`
 	DeploymentData    *string `schema:"deployment_data,omitempty"`
 	DeploymentHash    *string `schema:"deployment_hash,omitempty"`
+	FarmName          *string `schema:"farm_name,omitempty"`
+	FarmId            *uint64 `schema:"farm_id,omitempty"`
 }

--- a/grid-proxy/tests/queries/contract_test.go
+++ b/grid-proxy/tests/queries/contract_test.go
@@ -25,6 +25,8 @@ type ContractsAggregate struct {
 	Names            []string
 	DeploymentsData  []string
 	DeploymentHashes []string
+	farmNames        []string
+	farmIds          []uint64
 
 	maxNumberOfPublicIPs uint64
 }
@@ -76,6 +78,18 @@ var contractFilterRandomValueGenerator = map[string]func(agg ContractsAggregate)
 			return nil
 		}
 		return &c
+	},
+	"FarmName": func(agg ContractsAggregate) interface{} {
+		name := changeCase(agg.farmNames[rand.Intn(len(agg.farmNames))])
+		if len(name) == 0 {
+			return nil
+		}
+
+		return &name
+	},
+	"FarmId": func(agg ContractsAggregate) interface{} {
+		farmID := agg.farmIds[rand.Intn(len(agg.farmIds))]
+		return &farmID
 	},
 }
 
@@ -299,6 +313,11 @@ func calcContractsAggregates(data *mock.DBData) (res ContractsAggregate) {
 	sort.Slice(res.DeploymentHashes, func(i, j int) bool {
 		return res.DeploymentHashes[i] < res.DeploymentHashes[j]
 	})
+
+	for _, farm := range data.Farms {
+		res.farmIds = append(res.farmIds, farm.FarmID)
+		res.farmNames = append(res.farmNames, farm.Name)
+	}
 	return
 }
 

--- a/grid-proxy/tests/queries/mock_client/contracts.go
+++ b/grid-proxy/tests/queries/mock_client/contracts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
 )
@@ -20,7 +21,7 @@ func (g *GridProxyMockClient) Contracts(ctx context.Context, filter types.Contra
 	}
 
 	for _, contract := range g.data.NodeContracts {
-		if contract.satisfies(filter) {
+		if contract.satisfies(filter, g.data.Nodes, g.data.Farms) {
 			contract := types.Contract{
 				ContractID: uint(contract.ContractID),
 				TwinID:     uint(contract.TwinID),
@@ -32,6 +33,8 @@ func (g *GridProxyMockClient) Contracts(ctx context.Context, filter types.Contra
 					DeploymentData:    contract.DeploymentData,
 					DeploymentHash:    contract.DeploymentHash,
 					NumberOfPublicIps: uint(contract.NumberOfPublicIPs),
+					FarmName:          g.data.Farms[g.data.Nodes[contract.NodeID].FarmID].Name,
+					FarmId:            g.data.Nodes[contract.NodeID].FarmID,
 				},
 			}
 			res = append(res, contract)
@@ -39,7 +42,7 @@ func (g *GridProxyMockClient) Contracts(ctx context.Context, filter types.Contra
 	}
 
 	for _, contract := range g.data.RentContracts {
-		if contract.satisfies(filter) {
+		if contract.satisfies(filter, g.data.Nodes, g.data.Farms) {
 			contract := types.Contract{
 				ContractID: uint(contract.ContractID),
 				TwinID:     uint(contract.TwinID),
@@ -47,7 +50,9 @@ func (g *GridProxyMockClient) Contracts(ctx context.Context, filter types.Contra
 				CreatedAt:  uint(contract.CreatedAt),
 				Type:       "rent",
 				Details: types.RentContractDetails{
-					NodeID: uint(contract.NodeID),
+					NodeID:   uint(contract.NodeID),
+					FarmId:   g.data.Nodes[contract.NodeID].FarmID,
+					FarmName: g.data.Farms[g.data.Nodes[contract.NodeID].FarmID].Name,
 				},
 			}
 			res = append(res, contract)
@@ -79,7 +84,7 @@ func (g *GridProxyMockClient) Contracts(ctx context.Context, filter types.Contra
 	return
 }
 
-func (c *RentContract) satisfies(f types.ContractFilter) bool {
+func (c *RentContract) satisfies(f types.ContractFilter, nodes map[uint64]Node, farms map[uint64]Farm) bool {
 	if f.ContractID != nil && *f.ContractID != c.ContractID {
 		return false
 	}
@@ -116,10 +121,18 @@ func (c *RentContract) satisfies(f types.ContractFilter) bool {
 		return false
 	}
 
+	if f.FarmId != nil && *f.FarmId != nodes[c.NodeID].FarmID {
+		return false
+	}
+
+	if f.FarmName != nil && !strings.EqualFold(*f.FarmName, farms[nodes[c.NodeID].FarmID].Name) {
+		return false
+	}
+
 	return true
 }
 
-func (c *NodeContract) satisfies(f types.ContractFilter) bool {
+func (c *NodeContract) satisfies(f types.ContractFilter, nodes map[uint64]Node, farms map[uint64]Farm) bool {
 	if f.ContractID != nil && *f.ContractID != c.ContractID {
 		return false
 	}
@@ -153,6 +166,14 @@ func (c *NodeContract) satisfies(f types.ContractFilter) bool {
 	}
 
 	if f.DeploymentHash != nil && *f.DeploymentHash != c.DeploymentHash {
+		return false
+	}
+
+	if f.FarmId != nil && *f.FarmId != nodes[c.NodeID].FarmID {
+		return false
+	}
+
+	if f.FarmName != nil && !strings.EqualFold(*f.FarmName, farms[nodes[c.NodeID].FarmID].Name) {
 		return false
 	}
 
@@ -196,6 +217,14 @@ func (c *NameContract) satisfies(f types.ContractFilter) bool {
 		return false
 	}
 
+	if f.FarmId != nil && *f.FarmId != 0 {
+		return false
+	}
+
+	if f.FarmName != nil && *f.FarmName != "" {
+		return false
+	}
+
 	return true
 }
 
@@ -214,6 +243,8 @@ func (g *GridProxyMockClient) Contract(ctx context.Context, contractID uint32) (
 				DeploymentData:    nodeContract.DeploymentData,
 				DeploymentHash:    nodeContract.DeploymentHash,
 				NumberOfPublicIps: uint(nodeContract.NumberOfPublicIPs),
+				FarmId:            g.data.Nodes[nodeContract.NodeID].FarmID,
+				FarmName:          g.data.Farms[g.data.Nodes[nodeContract.NodeID].FarmID].Name,
 			},
 		}, err
 	}
@@ -241,7 +272,9 @@ func (g *GridProxyMockClient) Contract(ctx context.Context, contractID uint32) (
 			CreatedAt:  uint(rentContract.CreatedAt),
 			Type:       "rent",
 			Details: types.RentContractDetails{
-				NodeID: uint(rentContract.NodeID),
+				NodeID:   uint(rentContract.NodeID),
+				FarmId:   g.data.Nodes[nodeContract.NodeID].FarmID,
+				FarmName: g.data.Farms[g.data.Nodes[nodeContract.NodeID].FarmID].Name,
 			},
 		}, err
 	}


### PR DESCRIPTION
### Description
add farm name/id to contract endpoint response

### Changes
- add the new fields on the details object for both rent/node contract
- join contract table with the correlated farm table and filter based on its values
- add tests for the new fields/filters

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/919

### Checklist

- [x] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstring
