### PR TITLE
fix grid-client network state

### DIFF
--- a/grid-client/deployer/deployer_test.go
+++ b/grid-client/deployer/deployer_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	substrate "github.com/threefoldtech/tfchain/clients/tfchain-client-go"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/mocks"
 	client "github.com/threefoldtech/tfgrid-sdk-go/grid-client/node"
@@ -122,7 +123,9 @@ func mockDeployerValidator(d *Deployer, ctrl *gomock.Controller, nodes []uint32)
 
 func TestDeployer(t *testing.T) {
 	tfPluginClient, err := setup()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Skipf("failed to create plugin client: %v", err)
+	}
 
 	identity := tfPluginClient.Identity
 	twinID := tfPluginClient.TwinID
@@ -145,9 +148,9 @@ func TestDeployer(t *testing.T) {
 
 	t.Run("test create", func(t *testing.T) {
 		dl1, err := deploymentWithNameGateway(identity, twinID, true, 0, backendURLWithTLSPassthrough)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		dl2, err := deploymentWithFQDN(identity, twinID, 0)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		newDls := map[uint32]gridtypes.Deployment{
 			10: dl1,

--- a/grid-client/deployer/deployment_deployer.go
+++ b/grid-client/deployer/deployment_deployer.go
@@ -309,7 +309,7 @@ func (d *DeploymentDeployer) assignPrivateIPs(ctx context.Context, dls []*worklo
 
 	usedHosts, err := d.calculateNetworksUsedIPs(ctx, dls)
 	if err != nil {
-		return errors.Wrap(err, "couldn't calculate network used ips")
+		errs = multierror.Append(errs, errors.Wrap(err, "couldn't calculate networks used ips"))
 	}
 
 	for _, dl := range dls {

--- a/grid-client/deployer/deployment_deployer.go
+++ b/grid-client/deployer/deployment_deployer.go
@@ -170,7 +170,7 @@ func (d *DeploymentDeployer) BatchDeploy(ctx context.Context, dls []*workloads.D
 	// error is not returned immediately before updating state because of untracked failed deployments
 	for _, dl := range dls {
 		if err := d.updateStateFromDeployments(ctx, dl, newDls); err != nil {
-			return errors.Wrapf(err, "failed to update deployment '%s' state", dl.Name)
+			multiErr = multierror.Append(multiErr, errors.Wrapf(err, "failed to update deployment '%s' state", dl.Name))
 		}
 	}
 

--- a/grid-client/deployer/deployment_deployer.go
+++ b/grid-client/deployer/deployment_deployer.go
@@ -315,6 +315,7 @@ func (d *DeploymentDeployer) assignPrivateIPs(ctx context.Context, dls []*worklo
 
 	for _, dl := range dls {
 		if len(dl.Vms) == 0 {
+			newdls = append(newdls, dl)
 			continue
 		}
 

--- a/grid-client/deployer/deployment_deployer.go
+++ b/grid-client/deployer/deployment_deployer.go
@@ -65,12 +65,12 @@ func (d *DeploymentDeployer) GenerateVersionlessDeployments(ctx context.Context,
 	var mu sync.Mutex
 	var errs error
 
-	dls, err := d.assignPrivateIPs(ctx, dls)
+	newDls, err := d.assignPrivateIPs(ctx, dls)
 	if err != nil {
 		errs = multierror.Append(errs, errors.Wrap(err, "failed to assign node ips"))
 	}
 
-	for _, dl := range dls {
+	for _, dl := range newDls {
 		wg.Add(1)
 		go func(dl *workloads.Deployment) {
 			defer wg.Done()
@@ -303,11 +303,10 @@ func (d *DeploymentDeployer) calculateNetworksUsedIPs(ctx context.Context, dls [
 }
 
 func (d *DeploymentDeployer) assignPrivateIPs(ctx context.Context, dls []*workloads.Deployment) ([]*workloads.Deployment, error) {
+	var newdls []*workloads.Deployment
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var errs error
-
-	var newdls []*workloads.Deployment
 
 	usedHosts, err := d.calculateNetworksUsedIPs(ctx, dls)
 	if err != nil {

--- a/grid-client/deployer/deployment_deployer_test.go
+++ b/grid-client/deployer/deployment_deployer_test.go
@@ -333,9 +333,11 @@ func TestDeploymentDeployerDeploy(t *testing.T) {
 		assert.NoError(t, err)
 
 		d.tfPluginClient.State.CurrentNodeDeployments[nodeID] = append(d.tfPluginClient.State.CurrentNodeDeployments[nodeID], netContractID)
-		d.tfPluginClient.State.Networks = state.NetworkState{net.Name: state.Network{
-			Subnets: map[uint32]string{nodeID: net.IPRange.String()},
-		}}
+		d.tfPluginClient.State.Networks = state.NetworkState{
+			State: map[string]state.Network{net.Name: {
+				Subnets: map[uint32]string{nodeID: net.IPRange.String()},
+			}},
+		}
 
 		ncPool.EXPECT().
 			GetNodeClient(sub, nodeID).
@@ -495,11 +497,9 @@ func TestDeploymentDeployerSync(t *testing.T) {
 
 		d.tfPluginClient.State.CurrentNodeDeployments[nodeID] = append(d.tfPluginClient.State.CurrentNodeDeployments[nodeID], contractID)
 		d.tfPluginClient.State.Networks = state.NetworkState{
-			net.Name: state.Network{
-				Subnets: map[uint32]string{
-					nodeID: net.IPRange.String(),
-				},
-			},
+			State: map[string]state.Network{net.Name: {
+				Subnets: map[uint32]string{nodeID: net.IPRange.String()},
+			}},
 		}
 
 		ncPool.EXPECT().

--- a/grid-client/deployer/k8s_deployer_test.go
+++ b/grid-client/deployer/k8s_deployer_test.go
@@ -55,9 +55,11 @@ func constructTestK8s(t *testing.T, mock bool) (
 		tfPluginClient.K8sDeployer.tfPluginClient = &tfPluginClient
 	}
 	net := constructTestNetwork()
-	tfPluginClient.State.Networks = state.NetworkState{net.Name: state.Network{
-		Subnets: map[uint32]string{nodeID: net.IPRange.String()},
-	}}
+	tfPluginClient.State.Networks = state.NetworkState{
+		State: map[string]state.Network{net.Name: {
+			Subnets: map[uint32]string{nodeID: net.IPRange.String()},
+		}},
+	}
 
 	return tfPluginClient.K8sDeployer, cl, sub, ncPool, deployer, gridProxyCl
 }

--- a/grid-client/state/network_state.go
+++ b/grid-client/state/network_state.go
@@ -10,7 +10,7 @@ import (
 // NetworkState is a struct of networks names and their networks and mutex to protect the state
 type NetworkState struct {
 	State     map[string]Network
-	StateLock sync.Mutex
+	stateLock sync.Mutex
 }
 
 // Network struct includes Subnets and node IPs
@@ -27,8 +27,8 @@ func NewNetwork() Network {
 
 // GetNetwork get a Network using its name
 func (nm *NetworkState) GetNetwork(networkName string) Network {
-	nm.StateLock.Lock()
-	defer nm.StateLock.Unlock()
+	nm.stateLock.Lock()
+	defer nm.stateLock.Unlock()
 
 	if _, ok := nm.State[networkName]; !ok {
 		nm.State[networkName] = NewNetwork()
@@ -45,15 +45,15 @@ func (nm *NetworkState) UpdateNetworkSubnets(networkName string, ipRange map[uin
 		network.SetNodeSubnet(nodeID, subnet.String())
 	}
 
-	nm.StateLock.Lock()
-	defer nm.StateLock.Unlock()
+	nm.stateLock.Lock()
+	defer nm.stateLock.Unlock()
 	nm.State[networkName] = network
 }
 
 // DeleteNetwork deletes a Network using its name
 func (nm *NetworkState) DeleteNetwork(networkName string) {
-	nm.StateLock.Lock()
-	defer nm.StateLock.Unlock()
+	nm.stateLock.Lock()
+	defer nm.stateLock.Unlock()
 	delete(nm.State, networkName)
 }
 

--- a/grid-client/state/network_state_test.go
+++ b/grid-client/state/network_state_test.go
@@ -3,6 +3,7 @@ package state
 
 import (
 	"net"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,9 +30,16 @@ func TestNetworkState(t *testing.T) {
 	net := constructTestNetwork()
 	nodeID = net.Nodes[0]
 
-	networkState := NetworkState{net.Name: Network{
+	networkState := NetworkState{
+		State:     make(map[string]Network),
+		StateLock: sync.Mutex{},
+	}
+
+	networkState.State[net.Name] = Network{
 		Subnets: map[uint32]string{nodeID: net.IPRange.String()},
-	}}
+	}
+
+	// networkState := NetworkState{net.Name: }
 	network := networkState.GetNetwork(net.Name)
 
 	assert.Equal(t, network.GetNodeSubnet(nodeID), net.IPRange.String())

--- a/grid-client/state/network_state_test.go
+++ b/grid-client/state/network_state_test.go
@@ -3,7 +3,6 @@ package state
 
 import (
 	"net"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,15 +30,11 @@ func TestNetworkState(t *testing.T) {
 	nodeID = net.Nodes[0]
 
 	networkState := NetworkState{
-		State:     make(map[string]Network),
-		StateLock: sync.Mutex{},
+		State: map[string]Network{
+			net.Name: {Subnets: map[uint32]string{nodeID: net.IPRange.String()}},
+		},
 	}
 
-	networkState.State[net.Name] = Network{
-		Subnets: map[uint32]string{nodeID: net.IPRange.String()},
-	}
-
-	// networkState := NetworkState{net.Name: }
 	network := networkState.GetNetwork(net.Name)
 
 	assert.Equal(t, network.GetNodeSubnet(nodeID), net.IPRange.String())

--- a/grid-client/state/state.go
+++ b/grid-client/state/state.go
@@ -38,7 +38,7 @@ var ErrNotFound = errors.New("not found")
 func NewState(ncPool client.NodeClientGetter, substrate subi.SubstrateExt) *State {
 	return &State{
 		CurrentNodeDeployments: make(map[uint32]ContractIDs),
-		Networks:               NetworkState{},
+		Networks:               NetworkState{State: make(map[string]Network)},
 		NcPool:                 ncPool,
 		Substrate:              substrate,
 	}

--- a/tfrobot/pkg/deployer/deployer.go
+++ b/tfrobot/pkg/deployer/deployer.go
@@ -185,11 +185,13 @@ func massDeploy(ctx context.Context, tfPluginClient deployer.TFPluginClient, dep
 
 	log.Debug().Msg(fmt.Sprintf("Deploying %d networks, this may to take a while", len(deployments.networkDeployments)))
 	if err := tfPluginClient.NetworkDeployer.BatchDeploy(ctx, networks, false); err != nil {
+		log.Debug().Err(err).Send()
 		multiErr = multierror.Append(multiErr, err)
 	}
 
 	log.Debug().Msg(fmt.Sprintf("Deploying %d virtual machines, this may to take a while", len(deployments.vmDeployments)))
 	if err := tfPluginClient.DeploymentDeployer.BatchDeploy(ctx, vms); err != nil {
+		log.Debug().Err(err).Send()
 		multiErr = multierror.Append(multiErr, err)
 	}
 


### PR DESCRIPTION
### Description

- tried to test the client update and found multiple races while deployment

### Changes

- added a lock to network state to prevent any races to the state map
- update `DeploymentDeployer.BatchDeploy` to append errors and not return

### Related Issues

List of related issues

### Checklist

- [x] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstring
