### PR TITLE
allow sorting nodes with the free_cru

### DIFF
--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -642,7 +642,9 @@ func (d *PostgresDatabase) GetNodes(ctx context.Context, filter types.NodeFilter
 			}
 
 			if limit.SortBy == "status" {
-				q.Order(nodestatus.DecideNodeStatusOrdering(order))
+				q = q.Order(nodestatus.DecideNodeStatusOrdering(order))
+			} else if limit.SortBy == "free_cru" {
+				q = q.Order(fmt.Sprintf("total_cru-used_cru %s", order))
 			} else {
 				q = q.Order(fmt.Sprintf("%s %s", limit.SortBy, order))
 			}

--- a/grid-proxy/pkg/types/nodes.go
+++ b/grid-proxy/pkg/types/nodes.go
@@ -48,6 +48,7 @@ type Node struct {
 	ExtraFee          uint64       `json:"extraFee" sort:"extra_fee"`
 	Healthy           bool         `json:"healthy"`
 	PriceUsd          float64      `json:"price_usd" sort:"price_usd"`
+	_                 string       `sort:"free_cru"`
 }
 
 // CapacityResult is the NodeData capacity results to unmarshal json in it


### PR DESCRIPTION


### Description
allow sorting nodes with the free_cru

### Changes
- add new sort param `free_cru`
- add new order query to sort based on `total_cru-used_cru`

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/918

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
