### PR TITLE
update gateways metadata to match other clients

### DIFF
--- a/grid-client/deployer/gateway_fqdn_deployer_test.go
+++ b/grid-client/deployer/gateway_fqdn_deployer_test.go
@@ -142,7 +142,7 @@ func TestFQDNDeployer(t *testing.T) {
 				}),
 			},
 		})
-		testDl.Metadata = "{\"version\":3,\"type\":\"Gateway Fqdn\",\"name\":\"name\",\"projectName\":\"Gateway\"}"
+		testDl.Metadata = "{\"version\":3,\"type\":\"Gateway Fqdn\",\"name\":\"name\",\"projectName\":\"name\"}"
 
 		assert.Equal(t, dls, map[uint32]gridtypes.Deployment{
 			nodeID: testDl,

--- a/grid-client/deployer/gateway_name_deployer_test.go
+++ b/grid-client/deployer/gateway_name_deployer_test.go
@@ -123,7 +123,7 @@ func TestNameDeployer(t *testing.T) {
 				}),
 			},
 		})
-		testDl.Metadata = "{\"version\":3,\"type\":\"Gateway Name\",\"name\":\"name\",\"projectName\":\"Gateway\"}"
+		testDl.Metadata = "{\"version\":3,\"type\":\"Gateway Name\",\"name\":\"name\",\"projectName\":\"name\"}"
 
 		assert.Equal(t, dls, map[uint32]gridtypes.Deployment{
 			nodeID: testDl,

--- a/grid-client/workloads/gateway_fqdn.go
+++ b/grid-client/workloads/gateway_fqdn.go
@@ -84,7 +84,7 @@ func (g *GatewayFQDNProxy) ZosWorkload() gridtypes.Workload {
 // GenerateMetadata generates gateway deployment metadata
 func (g *GatewayFQDNProxy) GenerateMetadata() (string, error) {
 	if len(g.SolutionType) == 0 {
-		g.SolutionType = "Gateway"
+		g.SolutionType = g.Name
 	}
 
 	deploymentData := DeploymentData{

--- a/grid-client/workloads/gateway_name.go
+++ b/grid-client/workloads/gateway_name.go
@@ -91,7 +91,7 @@ func (g *GatewayNameProxy) ZosWorkload() gridtypes.Workload {
 // GenerateMetadata generates gateway deployment metadata
 func (g *GatewayNameProxy) GenerateMetadata() (string, error) {
 	if len(g.SolutionType) == 0 {
-		g.SolutionType = "Gateway"
+		g.SolutionType = g.Name
 	}
 
 	deploymentData := DeploymentData{


### PR DESCRIPTION
### Description

update name gateways and fqdn gateways default solution type to be the name of the gateway to match the other clients

### Changes

update name gateways and fqdn gateways default solution type to be the name of the gateway to match the other clients

### Related Issues

- #828 

### Checklist

- [x] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstring
