### PR TITLE
fix the ipv6 indexer

### DIFF
--- a/grid-proxy/CHANGELOG.md
+++ b/grid-proxy/CHANGELOG.md
@@ -12,6 +12,12 @@ Check `/version` on any instance to know the version.
 
 ## Releases
 
+### v0.15.2
+
+---
+
+- `fix` ipv6 indexer (default interval, rmb call result)
+
 ### v0.15.1
 
 ---

--- a/grid-proxy/charts/gridproxy/Chart.yaml
+++ b/grid-proxy/charts/gridproxy/Chart.yaml
@@ -20,6 +20,6 @@ version: 1.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.15.1
+appVersion: 0.15.2
 
 # make sure to update the changelog with the changes in this release

--- a/grid-proxy/cmds/proxy_server/main.go
+++ b/grid-proxy/cmds/proxy_server/main.go
@@ -101,7 +101,7 @@ func main() {
 	flag.UintVar(&f.dmiIndexerNumWorkers, "dmi-indexer-workers", 1, "number of workers checking on node dmi")
 	flag.UintVar(&f.speedIndexerIntervalMins, "speed-indexer-interval", 5, "node speed check interval in min")
 	flag.UintVar(&f.speedIndexerNumWorkers, "speed-indexer-workers", 100, "number of workers checking on node speed")
-	flag.UintVar(&f.ipv6IndexerIntervalMins, "ipv6-indexer-interval", 1, "node ipv6 check interval in min")
+	flag.UintVar(&f.ipv6IndexerIntervalMins, "ipv6-indexer-interval", 60*24, "node ipv6 check interval in min")
 	flag.UintVar(&f.ipv6IndexerNumWorkers, "ipv6-indexer-workers", 10, "number of workers checking on node having ipv6")
 	flag.Parse()
 

--- a/grid-proxy/internal/indexer/ipv6.go
+++ b/grid-proxy/internal/indexer/ipv6.go
@@ -31,7 +31,7 @@ func (w *Ipv6Work) Finders() map[string]time.Duration {
 
 func (w *Ipv6Work) Get(ctx context.Context, rmb *peer.RpcClient, id uint32) ([]types.HasIpv6, error) {
 	var has_ipv6 bool
-	if err := callNode(ctx, rmb, cmd, nil, id, has_ipv6); err != nil {
+	if err := callNode(ctx, rmb, cmd, nil, id, &has_ipv6); err != nil {
 		return []types.HasIpv6{}, nil
 	}
 


### PR DESCRIPTION

### Description
- fix the ipv6 indexer default duration
- fix the ipv6 rmb call result


### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/926

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
