### PR TITLE
add twin consumption calculation 

### DIFF
--- a/grid-proxy/docs/docs.go
+++ b/grid-proxy/docs/docs.go
@@ -1424,6 +1424,50 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/twins/{twin_id}/consumption": {
+            "get": {
+                "description": "Get a report of user spent for last hour and for lifetime",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "TwinConsumption"
+                ],
+                "summary": "Show a report for user consumption",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.TwinConsumption"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1526,6 +1570,9 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "amountBilled": {
+                    "type": "integer"
+                },
+                "contract_id": {
                     "type": "integer"
                 },
                 "discountReceived": {
@@ -2044,6 +2091,17 @@ const docTemplate = `{
                 },
                 "twinId": {
                     "type": "integer"
+                }
+            }
+        },
+        "types.TwinConsumption": {
+            "type": "object",
+            "properties": {
+                "last_hour_consumption": {
+                    "type": "number"
+                },
+                "overall_consumption": {
+                    "type": "number"
                 }
             }
         }

--- a/grid-proxy/docs/swagger.json
+++ b/grid-proxy/docs/swagger.json
@@ -1416,6 +1416,50 @@
                     }
                 }
             }
+        },
+        "/twins/{twin_id}/consumption": {
+            "get": {
+                "description": "Get a report of user spent for last hour and for lifetime",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "TwinConsumption"
+                ],
+                "summary": "Show a report for user consumption",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.TwinConsumption"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1518,6 +1562,9 @@
             "type": "object",
             "properties": {
                 "amountBilled": {
+                    "type": "integer"
+                },
+                "contract_id": {
                     "type": "integer"
                 },
                 "discountReceived": {
@@ -2036,6 +2083,17 @@
                 },
                 "twinId": {
                     "type": "integer"
+                }
+            }
+        },
+        "types.TwinConsumption": {
+            "type": "object",
+            "properties": {
+                "last_hour_consumption": {
+                    "type": "number"
+                },
+                "overall_consumption": {
+                    "type": "number"
                 }
             }
         }

--- a/grid-proxy/docs/swagger.yaml
+++ b/grid-proxy/docs/swagger.yaml
@@ -68,6 +68,8 @@ definitions:
     properties:
       amountBilled:
         type: integer
+      contract_id:
+        type: integer
       discountReceived:
         type: string
       timestamp:
@@ -408,6 +410,13 @@ definitions:
         type: string
       twinId:
         type: integer
+    type: object
+  types.TwinConsumption:
+    properties:
+      last_hour_consumption:
+        type: number
+      overall_consumption:
+        type: number
     type: object
 info:
   contact: {}
@@ -1378,4 +1387,33 @@ paths:
       summary: Show twins on the grid
       tags:
       - GridProxy
+  /twins/{twin_id}/consumption:
+    get:
+      consumes:
+      - application/json
+      description: Get a report of user spent for last hour and for lifetime
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.TwinConsumption'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "404":
+          description: Not Found
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Show a report for user consumption
+      tags:
+      - TwinConsumption
 swagger: "2.0"

--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -937,3 +937,14 @@ func (d *PostgresDatabase) GetContractReports(ctx context.Context, contractsIds 
 
 	return reports, nil
 }
+
+func (d *PostgresDatabase) GetContractsTotalBilledAmount(ctx context.Context, contractIds []uint32) (uint64, error) {
+	q := d.gormDB.Raw(`SELECT sum(amount_billed) FROM contract_bill_report WHERE contract_id IN (?);`, contractIds)
+
+	var total uint64
+	if res := q.Scan(&total); res.Error != nil {
+		return 0, res.Error
+	}
+
+	return total, nil
+}

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -20,7 +20,7 @@ type Database interface {
 	GetContracts(ctx context.Context, filter types.ContractFilter, limit types.Limit) ([]DBContract, uint, error)
 	GetContract(ctx context.Context, contractID uint32) (DBContract, error)
 	GetContractBills(ctx context.Context, contractID uint32, limit types.Limit) ([]ContractBilling, uint, error)
-	GetContractReports(ctx context.Context, contractsIds []uint32, limit uint) ([]ContractBilling, error)
+	GetContractsLatestBillReports(ctx context.Context, contractsIds []uint32, limit uint) ([]ContractBilling, error)
 	GetContractsTotalBilledAmount(ctx context.Context, contractIds []uint32) (uint64, error)
 
 	// indexer utils

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -21,6 +21,7 @@ type Database interface {
 	GetContract(ctx context.Context, contractID uint32) (DBContract, error)
 	GetContractBills(ctx context.Context, contractID uint32, limit types.Limit) ([]ContractBilling, uint, error)
 	GetContractReports(ctx context.Context, contractsIds []uint32, limit uint) ([]ContractBilling, error)
+	GetContractsTotalBilledAmount(ctx context.Context, contractIds []uint32) (uint64, error)
 
 	// indexer utils
 	DeleteOldGpus(ctx context.Context, nodeTwinIds []uint32, expiration int64) error

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -20,6 +20,7 @@ type Database interface {
 	GetContracts(ctx context.Context, filter types.ContractFilter, limit types.Limit) ([]DBContract, uint, error)
 	GetContract(ctx context.Context, contractID uint32) (DBContract, error)
 	GetContractBills(ctx context.Context, contractID uint32, limit types.Limit) ([]ContractBilling, uint, error)
+	GetContractReports(ctx context.Context, contractsIds []uint32, limit uint) ([]ContractBilling, error)
 
 	// indexer utils
 	DeleteOldGpus(ctx context.Context, nodeTwinIds []uint32, expiration int64) error

--- a/grid-proxy/internal/explorer/db_client.go
+++ b/grid-proxy/internal/explorer/db_client.go
@@ -131,35 +131,31 @@ func (c *DBClient) Stats(ctx context.Context, filter types.StatsFilter) (types.S
 	return c.DB.GetStats(ctx, filter)
 }
 
-func (c *DBClient) GetTwinFees(ctx context.Context, twinId uint64) (types.TwinFee, error) {
-	// get all contracts for a twin id
-	filter := types.ContractFilter{
-		TwinID: &twinId,
-		State:  []string{"Created", "GracePeriod", "Deleted"},
-	}
-	limit := types.Limit{
-		Size: 99999,
-	}
+func (c *DBClient) GetTwinConsumption(ctx context.Context, twinId uint64) (types.TwinConsumption, error) {
+	// get all twin contracts
+	maxContractSize := uint64(999999999)
+	filter := types.ContractFilter{TwinID: &twinId}
+	limit := types.Limit{Size: maxContractSize}
 	twinContracts, _, err := c.DB.GetContracts(ctx, filter, limit)
 	if err != nil {
-		return types.TwinFee{}, err
+		return types.TwinConsumption{}, err
 	}
 
-	nonDeletedCIds := []uint32{}
-	allCIds := []uint32{}
 	contracts := make(map[uint32]db.DBContract)
+	allCIds := []uint32{}
+	nonDeletedCIds := []uint32{}
 	for _, contract := range twinContracts {
+		contracts[uint32(contract.ContractID)] = contract
+		allCIds = append(allCIds, uint32(contract.ContractID))
 		if contract.State != "Deleted" {
 			nonDeletedCIds = append(nonDeletedCIds, uint32(contract.ContractID))
 		}
-		allCIds = append(allCIds, uint32(contract.ContractID))
-		contracts[uint32(contract.ContractID)] = contract
 	}
 
-	// get the latest two reports for each contract
-	reports, err := c.DB.GetContractReports(ctx, nonDeletedCIds, 2)
+	// get the latest two reports for each active contract
+	reports, err := c.DB.GetContractsLatestBillReports(ctx, nonDeletedCIds, 2)
 	if err != nil {
-		return types.TwinFee{}, err
+		return types.TwinConsumption{}, err
 	}
 
 	contractReports := make(map[uint32][]db.ContractBilling)
@@ -167,36 +163,20 @@ func (c *DBClient) GetTwinFees(ctx context.Context, twinId uint64) (types.TwinFe
 		contractReports[uint32(report.ContractId)] = append(contractReports[uint32(report.ContractId)], report)
 	}
 
-	// calc bills
-	var fee types.TwinFee
+	// calc contract billed amount and sum
+	var consumption types.TwinConsumption
 	for _, id := range nonDeletedCIds {
-		contractFee := calcContractFee(contracts[id], contractReports[id])
-		fee.LastHourSpent += contractFee
+		contractConsumption := calcContractConsumption(contracts[id], contractReports[id])
+		consumption.LastHourConsumption += contractConsumption
 	}
 
-	// calc all spent
-	spent, err := c.DB.GetContractsTotalBilledAmount(ctx, allCIds)
+	// calc all spent amounts
+	totalAmount, err := c.DB.GetContractsTotalBilledAmount(ctx, allCIds)
 	if err != nil {
-		return types.TwinFee{}, err
+		return types.TwinConsumption{}, err
 	}
 
-	fee.TotalSpend = float64(spent) / math.Pow(10, 7)
+	consumption.OverallConsumption = float64(totalAmount) / math.Pow(10, 7)
 
-	return fee, err
-}
-
-func calcContractFee(c db.DBContract, latestBills []db.ContractBilling) float64 {
-	var duration float64
-	switch len(latestBills) {
-	case 0:
-		return 0
-	case 1:
-		duration = float64(latestBills[0].Timestamp-uint64(c.CreatedAt)) / float64(3600)
-	case 2:
-		duration = float64(latestBills[0].Timestamp-latestBills[1].Timestamp) / float64(3600)
-	default:
-		duration = 1
-	}
-
-	return float64(latestBills[0].AmountBilled) / duration / math.Pow(10, 7)
+	return consumption, err
 }

--- a/grid-proxy/internal/explorer/helpers.go
+++ b/grid-proxy/internal/explorer/helpers.go
@@ -88,3 +88,20 @@ func (a *App) getContractBillsData(ctx context.Context, contractIDStr string, li
 
 	return bills, billsCount, nil
 }
+
+// calcContractConsumption for the last hour
+func calcContractConsumption(c db.DBContract, latestBills []db.ContractBilling) float64 {
+	var duration float64
+	switch len(latestBills) {
+	case 0:
+		return 0
+	case 1:
+		duration = float64(latestBills[0].Timestamp-uint64(c.CreatedAt)) / float64(3600)
+	case 2:
+		duration = float64(latestBills[0].Timestamp-latestBills[1].Timestamp) / float64(3600)
+	default:
+		duration = 1
+	}
+
+	return float64(latestBills[0].AmountBilled) / duration / math.Pow(10, 7)
+}

--- a/grid-proxy/internal/explorer/server.go
+++ b/grid-proxy/internal/explorer/server.go
@@ -327,6 +327,21 @@ func (a *App) listTwins(r *http.Request) (interface{}, mw.Response) {
 	return twins, resp
 }
 
+func (a *App) getTwinFees(r *http.Request) (interface{}, mw.Response) {
+	twinIdStr := mux.Vars(r)["twin_id"]
+	twinId, err := strconv.Atoi(twinIdStr)
+	if err != nil {
+		return types.TwinFee{}, mw.BadRequest(err)
+	}
+
+	fees, err := a.cl.GetTwinFees(r.Context(), uint64(twinId))
+	if err != nil {
+		return types.TwinFee{}, errorReply(err)
+	}
+
+	return fees, nil
+}
+
 // listContracts godoc
 // @Summary Show contracts on the grid
 // @Description Get all contracts on the grid, It has pagination
@@ -550,7 +565,9 @@ func Setup(router *mux.Router, gitCommit string, cl DBClient, relayClient rmb.Cl
 
 	router.HandleFunc("/farms", mw.AsHandlerFunc(a.listFarms))
 	router.HandleFunc("/stats", mw.AsHandlerFunc(a.getStats))
+
 	router.HandleFunc("/twins", mw.AsHandlerFunc(a.listTwins))
+	router.HandleFunc("/twins/{twin_id:[0-9]+}/fees", mw.AsHandlerFunc(a.getTwinFees))
 
 	router.HandleFunc("/nodes", mw.AsHandlerFunc(a.getNodes))
 	router.HandleFunc("/nodes/{node_id:[0-9]+}", mw.AsHandlerFunc(a.getNode))

--- a/grid-proxy/internal/explorer/server.go
+++ b/grid-proxy/internal/explorer/server.go
@@ -327,19 +327,30 @@ func (a *App) listTwins(r *http.Request) (interface{}, mw.Response) {
 	return twins, resp
 }
 
-func (a *App) getTwinFees(r *http.Request) (interface{}, mw.Response) {
+// getTwinConsumption godoc
+// @Summary Show a report for user consumption
+// @Description Get a report of user spent for last hour and for lifetime
+// @Tags TwinConsumption
+// @Accept  json
+// @Produce  json
+// @Success 200 {object} []types.TwinConsumption
+// @Failure 400 {object} string
+// @Failure 404 {object} string
+// @Failure 500 {object} string
+// @Router /twins/{twin_id}/consumption [get]
+func (a *App) getTwinConsumption(r *http.Request) (interface{}, mw.Response) {
 	twinIdStr := mux.Vars(r)["twin_id"]
 	twinId, err := strconv.Atoi(twinIdStr)
 	if err != nil {
-		return types.TwinFee{}, mw.BadRequest(err)
+		return types.TwinConsumption{}, mw.BadRequest(err)
 	}
 
-	fees, err := a.cl.GetTwinFees(r.Context(), uint64(twinId))
+	consumptions, err := a.cl.GetTwinConsumption(r.Context(), uint64(twinId))
 	if err != nil {
-		return types.TwinFee{}, errorReply(err)
+		return types.TwinConsumption{}, errorReply(err)
 	}
 
-	return fees, nil
+	return consumptions, nil
 }
 
 // listContracts godoc
@@ -567,7 +578,7 @@ func Setup(router *mux.Router, gitCommit string, cl DBClient, relayClient rmb.Cl
 	router.HandleFunc("/stats", mw.AsHandlerFunc(a.getStats))
 
 	router.HandleFunc("/twins", mw.AsHandlerFunc(a.listTwins))
-	router.HandleFunc("/twins/{twin_id:[0-9]+}/fees", mw.AsHandlerFunc(a.getTwinFees))
+	router.HandleFunc("/twins/{twin_id:[0-9]+}/consumption", mw.AsHandlerFunc(a.getTwinConsumption))
 
 	router.HandleFunc("/nodes", mw.AsHandlerFunc(a.getNodes))
 	router.HandleFunc("/nodes/{node_id:[0-9]+}", mw.AsHandlerFunc(a.getNode))

--- a/grid-proxy/pkg/types/contracts.go
+++ b/grid-proxy/pkg/types/contracts.go
@@ -54,6 +54,7 @@ type ContractBilling struct {
 	AmountBilled     uint64 `json:"amountBilled"`
 	DiscountReceived string `json:"discountReceived"`
 	Timestamp        uint64 `json:"timestamp"`
+	ContractId       uint64 `json:"contract_id,omitempty"`
 }
 
 // ContractFilter contract filters

--- a/grid-proxy/pkg/types/twins.go
+++ b/grid-proxy/pkg/types/twins.go
@@ -15,3 +15,8 @@ type TwinFilter struct {
 	Relay     *string `schema:"relay,omitempty"`
 	PublicKey *string `schema:"public_key,omitempty"`
 }
+
+type TwinFee struct {
+	LastHourSpent uint64
+	TotalSpend    uint64
+}

--- a/grid-proxy/pkg/types/twins.go
+++ b/grid-proxy/pkg/types/twins.go
@@ -16,7 +16,8 @@ type TwinFilter struct {
 	PublicKey *string `schema:"public_key,omitempty"`
 }
 
-type TwinFee struct {
-	LastHourSpent float64
-	TotalSpend    float64
+// TwinConsumption show a report of user spent in TFT
+type TwinConsumption struct {
+	LastHourConsumption float64 `json:"last_hour_consumption"`
+	OverallConsumption  float64 `json:"overall_consumption"`
 }

--- a/grid-proxy/pkg/types/twins.go
+++ b/grid-proxy/pkg/types/twins.go
@@ -17,6 +17,6 @@ type TwinFilter struct {
 }
 
 type TwinFee struct {
-	LastHourSpent uint64
-	TotalSpend    uint64
+	LastHourSpent float64
+	TotalSpend    float64
 }


### PR DESCRIPTION
### Description
add `/twins/<twin_id>/consumptions` to report that spent fee for a twin

### Changes
- add new endpoint `/twins/<twin_id>/consumptions`
- add a db getter for specific twin contracts latest two bill reports
- add new method to `DbClient` to call the twin fees
- calc all spent fees 

### Related Issues
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/1020
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/1058

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
