### PR TITLE
update goreleaser tag from --rm-dist to --clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6.0.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           # GitHub sets this automatically
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
release workflow is failing
![image](https://github.com/threefoldtech/tfgrid-sdk-go/assets/32527347/06bf5465-bba3-4cf6-8e07-0978e1cadfeb)

looks the flag is deprecated 
https://goreleaser.com/deprecations/#-rm-dist


### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
