### PR TITLE
increase tfrobot workflow timeout

### DIFF
--- a/.github/workflows/tfrobot_test.yml
+++ b/.github/workflows/tfrobot_test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
 


### PR DESCRIPTION
### Description

workflow failed because older workflow couldn't cancel it's contracts

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
