### PR TITLE
support multiple stacks in proxy client

### DIFF
--- a/grid-client/graphql/graphql.go
+++ b/grid-client/graphql/graphql.go
@@ -16,8 +16,8 @@ import (
 
 // GraphQl for tf graphql
 type GraphQl struct {
-	urls []string
-	i    int
+	urls           []string
+	activeStackIdx int
 }
 
 // NewGraphQl new tf graphql
@@ -26,7 +26,7 @@ func NewGraphQl(urls ...string) (GraphQl, error) {
 		return GraphQl{}, errors.New("graphql url is required")
 	}
 
-	return GraphQl{urls: urls, i: 0}, nil
+	return GraphQl{urls: urls, activeStackIdx: 0}, nil
 }
 
 // GetItemTotalCount return count of items
@@ -122,7 +122,7 @@ func (g *GraphQl) httpPost(body io.Reader) (*http.Response, error) {
 	)
 
 	err := backoff.RetryNotify(func() error {
-		endpoint = g.urls[g.i]
+		endpoint = g.urls[g.activeStackIdx]
 		log.Debug().Str("url", endpoint).Msg("checking")
 
 		resp, reqErr = cl.Post(endpoint, "application/json", body)
@@ -130,7 +130,7 @@ func (g *GraphQl) httpPost(body io.Reader) (*http.Response, error) {
 			(errors.Is(reqErr, http.ErrAbortHandler) ||
 				errors.Is(reqErr, http.ErrHandlerTimeout) ||
 				errors.Is(reqErr, http.ErrServerClosed)) {
-			g.i = (g.i + 1) % len(g.urls)
+			g.activeStackIdx = (g.activeStackIdx + 1) % len(g.urls)
 			return reqErr
 		}
 

--- a/grid-proxy/go.mod
+++ b/grid-proxy/go.mod
@@ -3,6 +3,7 @@ module github.com/threefoldtech/tfgrid-sdk-go/grid-proxy
 go 1.21
 
 require (
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v3 v3.2.2
 	github.com/go-acme/lego/v4 v4.16.1
 	github.com/google/go-cmp v0.6.0
@@ -28,7 +29,6 @@ require (
 	github.com/ChainSafe/go-schnorrkel v1.1.0 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/centrifuge/go-substrate-rpc-client/v4 v4.0.12 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect

--- a/grid-proxy/pkg/client/grid_client.go
+++ b/grid-proxy/pkg/client/grid_client.go
@@ -21,10 +21,7 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
 )
 
-var (
-	encoder               *schema.Encoder
-	ErrProxyURLNotWorking = errors.New("failed to get a working proxy url")
-)
+var encoder *schema.Encoder
 
 func init() {
 	encoder = schema.NewEncoder()
@@ -69,10 +66,6 @@ func NewClient(endpoints ...string) Client {
 			endpoints[i] += "/"
 		}
 	}
-
-	rand.Shuffle(len(endpoints), func(i, j int) {
-		endpoints[i], endpoints[j] = endpoints[j], endpoints[i]
-	})
 
 	proxy := Clientimpl{
 		endpoints: endpoints,
@@ -123,23 +116,7 @@ func RequestPages(r *http.Response) (uint64, error) {
 
 // Ping makes sure the server is up
 func (g *Clientimpl) Ping() error {
-	url, err := g.prepareURL("ping")
-	if err != nil {
-		return errors.Wrap(err, "failed to prepare url")
-	}
-
-	return g.PingEndpoint(url)
-}
-
-func (g *Clientimpl) PingEndpoint(endpoint string) error {
-	client := g.newHTTPClient()
-
-	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
-	if err != nil {
-		return err
-	}
-
-	res, err := client.Do(req)
+	res, err := g.httpGet("ping")
 	if res != nil {
 		defer res.Body.Close()
 	}
@@ -148,27 +125,14 @@ func (g *Clientimpl) PingEndpoint(endpoint string) error {
 	}
 
 	if res.StatusCode != http.StatusOK {
-		err = parseError(res.Body)
-		return errors.Wrapf(err, "non ok return status code from the the grid proxy home page: %s", http.StatusText(res.StatusCode))
+		return fmt.Errorf("non ok return status code from the the grid proxy home page: %s", http.StatusText(res.StatusCode))
 	}
-
 	return nil
 }
 
 // Nodes returns nodes with the given filters and pagination parameters
 func (g *Clientimpl) Nodes(ctx context.Context, filter types.NodeFilter, limit types.Limit) (nodes []types.Node, totalCount int, err error) {
-	client := g.newHTTPClient()
-	url, err := g.prepareURL("nodes", filter, limit)
-	if err != nil {
-		return nil, 0, errors.Wrap(err, "failed to prepare url")
-	}
-
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return
-	}
-
-	res, err := client.Do(req)
+	res, err := g.httpGet("nodes", filter, limit)
 	if res != nil {
 		defer res.Body.Close()
 	}
@@ -190,18 +154,7 @@ func (g *Clientimpl) Nodes(ctx context.Context, filter types.NodeFilter, limit t
 
 // Farms returns farms with the given filters and pagination parameters
 func (g *Clientimpl) Farms(ctx context.Context, filter types.FarmFilter, limit types.Limit) (farms []types.Farm, totalCount int, err error) {
-	url, err := g.prepareURL("farms", filter, limit)
-	if err != nil {
-		return nil, 0, errors.Wrap(err, "failed to prepare url")
-	}
-
-	client := g.newHTTPClient()
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return
-	}
-
-	res, err := client.Do(req)
+	res, err := g.httpGet("farms", filter, limit)
 	if res != nil {
 		defer res.Body.Close()
 	}
@@ -227,18 +180,7 @@ func (g *Clientimpl) Farms(ctx context.Context, filter types.FarmFilter, limit t
 
 // Twins returns twins with the given filters and pagination parameters
 func (g *Clientimpl) Twins(ctx context.Context, filter types.TwinFilter, limit types.Limit) (twins []types.Twin, totalCount int, err error) {
-	url, err := g.prepareURL("twins", filter, limit)
-	if err != nil {
-		return nil, 0, errors.Wrap(err, "failed to prepare url")
-	}
-
-	client := g.newHTTPClient()
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return
-	}
-
-	res, err := client.Do(req)
+	res, err := g.httpGet("twins", filter, limit)
 	if res != nil {
 		defer res.Body.Close()
 	}
@@ -264,18 +206,7 @@ func (g *Clientimpl) Twins(ctx context.Context, filter types.TwinFilter, limit t
 
 // Contracts returns contracts with the given filters and pagination parameters
 func (g *Clientimpl) Contracts(ctx context.Context, filter types.ContractFilter, limit types.Limit) (contracts []types.Contract, totalCount int, err error) {
-	url, err := g.prepareURL("contracts", filter, limit)
-	if err != nil {
-		return nil, 0, errors.Wrap(err, "failed to prepare url")
-	}
-
-	client := g.newHTTPClient()
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return
-	}
-
-	res, err := client.Do(req)
+	res, err := g.httpGet("contracts", filter, limit)
 	if res != nil {
 		defer res.Body.Close()
 	}
@@ -298,23 +229,12 @@ func (g *Clientimpl) Contracts(ctx context.Context, filter types.ContractFilter,
 
 // Node returns the node with the give id
 func (g *Clientimpl) Node(ctx context.Context, nodeID uint32) (node types.NodeWithNestedCapacity, err error) {
-	client := g.newHTTPClient()
-	url, err := g.prepareURL(fmt.Sprintf("nodes/%d", nodeID))
-	if err != nil {
-		return types.NodeWithNestedCapacity{}, errors.Wrap(err, "failed to prepare url")
-	}
-
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return types.NodeWithNestedCapacity{}, fmt.Errorf("failed to create node request: %w", err)
-	}
-
-	res, err := client.Do(req)
+	res, err := g.httpGet(fmt.Sprintf("nodes/%d", nodeID))
 	if res != nil {
 		defer res.Body.Close()
 	}
 	if err != nil {
-		return types.NodeWithNestedCapacity{}, err
+		return
 	}
 
 	if res.StatusCode != http.StatusOK {
@@ -331,23 +251,12 @@ func (g *Clientimpl) Node(ctx context.Context, nodeID uint32) (node types.NodeWi
 
 // NodeStatus returns the node status up/down
 func (g *Clientimpl) NodeStatus(ctx context.Context, nodeID uint32) (status types.NodeStatus, err error) {
-	client := g.newHTTPClient()
-	url, err := g.prepareURL(fmt.Sprintf("nodes/%d/status", nodeID))
-	if err != nil {
-		return types.NodeStatus{}, errors.Wrap(err, "failed to prepare url")
-	}
-
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return types.NodeStatus{}, fmt.Errorf("failed to create nodes request: %w", err)
-	}
-
-	res, err := client.Do(req)
+	res, err := g.httpGet(fmt.Sprintf("nodes/%d/status", nodeID))
 	if res != nil {
 		defer res.Body.Close()
 	}
 	if err != nil {
-		return types.NodeStatus{}, err
+		return
 	}
 
 	if res.StatusCode != http.StatusOK {
@@ -362,23 +271,12 @@ func (g *Clientimpl) NodeStatus(ctx context.Context, nodeID uint32) (status type
 
 // Stats return statistics about the grid
 func (g *Clientimpl) Stats(ctx context.Context, filter types.StatsFilter) (stats types.Stats, err error) {
-	url, err := g.prepareURL("stats", filter)
-	if err != nil {
-		return types.Stats{}, errors.Wrap(err, "failed to prepare url")
-	}
-
-	client := g.newHTTPClient()
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return types.Stats{}, fmt.Errorf("failed to create stats request: %w", err)
-	}
-
-	res, err := client.Do(req)
+	res, err := g.httpGet("stats", filter)
 	if res != nil {
 		defer res.Body.Close()
 	}
 	if err != nil {
-		return types.Stats{}, err
+		return
 	}
 
 	if res.StatusCode != http.StatusOK {
@@ -393,18 +291,7 @@ func (g *Clientimpl) Stats(ctx context.Context, filter types.StatsFilter) (stats
 
 // Contract returns a single contract based on the contractID
 func (g *Clientimpl) Contract(ctx context.Context, contractID uint32) (types.Contract, error) {
-	client := g.newHTTPClient()
-	url, err := g.prepareURL(fmt.Sprintf("contracts/%d", contractID))
-	if err != nil {
-		return types.Contract{}, errors.Wrap(err, "failed to prepare url")
-	}
-
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return types.Contract{}, fmt.Errorf("failed to create contract request: %w", err)
-	}
-
-	res, err := client.Do(req)
+	res, err := g.httpGet(fmt.Sprintf("contracts/%d", contractID))
 	if res != nil {
 		defer res.Body.Close()
 	}
@@ -432,18 +319,7 @@ func (g *Clientimpl) Contract(ctx context.Context, contractID uint32) (types.Con
 
 // ContractBills returns all bills for a single contract based on contractID and pagination params
 func (g *Clientimpl) ContractBills(ctx context.Context, contractID uint32, limit types.Limit) ([]types.ContractBilling, uint, error) {
-	client := g.newHTTPClient()
-	url, err := g.prepareURL(fmt.Sprintf("contracts/%d/bills", contractID), limit)
-	if err != nil {
-		return nil, 0, errors.Wrap(err, "failed to prepare url")
-	}
-
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	res, err := client.Do(req)
+	res, err := g.httpGet(fmt.Sprintf("contracts/%d/bills", contractID), limit)
 	if res != nil {
 		defer res.Body.Close()
 	}
@@ -489,31 +365,6 @@ func (g *Clientimpl) newHTTPClient() *http.Client {
 	}
 }
 
-func (g *Clientimpl) baseURL() (string, error) {
-	var baseURL string
-
-	boff := backoff.WithMaxRetries(
-		backoff.NewConstantBackOff(1*time.Nanosecond),
-		2,
-	)
-
-	err := backoff.RetryNotify(func() error {
-		baseURL = g.endpoints[g.r]
-		log.Debug().Str("url", baseURL).Msg("pinging")
-		g.r = (g.r + 1) % len(g.endpoints)
-
-		return g.PingEndpoint(fmt.Sprintf("%s/ping", baseURL))
-	}, boff, func(err error, _ time.Duration) {
-		log.Error().Err(err).Msg("failed to connect to endpoint, retrying")
-	})
-
-	if err != nil {
-		return "", errors.Wrap(ErrProxyURLNotWorking, err.Error())
-	}
-
-	return baseURL, nil
-}
-
 func (g *Clientimpl) prepareURL(path string, params ...interface{}) (string, error) {
 	values := url.Values{}
 
@@ -523,10 +374,7 @@ func (g *Clientimpl) prepareURL(path string, params ...interface{}) (string, err
 		}
 	}
 
-	baseURL, err := g.baseURL()
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to get proxy baseURL")
-	}
+	baseURL := g.endpoints[g.r]
 
 	u, err := url.ParseRequestURI(baseURL)
 	if err != nil {
@@ -537,4 +385,46 @@ func (g *Clientimpl) prepareURL(path string, params ...interface{}) (string, err
 	u.RawQuery = values.Encode()
 
 	return u.String(), nil
+}
+
+func (g *Clientimpl) httpGet(path string, params ...interface{}) (resp *http.Response, reqErr error) {
+	client := g.newHTTPClient()
+
+	backoffCfg := backoff.WithMaxRetries(
+		backoff.NewConstantBackOff(1*time.Millisecond),
+		2,
+	)
+
+	err := backoff.RetryNotify(func() error {
+		url, err := g.prepareURL(path, params...)
+		if err != nil {
+			reqErr = errors.Wrap(err, "failed to prepare url")
+			return nil
+		}
+
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			reqErr = err
+			return nil
+		}
+
+		resp, reqErr = client.Do(req)
+		if reqErr != nil &&
+			(errors.Is(reqErr, http.ErrAbortHandler) ||
+				errors.Is(reqErr, http.ErrHandlerTimeout) ||
+				errors.Is(reqErr, http.ErrServerClosed)) {
+			g.r = (g.r + 1) % len(g.endpoints)
+			return reqErr
+		}
+
+		return nil
+	}, backoffCfg, func(err error, _ time.Duration) {
+		log.Error().Err(err).Msg("failed to connect to endpoint, retrying")
+	})
+
+	if err != nil {
+		log.Error().Err(err).Msg("failed to connect to endpoint")
+	}
+
+	return
 }

--- a/grid-proxy/pkg/client/grid_client.go
+++ b/grid-proxy/pkg/client/grid_client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -56,7 +55,7 @@ type Client interface {
 // Clientimpl concrete implementation of the client to communicate with the grid proxy
 type Clientimpl struct {
 	endpoints []string
-	r         int
+	i         int
 }
 
 // NewClient grid proxy client constructor
@@ -69,7 +68,7 @@ func NewClient(endpoints ...string) Client {
 
 	proxy := Clientimpl{
 		endpoints: endpoints,
-		r:         rand.Intn(len(endpoints)),
+		i:         0,
 	}
 
 	return &proxy
@@ -374,7 +373,7 @@ func (g *Clientimpl) prepareURL(path string, params ...interface{}) (string, err
 		}
 	}
 
-	baseURL := g.endpoints[g.r]
+	baseURL := g.endpoints[g.i]
 
 	u, err := url.ParseRequestURI(baseURL)
 	if err != nil {
@@ -413,7 +412,7 @@ func (g *Clientimpl) httpGet(path string, params ...interface{}) (resp *http.Res
 			(errors.Is(reqErr, http.ErrAbortHandler) ||
 				errors.Is(reqErr, http.ErrHandlerTimeout) ||
 				errors.Is(reqErr, http.ErrServerClosed)) {
-			g.r = (g.r + 1) % len(g.endpoints)
+			g.i = (g.i + 1) % len(g.endpoints)
 			return reqErr
 		}
 

--- a/grid-proxy/pkg/client/grid_client.go
+++ b/grid-proxy/pkg/client/grid_client.go
@@ -54,8 +54,8 @@ type Client interface {
 
 // Clientimpl concrete implementation of the client to communicate with the grid proxy
 type Clientimpl struct {
-	endpoints []string
-	i         int
+	endpoints      []string
+	activeStackIdx int
 }
 
 // NewClient grid proxy client constructor
@@ -67,8 +67,8 @@ func NewClient(endpoints ...string) Client {
 	}
 
 	proxy := Clientimpl{
-		endpoints: endpoints,
-		i:         0,
+		endpoints:      endpoints,
+		activeStackIdx: 0,
 	}
 
 	return &proxy
@@ -373,7 +373,7 @@ func (g *Clientimpl) prepareURL(path string, params ...interface{}) (string, err
 		}
 	}
 
-	baseURL := g.endpoints[g.i]
+	baseURL := g.endpoints[g.activeStackIdx]
 
 	u, err := url.ParseRequestURI(baseURL)
 	if err != nil {
@@ -412,7 +412,7 @@ func (g *Clientimpl) httpGet(path string, params ...interface{}) (resp *http.Res
 			(errors.Is(reqErr, http.ErrAbortHandler) ||
 				errors.Is(reqErr, http.ErrHandlerTimeout) ||
 				errors.Is(reqErr, http.ErrServerClosed)) {
-			g.i = (g.i + 1) % len(g.endpoints)
+			g.activeStackIdx = (g.activeStackIdx + 1) % len(g.endpoints)
 			return reqErr
 		}
 

--- a/grid-proxy/pkg/client/grid_client_test.go
+++ b/grid-proxy/pkg/client/grid_client_test.go
@@ -3,14 +3,12 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -215,7 +213,7 @@ func testStatusCodeFailures(t *testing.T, f ProxyFunc) {
 		if err == nil {
 			t.Fatalf("proxy endpoint %s didn't fail for a status code error", name)
 		}
-		if !strings.Contains(err.Error(), "some generic error") {
+		if err.Error() != "some generic error" {
 			t.Fatalf("error parsed incorrectly in %s: %s, should be: some generic error", name, err.Error())
 		}
 	}
@@ -253,7 +251,7 @@ func AssertHTTPRequest(
 	defer ts.Close()
 	proxy := f(ts.URL)
 	err := call(proxy)
-	if err != nil && !errors.Is(err, ErrProxyURLNotWorking) {
+	if err != nil {
 		log.Printf(
 			`
 			path: %s
@@ -356,12 +354,12 @@ func TestPrepareURL(t *testing.T) {
 	}
 	limit := types.DefaultLimit()
 
-	endpoint := "https://gridproxy.grid.tf"
+	endpoint := "http://www.gridproxy.com"
 	client := Clientimpl{
 		endpoints: []string{endpoint},
 	}
 
-	want := fmt.Sprintf("%s/nodes?status=st&free_mru=10&farm_ids=1&farm_ids=2&farm_ids=3&dedicated=true&size=50&page=1", endpoint)
+	want := "http://www.gridproxy.com/nodes?status=st&free_mru=10&farm_ids=1&farm_ids=2&farm_ids=3&dedicated=true&size=50&page=1"
 	wantURL, err := url.Parse(want)
 	assert.NoError(t, err)
 

--- a/grid-proxy/pkg/client/retrying_grid_client_test.go
+++ b/grid-proxy/pkg/client/retrying_grid_client_test.go
@@ -61,8 +61,8 @@ func (r *requestCounter) ContractBills(ctx context.Context, contractID uint32, l
 	return nil, 0, errors.New("error")
 }
 
-func retryingConstructor(u string) Client {
-	return NewRetryingClientWithTimeout(NewClient(u), 1*time.Millisecond)
+func retryingConstructor(u ...string) Client {
+	return NewRetryingClientWithTimeout(NewClient(u...), 1*time.Millisecond)
 }
 
 func TestRetryingConnectionFailures(t *testing.T) {


### PR DESCRIPTION
### Description

Support multiple stacks in proxy client

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-go/issues/1115

### Checklist

- [x] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstring

### Testing result

- Tried to use proxy multiple times 

```bash
12:01PM DBG pinging url=https://gridproxy.dev.grid.tf/
baseURL: https://gridproxy.dev.grid.tf/
12:01PM DBG pinging url=https://gridproxy.02.dev.grid.tf/
baseURL: https://gridproxy.02.dev.grid.tf/
12:01PM DBG pinging url=https://gridproxy.dev.grid.tf/
baseURL: https://gridproxy.dev.grid.tf/
12:01PM DBG pinging url=https://gridproxy.02.dev.grid.tf/
baseURL: https://gridproxy.02.dev.grid.tf/
12:01PM DBG pinging url=https://gridproxy.dev.grid.tf/
baseURL: https://gridproxy.dev.grid.tf/
```
