### PR TITLE
Development support deploying k8s workers on multiple nodes

### DIFF
--- a/grid-cli/README.md
+++ b/grid-cli/README.md
@@ -14,7 +14,7 @@ Login using your mnemonics and specify which grid network (mainnet/testnet) to d
 tfcmd login
 ```
 
-Check [Wallet Connector](https://manual.grid.tf/dashboard/wallet_connector.html) for more details if you do not have mnemonics yet.
+Check [Wallet Connector](https://manual.grid.tf/documentation/dashboard/wallet_connector.html) for more details if you do not have mnemonics yet.
 
 For examples and description of tfcmd commands check out:
 

--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -186,7 +186,7 @@ var deployKubernetesCmd = &cobra.Command{
 			masterNode = uint32(nodes[0].NodeID)
 		}
 		master.Node = masterNode
-		if len(workersNode)< len(workers) &&len(workers) > 0 {
+		if len(workersNode) < len(workers) && len(workers) > 0 {
 			filter, disks, rootfss := filters.BuildK8sFilter(
 				workers[0],
 				workersFarm,
@@ -204,7 +204,7 @@ var deployKubernetesCmd = &cobra.Command{
 				log.Fatal().Err(err).Send()
 			}
 			for i := 0; i < len(workersNodes); i++ {
-				workersNode = append(workersNode, uint(workersNodes[i].NodeID) )
+				workersNode = append(workersNode, uint(workersNodes[i].NodeID))
 			}
 		}
 		for i := 0; i < len(workers); i++ {

--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -202,12 +202,12 @@ var deployKubernetesCmd = &cobra.Command{
 			if err != nil {
 				log.Fatal().Err(err).Send()
 			}
-			for i := 0; i < len(nodes); i++ {
-				workersNodes = append(workersNodes, uint(nodes[i].NodeID))
+			for _,node := range nodes {
+				workersNodes = append(workersNodes, uint(node.NodeID))
 			}
 		}
-		for i := 0; i < workerNumber; i++ {
-			workers[i].Node = uint32(workersNodes[i])
+		for i, node := range workersNodes{
+			workers[i].Node = uint32(node)
 		}
 		cluster, err := command.DeployKubernetesCluster(cmd.Context(), t, master, workers, string(sshKey))
 		if err != nil {

--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -185,7 +185,7 @@ var deployKubernetesCmd = &cobra.Command{
 			masterNode = uint32(nodes[0].NodeID)
 		}
 		master.Node = masterNode
-		if len(workersNode) < len(workers) && len(workers) > 0 {
+		if len(workersNode) < workerNumber && workerNumber > 0 {
 			filter, disks, rootfss := filters.BuildK8sFilter(
 				workers[0],
 				workersFarm,
@@ -197,7 +197,7 @@ var deployKubernetesCmd = &cobra.Command{
 				disks,
 				nil,
 				rootfss,
-				uint64(len(workers)-len(workersNode)),
+				uint64(workerNumber-len(workersNode)),
 			)
 			if err != nil {
 				log.Fatal().Err(err).Send()
@@ -206,7 +206,7 @@ var deployKubernetesCmd = &cobra.Command{
 				workersNode = append(workersNode, uint(workersNodes[i].NodeID))
 			}
 		}
-		for i := 0; i < len(workers); i++ {
+		for i := 0; i < workerNumber; i++ {
 			workers[i].Node = uint32(workersNode[i])
 		}
 		cluster, err := command.DeployKubernetesCluster(cmd.Context(), t, master, workers, string(sshKey))

--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -200,7 +200,7 @@ var deployKubernetesCmd = &cobra.Command{
 				disks,
 				nil,
 				rootfss,
-				uint64(len(workers) - len(workersNode)),
+				uint64(len(workers)-len(workersNode)),
 			)
 			if err != nil {
 				log.Fatal().Err(err).Send()
@@ -208,7 +208,7 @@ var deployKubernetesCmd = &cobra.Command{
 			for i := 0; i < len(workersNode); i++ {
 				workers[i].Node = uint32(workersNode[i])
 			}
-			for i, j := len(workersNode),0; i < len(workers); i++ {
+			for i, j := len(workersNode), 0; i < len(workers); i++ {
 				workers[i].Node = uint32(workersNodes[j].NodeID)
 			}
 		} else {

--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -202,11 +202,11 @@ var deployKubernetesCmd = &cobra.Command{
 			if err != nil {
 				log.Fatal().Err(err).Send()
 			}
-			for _,node := range nodes {
+			for _, node := range nodes {
 				workersNodes = append(workersNodes, uint(node.NodeID))
 			}
 		}
-		for i, node := range workersNodes{
+		for i, node := range workersNodes {
 			workers[i].Node = uint32(node)
 		}
 		cluster, err := command.DeployKubernetesCluster(cmd.Context(), t, master, workers, string(sshKey))

--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -18,26 +18,25 @@ import (
 
 var k8sFlist = "https://hub.grid.tf/tf-official-apps/threefoldtech-k3s-latest.flist"
 
-
-func stringToIntArray(s string)( []uint32, error){
+func stringToIntArray(s string) ([]uint32, error) {
 
 	s = strings.TrimSpace(s)
 	if len(s) <= 0 {
-		return make([]uint32,0),fmt.Errorf("error parsing the worker nodes  number")
+		return make([]uint32, 0), fmt.Errorf("error parsing the worker nodes  number")
 	}
-	nodesMapped := strings.Split(s," ")
+	nodesMapped := strings.Split(s, " ")
 	parsedNodes := []uint32{}
-	for _,num := range nodesMapped {
-		numParsed ,err := strconv.ParseUint(num, 10, 32)
+	for _, num := range nodesMapped {
+		numParsed, err := strconv.ParseUint(num, 10, 32)
 		if err != nil {
-			return make([]uint32,0),fmt.Errorf("error parsing the worker nodes  number")
+			return make([]uint32, 0), fmt.Errorf("error parsing the worker nodes  number")
 		}
 		parsedNodes = append(parsedNodes, uint32(numParsed))
 	}
 	if len(parsedNodes) <= 0 {
-		return make([]uint32,0),fmt.Errorf("error parsing the worker nodes  umber")
+		return make([]uint32, 0), fmt.Errorf("error parsing the worker nodes  umber")
 	}
-	return parsedNodes,nil
+	return parsedNodes, nil
 }
 
 // deployKubernetesCmd represents the deploy kubernetes command
@@ -122,7 +121,7 @@ var deployKubernetesCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		workersNode,err := stringToIntArray(workersNodeToParse)
+		workersNode, err := stringToIntArray(workersNodeToParse)
 		if err != nil {
 			return err
 		}
@@ -238,7 +237,7 @@ var deployKubernetesCmd = &cobra.Command{
 			}
 		} else {
 			for i := 0; i < workerNumber; i++ {
-				workers[i].Node =  workersNode[i%len(workersNode)]
+				workers[i].Node = workersNode[i%len(workersNode)]
 			}
 		}
 		cluster, err := command.DeployKubernetesCluster(cmd.Context(), t, master, workers, string(sshKey))

--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -94,7 +94,7 @@ var deployKubernetesCmd = &cobra.Command{
 			return err
 		}
 
-		workersNode, err := cmd.Flags().GetUintSlice("workers-node")
+		workersNodes, err := cmd.Flags().GetUintSlice("workers-node")
 		if err != nil {
 			return err
 		}
@@ -185,29 +185,29 @@ var deployKubernetesCmd = &cobra.Command{
 			masterNode = uint32(nodes[0].NodeID)
 		}
 		master.Node = masterNode
-		if len(workersNode) < workerNumber && workerNumber > 0 {
+		if len(workersNodes) < workerNumber && workerNumber > 0 {
 			filter, disks, rootfss := filters.BuildK8sFilter(
 				workers[0],
 				workersFarm,
 			)
-			workersNodes, err := deployer.FilterNodes(
+			nodes, err := deployer.FilterNodes(
 				cmd.Context(),
 				t,
 				filter,
 				disks,
 				nil,
 				rootfss,
-				uint64(workerNumber-len(workersNode)),
+				uint64(workerNumber-len(workersNodes)),
 			)
 			if err != nil {
 				log.Fatal().Err(err).Send()
 			}
-			for i := 0; i < len(workersNodes); i++ {
-				workersNode = append(workersNode, uint(workersNodes[i].NodeID))
+			for i := 0; i < len(nodes); i++ {
+				workersNodes = append(workersNodes, uint(nodes[i].NodeID))
 			}
 		}
 		for i := 0; i < workerNumber; i++ {
-			workers[i].Node = uint32(workersNode[i])
+			workers[i].Node = uint32(workersNodes[i])
 		}
 		cluster, err := command.DeployKubernetesCluster(cmd.Context(), t, master, workers, string(sshKey))
 		if err != nil {
@@ -279,7 +279,7 @@ func init() {
 	deployKubernetesCmd.Flags().Int("workers-cpu", 1, "workers number of cpu units")
 	deployKubernetesCmd.Flags().Int("workers-memory", 1, "workers memory size in gb")
 	deployKubernetesCmd.Flags().Int("workers-disk", 2, "workers disk size in gb")
-	deployKubernetesCmd.Flags().UintSlice("workers-node", []uint{0}, "node id workers should be deployed on")
+	deployKubernetesCmd.Flags().UintSlice("workers-node", []uint{}, "node id workers should be deployed on")
 	deployKubernetesCmd.Flags().Uint64("workers-farm", 1, "farm id workers should be deployed on")
 	deployKubernetesCmd.MarkFlagsMutuallyExclusive("workers-node", "workers-farm")
 	deployKubernetesCmd.Flags().Bool("workers-ipv4", false, "assign public ipv4 for workers")

--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -94,7 +94,7 @@ var deployKubernetesCmd = &cobra.Command{
 			return err
 		}
 
-		workersNodes, err := cmd.Flags().GetUintSlice("workers-node")
+		workersNodes, err := cmd.Flags().GetUintSlice("workers-nodes")
 		if err != nil {
 			return err
 		}
@@ -279,9 +279,9 @@ func init() {
 	deployKubernetesCmd.Flags().Int("workers-cpu", 1, "workers number of cpu units")
 	deployKubernetesCmd.Flags().Int("workers-memory", 1, "workers memory size in gb")
 	deployKubernetesCmd.Flags().Int("workers-disk", 2, "workers disk size in gb")
-	deployKubernetesCmd.Flags().UintSlice("workers-node", []uint{}, "node id workers should be deployed on")
+	deployKubernetesCmd.Flags().UintSlice("workers-nodes", []uint{}, "node id workers should be deployed on")
 	deployKubernetesCmd.Flags().Uint64("workers-farm", 1, "farm id workers should be deployed on")
-	deployKubernetesCmd.MarkFlagsMutuallyExclusive("workers-node", "workers-farm")
+	deployKubernetesCmd.MarkFlagsMutuallyExclusive("workers-nodes", "workers-farm")
 	deployKubernetesCmd.Flags().Bool("workers-ipv4", false, "assign public ipv4 for workers")
 	deployKubernetesCmd.Flags().Bool("workers-ipv6", false, "assign public ipv6 for workers")
 	deployKubernetesCmd.Flags().Bool("workers-ygg", true, "assign yggdrasil ip for workers")

--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -16,7 +16,6 @@ import (
 
 var k8sFlist = "https://hub.grid.tf/tf-official-apps/threefoldtech-k3s-latest.flist"
 
-
 // deployKubernetesCmd represents the deploy kubernetes command
 var deployKubernetesCmd = &cobra.Command{
 	Use:   "kubernetes",

--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -185,7 +185,7 @@ var deployKubernetesCmd = &cobra.Command{
 			masterNode = uint32(nodes[0].NodeID)
 		}
 		master.Node = masterNode
-		if len(workersNodes) < workerNumber && workerNumber > 0 {
+		if len(workersNodes) < workerNumber {
 			filter, disks, rootfss := filters.BuildK8sFilter(
 				workers[0],
 				workersFarm,

--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -186,7 +186,7 @@ var deployKubernetesCmd = &cobra.Command{
 			masterNode = uint32(nodes[0].NodeID)
 		}
 		master.Node = masterNode
-		if len(workersNode) < len(workers) {
+		if len(workersNode) < len(workers) && len(workers) > 0 {
 
 			filter, disks, rootfss := filters.BuildK8sFilter(
 				workers[0],
@@ -200,17 +200,20 @@ var deployKubernetesCmd = &cobra.Command{
 				disks,
 				nil,
 				rootfss,
-				uint64(len(workers)),
+				uint64(len(workers) - len(workersNode)),
 			)
 			if err != nil {
 				log.Fatal().Err(err).Send()
 			}
-			for i, node := range workersNodes {
-				workers[i].Node = uint32(node.NodeID)
+			for i := 0; i < len(workersNode); i++ {
+				workers[i].Node = uint32(workersNode[i])
+			}
+			for i, j := len(workersNode),0; i < len(workers); i++ {
+				workers[i].Node = uint32(workersNodes[j].NodeID)
 			}
 		} else {
 			for i := 0; i < workerNumber; i++ {
-				workers[i].Node = uint32(workersNode[i%len(workersNode)])
+				workers[i].Node = uint32(workersNode[i])
 			}
 		}
 		cluster, err := command.DeployKubernetesCluster(cmd.Context(), t, master, workers, string(sshKey))

--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -190,7 +190,7 @@ var deployKubernetesCmd = &cobra.Command{
 			filter, disks, rootfss := filters.BuildK8sFilter(
 				workers[0],
 				workersFarm,
-				uint(len(workers)-len(workersNode)),
+				1,
 			)
 			workersNodes, err := deployer.FilterNodes(
 				cmd.Context(),

--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -197,6 +197,7 @@ var deployKubernetesCmd = &cobra.Command{
 				disks,
 				nil,
 				rootfss,
+				uint64(len(workers)-len(workersNode)),
 			)
 			if err != nil {
 				log.Fatal().Err(err).Send()

--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -206,8 +206,8 @@ var deployKubernetesCmd = &cobra.Command{
 				workersNodes = append(workersNodes, uint(node.NodeID))
 			}
 		}
-		for i, node := range workersNodes {
-			workers[i].Node = uint32(node)
+		for i := range workers {
+			workers[i].Node = uint32(workersNodes[i])
 		}
 		cluster, err := command.DeployKubernetesCluster(cmd.Context(), t, master, workers, string(sshKey))
 		if err != nil {

--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -169,7 +169,6 @@ var deployKubernetesCmd = &cobra.Command{
 			filter, disks, rootfss := filters.BuildK8sFilter(
 				master,
 				masterFarm,
-				1,
 			)
 			nodes, err := deployer.FilterNodes(
 				cmd.Context(),
@@ -190,7 +189,6 @@ var deployKubernetesCmd = &cobra.Command{
 			filter, disks, rootfss := filters.BuildK8sFilter(
 				workers[0],
 				workersFarm,
-				1,
 			)
 			workersNodes, err := deployer.FilterNodes(
 				cmd.Context(),

--- a/grid-cli/cmd/deploy_kubernetes.go
+++ b/grid-cli/cmd/deploy_kubernetes.go
@@ -4,6 +4,8 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -15,6 +17,28 @@ import (
 )
 
 var k8sFlist = "https://hub.grid.tf/tf-official-apps/threefoldtech-k3s-latest.flist"
+
+
+func stringToIntArray(s string)( []uint32, error){
+
+	s = strings.TrimSpace(s)
+	if len(s) <= 0 {
+		return make([]uint32,0),fmt.Errorf("error parsing the worker nodes  number")
+	}
+	nodesMapped := strings.Split(s," ")
+	parsedNodes := []uint32{}
+	for _,num := range nodesMapped {
+		numParsed ,err := strconv.ParseUint(num, 10, 32)
+		if err != nil {
+			return make([]uint32,0),fmt.Errorf("error parsing the worker nodes  number")
+		}
+		parsedNodes = append(parsedNodes, uint32(numParsed))
+	}
+	if len(parsedNodes) <= 0 {
+		return make([]uint32,0),fmt.Errorf("error parsing the worker nodes  umber")
+	}
+	return parsedNodes,nil
+}
 
 // deployKubernetesCmd represents the deploy kubernetes command
 var deployKubernetesCmd = &cobra.Command{
@@ -94,7 +118,11 @@ var deployKubernetesCmd = &cobra.Command{
 			return err
 		}
 
-		workersNode, err := cmd.Flags().GetUint32("workers-node")
+		workersNodeToParse, err := cmd.Flags().GetString("workers-node")
+		if err != nil {
+			return err
+		}
+		workersNode,err := stringToIntArray(workersNodeToParse)
 		if err != nil {
 			return err
 		}
@@ -186,7 +214,7 @@ var deployKubernetesCmd = &cobra.Command{
 			masterNode = uint32(nodes[0].NodeID)
 		}
 		master.Node = masterNode
-		if workersNode == 0 && len(workers) > 0 {
+		if len(workersNode) < len(workers) {
 
 			filter, disks, rootfss := filters.BuildK8sFilter(
 				workers[0],
@@ -210,7 +238,7 @@ var deployKubernetesCmd = &cobra.Command{
 			}
 		} else {
 			for i := 0; i < workerNumber; i++ {
-				workers[i].Node = workersNode
+				workers[i].Node =  workersNode[i%len(workersNode)]
 			}
 		}
 		cluster, err := command.DeployKubernetesCluster(cmd.Context(), t, master, workers, string(sshKey))
@@ -283,7 +311,7 @@ func init() {
 	deployKubernetesCmd.Flags().Int("workers-cpu", 1, "workers number of cpu units")
 	deployKubernetesCmd.Flags().Int("workers-memory", 1, "workers memory size in gb")
 	deployKubernetesCmd.Flags().Int("workers-disk", 2, "workers disk size in gb")
-	deployKubernetesCmd.Flags().Uint32("workers-node", 0, "node id workers should be deployed on")
+	deployKubernetesCmd.Flags().String("workers-node", "0", "node id workers should be deployed on")
 	deployKubernetesCmd.Flags().Uint64("workers-farm", 1, "farm id workers should be deployed on")
 	deployKubernetesCmd.MarkFlagsMutuallyExclusive("workers-node", "workers-farm")
 	deployKubernetesCmd.Flags().Bool("workers-ipv4", false, "assign public ipv4 for workers")

--- a/grid-cli/docs/kubernetes.md
+++ b/grid-cli/docs/kubernetes.md
@@ -17,7 +17,7 @@ tfcmd deploy kubernetes [flags]
 
 - master-node: node id master should be deployed on.
 - master-farm: farm id master should be deployed on, if set choose available node from farm that fits master specs (default 1). note: master-node and master-farm flags cannot be set both.
-- workers-node: node id workers should be deployed on.
+- workers-nodes: array of nodes ids workers should be deployed on and the remaining unassigned workers will be randomly assigned to nodes that meet the specifications.
 - workers-farm: farm id workers should be deployed on, if set choose available node from farm that fits master specs (default 1). note: workers-node and workers-farm flags cannot be set both.
 - ipv4: assign public ipv4 for master node (default false).
 - ipv6: assign public ipv6 for master node (default false).
@@ -38,7 +38,7 @@ tfcmd deploy kubernetes [flags]
 Example:
 
 ```console
-$ tfcmd deploy kubernetes -n kube --ssh ~/.ssh/id_rsa.pub --master-node 14 --workers-number 2 --workers-node 14
+$ tfcmd deploy kubernetes -n kube --ssh ~/.ssh/id_rsa.pub --master-node 14 --workers-number 2 --workers-nodes 14,1
 11:43AM INF starting peer session=tf-1510734 twin=192
 11:43AM INF deploying network
 11:43AM INF deploying cluster

--- a/grid-cli/internal/filters/filters.go
+++ b/grid-cli/internal/filters/filters.go
@@ -9,7 +9,7 @@ import (
 // BuildK8sFilter build a filter for a k8s node
 func BuildK8sFilter(k8sNode workloads.K8sNode, farmID uint64) (types.NodeFilter, []uint64, []uint64) {
 	freeMRUs := uint64(k8sNode.Memory) / 1024
-	freeSRUs := uint64(k8sNode.DiskSize )
+	freeSRUs := uint64(k8sNode.DiskSize)
 	freeIPs := uint64(0)
 
 	disks := make([]uint64, 1)

--- a/grid-cli/internal/filters/filters.go
+++ b/grid-cli/internal/filters/filters.go
@@ -7,21 +7,16 @@ import (
 )
 
 // BuildK8sFilter build a filter for a k8s node
-func BuildK8sFilter(k8sNode workloads.K8sNode, farmID uint64, k8sNodesNum uint) (types.NodeFilter, []uint64, []uint64) {
-	freeMRUs := uint64(k8sNode.Memory*int(k8sNodesNum)) / 1024
-	freeSRUs := uint64(k8sNode.DiskSize * int(k8sNodesNum))
+func BuildK8sFilter(k8sNode workloads.K8sNode, farmID uint64) (types.NodeFilter, []uint64, []uint64) {
+	freeMRUs := uint64(k8sNode.Memory) / 1024
+	freeSRUs := uint64(k8sNode.DiskSize )
 	freeIPs := uint64(0)
-	if k8sNode.PublicIP {
-		freeIPs = uint64(k8sNodesNum)
-	}
 
-	disks := make([]uint64, k8sNodesNum)
-	rootfss := make([]uint64, k8sNodesNum)
-	for i := 0; i < int(k8sNodesNum); i++ {
-		disks = append(disks, *convertGBToBytes(uint64(k8sNode.DiskSize)))
-		// k8s rootfs is either 2 or 0.5
-		rootfss = append(rootfss, *convertGBToBytes(uint64(2)))
-	}
+	disks := make([]uint64, 1)
+	rootfss := make([]uint64, 1)
+	disks = append(disks, *convertGBToBytes(uint64(k8sNode.DiskSize)))
+	// k8s rootfs is either 2 or 0.5
+	rootfss = append(rootfss, *convertGBToBytes(uint64(2)))
 
 	return buildGenericFilter(&freeMRUs, &freeSRUs, nil, &freeIPs, []uint64{farmID}, nil), disks, rootfss
 }

--- a/grid-cli/internal/filters/filters.go
+++ b/grid-cli/internal/filters/filters.go
@@ -12,11 +12,12 @@ func BuildK8sFilter(k8sNode workloads.K8sNode, farmID uint64) (types.NodeFilter,
 	freeSRUs := uint64(k8sNode.DiskSize)
 	freeIPs := uint64(0)
 
-	disks := make([]uint64, 1)
-	rootfss := make([]uint64, 1)
-	disks = append(disks, *convertGBToBytes(uint64(k8sNode.DiskSize)))
+	if k8sNode.PublicIP {
+		freeIPs = uint64(1)
+	}
+	disks := []uint64{*convertGBToBytes(uint64(k8sNode.DiskSize))}
 	// k8s rootfs is either 2 or 0.5
-	rootfss = append(rootfss, *convertGBToBytes(uint64(2)))
+	rootfss := []uint64{*convertGBToBytes(uint64(2))}
 
 	return buildGenericFilter(&freeMRUs, &freeSRUs, nil, &freeIPs, []uint64{farmID}, nil), disks, rootfss
 }


### PR DESCRIPTION
## Description

Make workers deploy on multiple nodes.

## changes 

List of changes this PR includes

- grid cli
   - added the option flag to specify nodes workers can work on

## Related Issues
List of related issues

- #1134