### PR TITLE
fix mycelium update after failures

### DIFF
--- a/grid-client/workloads/network.go
+++ b/grid-client/workloads/network.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"slices"
 
 	"github.com/pkg/errors"
 	client "github.com/threefoldtech/tfgrid-sdk-go/grid-client/node"
@@ -166,9 +167,13 @@ func (znet *ZNet) Validate() error {
 	if ones, _ := mask.Size(); ones != 16 {
 		return errors.Errorf("subnet in ip range %s should be 16", znet.IPRange.String())
 	}
-	for _, key := range znet.MyceliumKeys {
+	for node, key := range znet.MyceliumKeys {
 		if len(key) != zos.MyceliumKeyLen && len(key) != 0 {
 			return fmt.Errorf("invalid mycelium key length %d must be %d or empty", len(key), zos.MyceliumKeyLen)
+		}
+
+		if !slices.Contains(znet.Nodes, node) {
+			return fmt.Errorf("invalid node %d for mycelium key, must be included in the network nodes %v", node, znet.Nodes)
 		}
 	}
 

--- a/tfrobot/pkg/deployer/deployer.go
+++ b/tfrobot/pkg/deployer/deployer.go
@@ -197,6 +197,15 @@ func updateFailedDeployments(ctx context.Context, tfPluginClient deployer.TFPlug
 			nodeID := uint32(nodesIDs[idx%len(nodesIDs)])
 			groupDeployments.vmDeployments[idx].NodeID = nodeID
 			groupDeployments.networkDeployments[idx].Nodes = []uint32{nodeID}
+
+			myceliumKeys := groupDeployments.networkDeployments[idx].MyceliumKeys
+			if len(myceliumKeys) != 0 {
+				myceliumKey, err := workloads.RandomMyceliumKey()
+				if err != nil {
+					log.Debug().Err(err).Send()
+				}
+				groupDeployments.networkDeployments[idx].MyceliumKeys = map[uint32][]byte{nodeID: myceliumKey}
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description

update mycelium keys nodes after failures, make sure mycelium keys nodes are included in the network nodes

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-go/issues/1138
