### PR TITLE
fix getting consumption for a twin doesn't have contracts

### DIFF
--- a/grid-proxy/internal/explorer/db_client.go
+++ b/grid-proxy/internal/explorer/db_client.go
@@ -152,6 +152,10 @@ func (c *DBClient) GetTwinConsumption(ctx context.Context, twinId uint64) (types
 		}
 	}
 
+	if len(allCIds) == 0 {
+		return types.TwinConsumption{}, nil
+	}
+
 	// get the latest two reports for each active contract
 	reports, err := c.DB.GetContractsLatestBillReports(ctx, nonDeletedCIds, 2)
 	if err != nil {


### PR DESCRIPTION
- early return when a twin does not have contracts
- https://github.com/threefoldtech/tfgrid-sdk-go/issues/1186

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
