### PR TITLE
fix: use the correct mycelium tar.gz filename

### DIFF
--- a/.github/workflows/grid-client-integration.yml
+++ b/.github/workflows/grid-client-integration.yml
@@ -38,7 +38,7 @@ jobs:
           sudo apt-get install dirmngr
           sudo apt-get install curl
           wget https://github.com/threefoldtech/mycelium/releases/download/v0.5.7/mycelium-private-x86_64-unknown-linux-musl.tar.gz
-          tar xzf mycelium-x86_64-unknown-linux-musl.tar.gz
+          tar xzf mycelium-private-x86_64-unknown-linux-musl.tar.gz
           sudo ./mycelium --peers tcp://188.40.132.242:9651 quic://185.69.166.8:9651 --tun-name utun9 -k /tmp/mycelium_priv_key.bin &
 
       - name: Test


### PR DESCRIPTION
### Description

fix: use the correct mycelium tar.gz filename

### Changes

changes in client integration github workflow


