### PR TITLE
supports inmemory cache expiration for twindb

### DIFF
--- a/grid-client/deployer/tf_plugin_client.go
+++ b/grid-client/deployer/tf_plugin_client.go
@@ -309,7 +309,7 @@ func NewTFPluginClient(
 	}
 
 	if !cfg.rmbInMemCache {
-		peerOpts = append(peerOpts, peer.WithTwinCache(10*60*60)) // in seconds that's 10 hours
+		peerOpts = append(peerOpts, peer.WithTmpCacheExpiration(10*60*60)) // in seconds that's 10 hours
 	}
 	rmbClient, err := peer.NewRpcClient(ctx, tfPluginClient.mnemonicOrSeed, manager, peerOpts...)
 	if err != nil {

--- a/rmb-sdk-go/peer/examples/peer/main.go
+++ b/rmb-sdk-go/peer/examples/peer/main.go
@@ -26,6 +26,7 @@ func app() error {
 		relayCallback,
 		peer.WithRelay("wss://relay.dev.grid.tf"),
 		peer.WithSession("test-client"),
+		peer.WithInMemoryExpiration(6*60*60), // six hours
 	)
 
 	if err != nil {

--- a/rmb-sdk-go/peer/examples/peer_pingmany/main.go
+++ b/rmb-sdk-go/peer/examples/peer_pingmany/main.go
@@ -65,7 +65,7 @@ func main() {
 		handler,
 		peer.WithKeyType(peer.KeyTypeSr25519),
 		peer.WithSession("rmb-playground999"),
-		peer.WithTwinCache(10*60*60), // in seconds that's 10 hours
+		peer.WithInMemoryExpiration(10*60*60), // in seconds that's 10 hours
 	)
 
 	if err != nil {

--- a/rmb-sdk-go/peer/peer.go
+++ b/rmb-sdk-go/peer/peer.go
@@ -88,11 +88,20 @@ func WithEncoder(encoder encoder.Encoder) PeerOpt {
 }
 
 // WithTwinCache cache twin information for this ttl number of seconds
-// by default twins are cached in memory forever
-func WithTwinCache(ttl uint64) PeerOpt {
+// if ttl == 0, twins are cached forever
+func WithTmpCacheExpiration(ttl uint64) PeerOpt {
 	return func(pc *peerCfg) {
 		pc.cacheFactory = func(inner TwinDB, chainURL string) (TwinDB, error) {
 			return newTmpCache(ttl, inner, chainURL)
+		}
+	}
+}
+
+// if ttl == 0 twins are cached forever
+func WithInMemoryExpiration(ttl uint64) PeerOpt {
+	return func(pc *peerCfg) {
+		pc.cacheFactory = func(inner TwinDB, chainURL string) (TwinDB, error) {
+			return newInMemoryCache(inner, ttl), nil
 		}
 	}
 }
@@ -158,7 +167,7 @@ func NewPeer(
 		enableEncryption: true,
 		keyType:          KeyTypeSr25519,
 		cacheFactory: func(inner TwinDB, _ string) (TwinDB, error) {
-			return newInMemoryCache(inner), nil
+			return newInMemoryCache(inner, 0), nil
 		},
 	}
 


### PR DESCRIPTION
### Description

support inmemory cache expiration for twins 
- if ttl == 0 it will stay forever otherwise will be cached for a limited amount of time

### Changes

inmemory cache expiration
### Related Issues
https://github.com/threefoldtech/tfgrid-sdk-go/issues/1294
### Checklist

