### PR TITLE
recalc the node gpu count

### DIFF
--- a/grid-proxy/CHANGELOG.md
+++ b/grid-proxy/CHANGELOG.md
@@ -4,6 +4,18 @@ Check `/version` on any instance to know the version.
 
 ## Releases
 
+### v0.16.4
+
+---
+
+- `fix` gpus number and list in node response
+
+### v0.16.2
+
+---
+
+- `feat` add openConnection on node stats 
+
 ### v0.16.0
 
 ---

--- a/grid-proxy/cmds/proxy_server/main.go
+++ b/grid-proxy/cmds/proxy_server/main.go
@@ -177,7 +177,7 @@ func main() {
 
 func startIndexers(ctx context.Context, f flags, db db.Database, rpcRmbClient *peer.RpcClient) {
 	gpuIdx := indexer.NewIndexer[types.NodeGPU](
-		indexer.NewGPUWork(f.gpuIndexerIntervalMins),
+		indexer.NewGPUWork(f.gpuIndexerIntervalMins, db),
 		"GPU",
 		db,
 		rpcRmbClient,

--- a/grid-proxy/internal/explorer/db/setup.sql
+++ b/grid-proxy/internal/explorer/db/setup.sql
@@ -478,27 +478,20 @@ $$
 BEGIN
     BEGIN
         UPDATE resources_cache
-        SET node_gpu_count = node_gpu_count + (
-            CASE 
-            WHEN TG_OP = 'INSERT' 
-                THEN 1 
-            WHEN TG_OP = 'DELETE'
-                THEN -1
-            ELSE 0
-            END
-        ),
-            gpus = (
-                SELECT json_agg(
-                    json_build_object(
-                        'id', node_gpu.id,
-                        'vendor', node_gpu.vendor,
-                        'device', node_gpu.device,
-                        'contract', node_gpu.contract
-                    )
+            SET node_gpu_count = gpu.count, gpus = gpu.gpus
+            FROM (
+              SELECT COUNT(*) AS count,
+                json_agg(
+                  json_build_object(
+                      'id', id,
+                      'vendor', vendor,
+                      'device', device,
+                      'contract', contract
                 )
-                from node_gpu where node_twin_id = COALESCE(NEW.node_twin_id, OLD.node_twin_id)
-            )
-
+              ) AS gpus
+              FROM node_gpu 
+              WHERE node_twin_id = COALESCE(NEW.node_twin_id, OLD.node_twin_id)
+            ) AS gpu
         WHERE resources_cache.node_id = (
             SELECT node_id from node where node.twin_id = COALESCE(NEW.node_twin_id, OLD.node_twin_id)
         );
@@ -511,7 +504,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE TRIGGER tg_node_gpu_count
-    AFTER INSERT OR DELETE ON node_gpu FOR EACH ROW
+    AFTER INSERT OR DELETE OR UPDATE ON node_gpu FOR EACH ROW
     EXECUTE PROCEDURE reflect_node_gpu_count_change();
 
 /*


### PR DESCRIPTION
- re calculate the node gpu count with each trigger instead of inc/decreasing the accumilated count
- trigger the update cache function on update beside insert/delete for an updated gpus list in the cache
- invalidate the old indexed card in case the node returns null as the card ejected
- fix: https://github.com/threefoldtech/tfgrid-sdk-go/issues/1325

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
