### PR TITLE
Ensure relays that fail at startup are retried

### DIFF
--- a/rmb-sdk-go/peer/peer.go
+++ b/rmb-sdk-go/peer/peer.go
@@ -37,6 +37,13 @@ type Handler func(ctx context.Context, peer *Peer, env *types.Envelope, err erro
 
 type cacheFactory = func(inner TwinDB, chainURL string) (TwinDB, error)
 
+var (
+	// ErrNoValidRelayURLs is returned when no valid relay URLs are provided.
+	ErrNoValidRelayURLs = errors.New("no valid relay URLs provided")
+	// ErrNoFunctionalRelayAtStartup is returned when no relay connections are functional at startup.
+	ErrNoFunctionalRelayAtStartup = errors.New("no relay connections are functional at startup")
+)
+
 type peerCfg struct {
 	// Require at least one working relay at startup (default: false, for backward compatibility)
 	RequireFunctionalRelayOnStartup bool
@@ -157,7 +164,7 @@ func getRelayConnections(relayURLs []string, identity substrate.Identity, sessio
 	}
 
 	if len(connections) == 0 {
-		return nil, nil, errors.New("no valid relay URLs provided")
+		return nil, nil, ErrNoValidRelayURLs
 	}
 
 	sort.Slice(validRelayURLs, func(i, j int) bool {
@@ -266,15 +273,11 @@ func NewPeer(
 
 	// Hybrid approach: if RequireFunctionalRelayOnStartup is true, require at least one working relay at startup
 	if cfg.RequireFunctionalRelayOnStartup {
-		hasWorking := false
-		for _, conn := range conns {
-			if conn.TryConnect() {
-				hasWorking = true
-				break
-			}
-		}
-		if !hasWorking {
-			return nil, errors.New("no relay connections are functional at startup")
+		firstWorking := slices.IndexFunc(conns, func(c InnerConnection) bool {
+			return c.TryConnect()
+		})
+		if firstWorking == -1 {
+			return nil, ErrNoFunctionalRelayAtStartup
 		}
 	}
 

--- a/rmb-sdk-go/peer/peer.go
+++ b/rmb-sdk-go/peer/peer.go
@@ -38,6 +38,8 @@ type Handler func(ctx context.Context, peer *Peer, env *types.Envelope, err erro
 type cacheFactory = func(inner TwinDB, chainURL string) (TwinDB, error)
 
 type peerCfg struct {
+	// Require at least one working relay at startup (default: false, for backward compatibility)
+	RequireFunctionalRelayOnStartup bool
 	relayURLs        []string
 	keyType          string
 	session          string
@@ -63,6 +65,14 @@ func WithEncryption(enable bool) PeerOpt {
 }
 
 // WithRelay set up the relay url, default is mainnet relay
+// WithRequireFunctionalRelayOnStartup configures whether the peer should require at least one working relay at startup.
+// If not set, the peer will always self-heal (default, backward compatible).
+func WithRequireFunctionalRelayOnStartup(required bool) PeerOpt {
+	return func(p *peerCfg) {
+		p.RequireFunctionalRelayOnStartup = required
+	}
+}
+
 func WithRelay(urls ...string) PeerOpt {
 	return func(p *peerCfg) {
 		p.relayURLs = urls
@@ -130,38 +140,32 @@ func generateSecureKey(identity substrate.Identity) (*secp256k1.PrivateKey, erro
 }
 
 // getRelayConnections tries to connect to all relays and returns only the successful ones
+// getRelayConnections returns InnerConnections for all valid relay URLs
 func getRelayConnections(relayURLs []string, identity substrate.Identity, session string, twinID uint32) ([]string, []InnerConnection, error) {
-	var successfulRelayURLs []string
-	var successfulConnections []InnerConnection
+	var validRelayURLs []string
+	var connections []InnerConnection
 
 	for _, relayURL := range relayURLs {
 		parsedURL, err := url.Parse(relayURL)
 		if err != nil {
-			log.Warn().Err(err).Str("url", relayURL).Msg("failed to parse relay URL")
+			log.Warn().Err(err).Str("url", relayURL).Msg("failed to parse relay URL, skipping")
 			continue
 		}
-
+		validRelayURLs = append(validRelayURLs, parsedURL.Host)
 		conn := NewConnection(identity, relayURL, session, twinID)
-		if conn.TryConnect() {
-			log.Info().Str("url", relayURL).Msg("connected")
-			successfulRelayURLs = append(successfulRelayURLs, parsedURL.Host)
-			successfulConnections = append(successfulConnections, conn)
-			continue
-		}
-
-		log.Warn().Str("url", relayURL).Msg("failed to connect")
+		connections = append(connections, conn)
 	}
 
-	if len(successfulRelayURLs) == 0 {
-		return nil, nil, errors.New("failed to connect to any relay")
+	if len(connections) == 0 {
+		return nil, nil, errors.New("no valid relay URLs provided")
 	}
 
-	sort.Slice(successfulRelayURLs, func(i, j int) bool {
-		return strings.ToLower(successfulRelayURLs[i]) < strings.ToLower(successfulRelayURLs[j])
+	sort.Slice(validRelayURLs, func(i, j int) bool {
+		return strings.ToLower(validRelayURLs[i]) < strings.ToLower(validRelayURLs[j])
 	})
-	successfulRelayURLs = slices.Compact(successfulRelayURLs)
+	validRelayURLs = slices.Compact(validRelayURLs)
 
-	return successfulRelayURLs, successfulConnections, nil
+	return validRelayURLs, connections, nil
 }
 
 func getIdentity(keytype string, mnemonics string) (substrate.Identity, error) {
@@ -260,6 +264,20 @@ func NewPeer(
 		return nil, err
 	}
 
+	// Hybrid approach: if RequireFunctionalRelayOnStartup is true, require at least one working relay at startup
+	if cfg.RequireFunctionalRelayOnStartup {
+		hasWorking := false
+		for _, conn := range conns {
+			if conn.TryConnect() {
+				hasWorking = true
+				break
+			}
+		}
+		if !hasWorking {
+			return nil, errors.New("no relay connections are functional at startup")
+		}
+	}
+
 	joinURLs := strings.Join(relayURLs, "_")
 	if !bytes.Equal(twin.E2EKey, publicKey) || twin.Relay == nil || joinURLs != *twin.Relay {
 		log.Info().Str("Relay url/s", joinURLs).Msg("twin relay/public key didn't match, updating on chain ...")
@@ -271,6 +289,7 @@ func NewPeer(
 	reader := make(chan []byte)
 	weightCons := make([]WeightItem[InnerConnection], 0, len(conns))
 	for _, conn := range conns {
+		// Always start reconnection goroutine for all valid relays
 		conn.Start(ctx, reader)
 		weightCons = append(weightCons, WeightItem[InnerConnection]{Item: conn, Weight: 1})
 	}

--- a/rmb-sdk-go/peer/peer.go
+++ b/rmb-sdk-go/peer/peer.go
@@ -40,12 +40,12 @@ type cacheFactory = func(inner TwinDB, chainURL string) (TwinDB, error)
 type peerCfg struct {
 	// Require at least one working relay at startup (default: false, for backward compatibility)
 	RequireFunctionalRelayOnStartup bool
-	relayURLs        []string
-	keyType          string
-	session          string
-	enableEncryption bool
-	encoder          encoder.Encoder
-	cacheFactory     cacheFactory
+	relayURLs                       []string
+	keyType                         string
+	session                         string
+	enableEncryption                bool
+	encoder                         encoder.Encoder
+	cacheFactory                    cacheFactory
 }
 
 type PeerOpt func(*peerCfg)

--- a/rmb-sdk-go/peer/peer.go
+++ b/rmb-sdk-go/peer/peer.go
@@ -71,7 +71,6 @@ func WithEncryption(enable bool) PeerOpt {
 	}
 }
 
-// WithRelay set up the relay url, default is mainnet relay
 // WithRequireFunctionalRelayOnStartup configures whether the peer should require at least one working relay at startup.
 // If not set, the peer will always self-heal (default, backward compatible).
 func WithRequireFunctionalRelayOnStartup(required bool) PeerOpt {
@@ -80,6 +79,7 @@ func WithRequireFunctionalRelayOnStartup(required bool) PeerOpt {
 	}
 }
 
+// WithRelay set up the relay url, default is mainnet relay
 func WithRelay(urls ...string) PeerOpt {
 	return func(p *peerCfg) {
 		p.relayURLs = urls


### PR DESCRIPTION
### Description
**Problem Context**: During peer startup, only relays that connect successfully have their reconnection goroutine (InnerConnection.Start()) started. Relays that fail the initial connection are ignored forever.
**Impact**: If a relay is down at startup, it is never retried unless the app is restarted. This reduces redundancy and resilience.

This pull request (PR) introduces a change in behavior for the SDK. By default, the SDK will now automatically attempt to self-heal by retrying all configured relays in the background, even if any are down at startup.

An option `WithRequireFunctionalRelayOnStartup` was added to allow applications to choose stricter startup checks if needed. If it is enabled, the SDK will require at least one relay to be functional at startup. If no relays are functional, the SDK will return an error and will not start, which reflects the old behavior. This is not enabled by default. 

### Changes

- Refactor `getRelayConnections`:
  - Creates `InnerConnection` instances for valid relay URLs (those that can be parsed).
  - Invalid URLs are logged and skipped (no retry, no goroutine).
  - The function returns all valid connections, regardless of initial connection success.

- Refactor `NewPeer`:
  - Starts the reconnection goroutine `Start` for all valid InnerConnection instances, ensuring that even relays that are temporarily down at startup will be retried.
  - There is no longer any logic that filters out relays based on initial connection success.

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-go/issues/1389

### Checklist

- [ ] Tests included
- [X] Build pass
- [ ] Documentation
- [X] Code format and docstring
