### PR TITLE
feat: implement TTL handling and expiration checks for RMB messages

### DIFF
--- a/rmb-sdk-go/peer/peer.go
+++ b/rmb-sdk-go/peer/peer.go
@@ -31,6 +31,13 @@ const (
 	KeyTypeSr25519 = "sr25519"
 )
 
+const (
+	// DefaultTTL is the default time-to-live for a message in seconds
+	DefaultTTL uint64 = 300 // 5 minutes
+	// MaxTTL is the maximum time-to-live for a message in seconds
+	MaxTTL uint64 = 1800 // 30 minutes
+)
+
 // Handler is a call back that is called with verified and decrypted incoming
 // messages. An error can be non-nil error if verification or decryption failed
 type Handler func(ctx context.Context, peer *Peer, env *types.Envelope, err error)
@@ -550,10 +557,23 @@ func (d *Peer) SendRequest(ctx context.Context, id string, twin uint32, session 
 		return errors.Wrap(err, "failed to serialize request body")
 	}
 
-	var ttl uint64 = 5 * 60
+	var ttl uint64
 	deadline, ok := ctx.Deadline()
 	if ok {
+		if time.Until(deadline) < 0 {
+			return errors.New("context deadline is in the past")
+		}
 		ttl = uint64(time.Until(deadline).Seconds())
+
+		if ttl == 0 {
+			ttl = DefaultTTL
+		}
+
+		if ttl > MaxTTL {
+			ttl = MaxTTL
+		}
+	} else {
+		ttl = DefaultTTL
 	}
 
 	request, err := d.makeEnvelope(id, twin, session, &fn, nil, payload, ttl)
@@ -569,16 +589,10 @@ func (d *Peer) SendRequest(ctx context.Context, id string, twin uint32, session 
 }
 
 // SendResponse sends an rmb message to the relay
-func (d *Peer) SendResponse(ctx context.Context, id string, twin uint32, session *string, responseError error, data interface{}) error {
+func (d *Peer) SendResponse(ctx context.Context, id string, twin uint32, session *string, responseError error, data interface{}, ttl uint64) error {
 	payload, err := d.encoder.Encode(data)
 	if err != nil {
 		return errors.Wrap(err, "failed to serialize request body")
-	}
-
-	var ttl uint64 = 5 * 60
-	deadline, ok := ctx.Deadline()
-	if ok {
-		ttl = uint64(time.Until(deadline).Seconds())
 	}
 
 	request, err := d.makeEnvelope(id, twin, session, nil, responseError, payload, ttl)

--- a/rmb-sdk-go/peer/router.go
+++ b/rmb-sdk-go/peer/router.go
@@ -105,7 +105,14 @@ func (r *Router) Serve(ctx context.Context, peer *Peer, env *types.Envelope, err
 
 		response, err := r.call(handlerCtx, cmd, payload.Plain)
 
-		age := uint64(time.Now().Unix()) - env.Timestamp
+		// Compute age robustly: avoid unsigned underflow if sender’s clock is slightly ahead (or the envelope’s timestamp is marginally in the future)
+		var age uint64
+		{
+			now := time.Now().Unix()
+			delta := now - int64(env.Timestamp)
+			age = uint64(max(0, delta))
+		}
+
 		ttl := env.Expiration
 		if age >= ttl {
 			log.Warn().Msgf("request %s has expired, dropping response", env.Uid)

--- a/rmb-sdk-go/peer/router.go
+++ b/rmb-sdk-go/peer/router.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go"
@@ -104,8 +105,16 @@ func (r *Router) Serve(ctx context.Context, peer *Peer, env *types.Envelope, err
 
 		response, err := r.call(handlerCtx, cmd, payload.Plain)
 
+		age := uint64(time.Now().Unix()) - env.Timestamp
+		ttl := env.Expiration
+		if age >= ttl {
+			log.Warn().Msgf("request %s has expired, dropping response", env.Uid)
+			return
+		}
+
+		remainingTTL := ttl - age
 		// send response
-		if err := peer.SendResponse(ctx, env.Uid, env.Source.Twin, env.Source.Connection, err, response); err != nil {
+		if err := peer.SendResponse(ctx, env.Uid, env.Source.Twin, env.Source.Connection, err, response, remainingTTL); err != nil {
 			log.Error().Err(err).Msgf("failed to send response to twin id '%d'", env.Destination.Twin)
 		}
 	}()


### PR DESCRIPTION
### Description

  While the changes are small, they are important and collectively and defensively fix a possible bug related to incorrect use of contexts, harden the system against invalid TTL values, and make the request/response lifecycle more robust and more consistent with our original Rust implementation.


### Changes

 1. In rmb-sdk-go/peer/peer.go:

 Improve the client-side request TTL validation logic to be safer.

   * Added TTL Constants: Introduced DefaultTTL (5 minutes) and MaxTTL (30 minutes) to define clear boundaries for message lifetimes.
   * Enhanced `SendRequest` Function:
       * Context Validation: It now returns an error immediately if the request context has a deadline that is already in the past, preventing unexpected behaviour, where a past-due context would create a massive, near-infinite TTL
       * TTL Logic:
           * If the context has no deadline, it uses DefaultTTL.
           * If the context deadline results in a TTL of 0, it is defaulted to DefaultTTL.
           * If the context deadline results in a TTL greater than MaxTTL, the TTL is capped at MaxTTL.
   * Modified `SendResponse` Function: Changed its signature from SendResponse(...) to SendResponse(..., ttl uint64) to allow the caller to specify the response's time-to-live, which was crucial for the server-side changes.


  2. In rmb-sdk-go/peer/router.go:

 Improve the server-side response handling logic to be safer and more consistent with the request's lifecycle.

   * Enhanced `Serve` Method:
       * Expired Request Check: It now checks if an incoming request has already expired by comparing its age to its TTL. If it's expired, it logs a warning and drops the response, preventing processing of stale requests.
       * Response TTL Calculation: For valid requests, it calculates the remaining TTL and passes this value to the SendResponse function. This ensures a response cannot outlive the original request's intended lifespan.

### Related Issues

#1390
 
### Checklist

- [ ] Tests included
- [X] Build pass
- [ ] Documentation
- [X] Code format and docstring
