### PR TITLE
update hidden nodes peer to use the subnet of the public node

### DIFF
--- a/grid-client/workloads/network.go
+++ b/grid-client/workloads/network.go
@@ -756,7 +756,7 @@ func (znet *ZNet) generateDeployments(endpointIPs map[uint32]net.IP, usedPorts m
 		if znet.PublicNodeID != 0 {
 			peers = append(peers, zos.Peer{
 				WGPublicKey: znet.Keys[znet.PublicNodeID].PublicKey().String(),
-				Subnet:      znet.NodesIPRange[nodeID],
+				Subnet:      znet.NodesIPRange[znet.PublicNodeID],
 				AllowedIPs: []zos.IPNet{
 					znet.IPRange,
 					IPNet(100, 64, 0, 0, 16),


### PR DESCRIPTION
while investigating a problem in network deployment, we found that the peer in hidden nodes uses its own subnet instead of the chosen publicNode subnet.

eventually it turns out it is not the problem we faced, and since the allowed list in this peer have `*/16` subnet range which include both (hidden node/public node) ips it will work fine.

but it is more clear to use the publicNode subnet to remove confusion in future