### PR TITLE
feat: Request Tagging and more clear errors distinguish twin-origin

### DIFF
--- a/rmb-sdk-go/peer/peer.go
+++ b/rmb-sdk-go/peer/peer.go
@@ -38,6 +38,15 @@ const (
 	MaxTTL uint64 = 1800 // 30 minutes
 )
 
+// Tag represents a well-known request tag to be sent with envelopes.
+type Tag string
+
+// TagFailFast is a well-known tag that asks the relay to fail immediately
+// (return an error) if the destination is offline, instead of queuing the
+// message until the destination comes online or the message expires.
+// Multiple tags can be sent using a comma-separated list in Envelope.Tags.
+const TagFailFast Tag = "fail-fast"
+
 // Handler is a call back that is called with verified and decrypted incoming
 // messages. An error can be non-nil error if verification or decryption failed
 type Handler func(ctx context.Context, peer *Peer, env *types.Envelope, err error)
@@ -452,7 +461,7 @@ func (d *Peer) decrypt(data []byte, pubKey []byte) ([]byte, error) {
 	return decrypted, nil
 }
 
-func (d *Peer) makeEnvelope(id string, dest uint32, session *string, cmd *string, err error, data []byte, ttl uint64) (*types.Envelope, error) {
+func (d *Peer) makeEnvelope(id string, dest uint32, session *string, cmd *string, err error, data []byte, ttl uint64, tags string) (*types.Envelope, error) {
 	schema := d.encoder.Schema()
 
 	env := types.Envelope{
@@ -466,6 +475,10 @@ func (d *Peer) makeEnvelope(id string, dest uint32, session *string, cmd *string
 		},
 		Schema: &schema,
 		Relays: d.relays,
+	}
+
+	if tags != "" {
+		env.Tags = &tags
 	}
 
 	if err != nil {
@@ -552,40 +565,34 @@ func (d *Peer) send(ctx context.Context, request *types.Envelope) error {
 
 // SendRequest sends an rmb message to the relay
 func (d *Peer) SendRequest(ctx context.Context, id string, twin uint32, session *string, fn string, data interface{}) error {
-	payload, err := d.encoder.Encode(data)
-	if err != nil {
-		return errors.Wrap(err, "failed to serialize request body")
-	}
+    return d.SendRequestWithTags(ctx, id, twin, session, fn, data, nil)
+}
 
-	var ttl uint64
-	deadline, ok := ctx.Deadline()
-	if ok {
-		if time.Until(deadline) < 0 {
-			return errors.New("context deadline is in the past")
-		}
-		ttl = uint64(time.Until(deadline).Seconds())
+// SendRequestWithTags sends a request with custom tags.
+// Tags are a slice of Tag that will be serialized as a comma-separated string in Envelope.Tags.
+func (d *Peer) SendRequestWithTags(ctx context.Context, id string, twin uint32, session *string, fn string, data interface{}, tags []Tag) error {
+    payload, err := d.encoder.Encode(data)
+    if err != nil {
+        return errors.Wrap(err, "failed to serialize request body")
+    }
 
-		if ttl == 0 {
-			ttl = DefaultTTL
-		}
+    ttl, err := ttlFromContext(ctx)
+    if err != nil {
+        return err
+    }
 
-		if ttl > MaxTTL {
-			ttl = MaxTTL
-		}
-	} else {
-		ttl = DefaultTTL
-	}
+    tagsStr := serializeTags(tags)
 
-	request, err := d.makeEnvelope(id, twin, session, &fn, nil, payload, ttl)
-	if err != nil {
-		return errors.Wrap(err, "failed to build request")
-	}
+    request, err := d.makeEnvelope(id, twin, session, &fn, nil, payload, ttl, tagsStr)
+    if err != nil {
+        return errors.Wrap(err, "failed to build request")
+    }
 
-	if err := d.send(ctx, request); err != nil {
-		return err
-	}
+    if err := d.send(ctx, request); err != nil {
+        return err
+    }
 
-	return nil
+    return nil
 }
 
 // SendResponse sends an rmb message to the relay
@@ -595,7 +602,7 @@ func (d *Peer) SendResponse(ctx context.Context, id string, twin uint32, session
 		return errors.Wrap(err, "failed to serialize request body")
 	}
 
-	request, err := d.makeEnvelope(id, twin, session, nil, responseError, payload, ttl)
+	request, err := d.makeEnvelope(id, twin, session, nil, responseError, payload, ttl, "")
 	if err != nil {
 		return errors.Wrap(err, "failed to build request")
 	}
@@ -629,4 +636,39 @@ func Json(response *types.Envelope, callBackErr error) ([]byte, error) {
 
 	output := response.Payload.(*types.Envelope_Plain).Plain
 	return output, nil
+}
+
+// ttlFromContext computes the TTL (in seconds) from the context deadline, applying
+// defaulting and clamping rules. Returns an error if the deadline is in the past.
+func ttlFromContext(ctx context.Context) (uint64, error) {
+	var ttl uint64
+	deadline, ok := ctx.Deadline()
+	if ok {
+		if time.Until(deadline) < 0 {
+			return 0, errors.New("context deadline is in the past")
+		}
+		ttl = uint64(time.Until(deadline).Seconds())
+		if ttl == 0 {
+			ttl = DefaultTTL
+		}
+		if ttl > MaxTTL {
+			ttl = MaxTTL
+		}
+	} else {
+		ttl = DefaultTTL
+	}
+	return ttl, nil
+}
+
+// serializeTags normalizes a slice of tags (trim spaces, drop empties) and
+// returns a single comma-separated string suitable for Envelope.Tags.
+func serializeTags(tags []Tag) string {
+	norm := make([]string, 0, len(tags))
+	for _, t := range tags {
+		tt := strings.ToLower(strings.TrimSpace(string(t)))
+		if tt != "" {
+			norm = append(norm, tt)
+		}
+	}
+	return strings.Join(norm, ",")
 }

--- a/rmb-sdk-go/peer/peer.go
+++ b/rmb-sdk-go/peer/peer.go
@@ -565,34 +565,34 @@ func (d *Peer) send(ctx context.Context, request *types.Envelope) error {
 
 // SendRequest sends an rmb message to the relay
 func (d *Peer) SendRequest(ctx context.Context, id string, twin uint32, session *string, fn string, data interface{}) error {
-    return d.SendRequestWithTags(ctx, id, twin, session, fn, data, nil)
+	return d.SendRequestWithTags(ctx, id, twin, session, fn, data, nil)
 }
 
 // SendRequestWithTags sends a request with custom tags.
 // Tags are a slice of Tag that will be serialized as a comma-separated string in Envelope.Tags.
 func (d *Peer) SendRequestWithTags(ctx context.Context, id string, twin uint32, session *string, fn string, data interface{}, tags []Tag) error {
-    payload, err := d.encoder.Encode(data)
-    if err != nil {
-        return errors.Wrap(err, "failed to serialize request body")
-    }
+	payload, err := d.encoder.Encode(data)
+	if err != nil {
+		return errors.Wrap(err, "failed to serialize request body")
+	}
 
-    ttl, err := ttlFromContext(ctx)
-    if err != nil {
-        return err
-    }
+	ttl, err := ttlFromContext(ctx)
+	if err != nil {
+		return err
+	}
 
-    tagsStr := serializeTags(tags)
+	tagsStr := serializeTags(tags)
 
-    request, err := d.makeEnvelope(id, twin, session, &fn, nil, payload, ttl, tagsStr)
-    if err != nil {
-        return errors.Wrap(err, "failed to build request")
-    }
+	request, err := d.makeEnvelope(id, twin, session, &fn, nil, payload, ttl, tagsStr)
+	if err != nil {
+		return errors.Wrap(err, "failed to build request")
+	}
 
-    if err := d.send(ctx, request); err != nil {
-        return err
-    }
+	if err := d.send(ctx, request); err != nil {
+		return err
+	}
 
-    return nil
+	return nil
 }
 
 // SendResponse sends an rmb message to the relay

--- a/rmb-sdk-go/peer/rpc.go
+++ b/rmb-sdk-go/peer/rpc.go
@@ -3,11 +3,11 @@ package peer
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	substrate "github.com/threefoldtech/tfchain/clients/tfchain-client-go"
 	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go"
 	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go/peer/types"
@@ -73,11 +73,23 @@ func (d *RpcClient) router(ctx context.Context, peer *Peer, env *types.Envelope,
 		// client is not waiting anymore! just return then
 	}
 }
+
 func (d *RpcClient) Call(ctx context.Context, twin uint32, fn string, data interface{}, result interface{}) error {
 	return d.CallWithSession(ctx, twin, nil, fn, data, result)
 }
 
+// CallWithTags is like Call but allows specifying request tags (e.g., fail-fast)
+func (d *RpcClient) CallWithTags(ctx context.Context, twin uint32, fn string, data interface{}, result interface{}, tags []Tag) error {
+	return d.CallWithSessionWithTags(ctx, twin, nil, fn, data, result, tags)
+}
+
 func (d *RpcClient) CallWithSession(ctx context.Context, twin uint32, session *string, fn string, data interface{}, result interface{}) error {
+	return d.CallWithSessionWithTags(ctx, twin, session, fn, data, result, nil)
+}
+
+// CallWithSessionWithTags is like CallWithSession but allows specifying request tags (e.g., fail-fast)
+// Tags are normalized and serialized by the underlying peer before being set on the envelope.
+func (d *RpcClient) CallWithSessionWithTags(ctx context.Context, twin uint32, session *string, fn string, data interface{}, result interface{}, tags []Tag) error {
 	id := uuid.NewString()
 
 	ch := make(chan incomingEnv, 1)
@@ -93,19 +105,30 @@ func (d *RpcClient) CallWithSession(ctx context.Context, twin uint32, session *s
 	d.responses[id] = ch
 	d.m.Unlock()
 
-	if err := d.base.SendRequest(ctx, id, twin, session, fn, data); err != nil {
-		return err
+	if err := d.base.SendRequestWithTags(ctx, id, twin, session, fn, data, tags); err != nil {
+		return fmt.Errorf("failed to send request (twin=%d, fn=%s): %w", twin, fn, err)
 	}
 
 	var incoming incomingEnv
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return fmt.Errorf("rpc call canceled/timeout (twin=%d, fn=%s): %w", twin, fn, ctx.Err())
 	case incoming = <-ch:
 	}
 
 	if incoming.err != nil {
-		return incoming.err
+		// Error envelope from a destination twin
+		if incoming.env != nil && incoming.env.Source != nil {
+			return fmt.Errorf(
+				"remote error from twin %d (fn=%s, uid=%s): %w",
+				incoming.env.Source.Twin, fn, id, incoming.err,
+			)
+		}
+		// Relay-origin or transport error; envelope may be nil
+		return fmt.Errorf(
+			"relay/transport error (twin=%d, fn=%s, uid=%s): %w",
+			twin, fn, id, incoming.err,
+		)
 	}
 
 	response := incoming.env


### PR DESCRIPTION
**Note**: should be merged after https://github.com/threefoldtech/tfgrid-sdk-go/tree/handle-back-pressure

### Description

Added Request tags support in a backward-compatible way.

- Introduced a Tag type for well-known request tags.

- Added predefined tag `TagFailFast` to instruct relays to fail immediately if the destination is offline.

- New helper `serializeTags()` to normalize and encode tags into a comma-separated string.

- Added a new `SendRequestWithTags` method in Peer that allows sending requests with custom tags.

- Added new `CallWithTags` / `CallWithSessionWithTags` methods in `RpcClient` to allow specifying tags when making RPC calls.

### Changes

- `makeEnvelope` now accepts a tags parameter and sets `Envelope.Tags` if provided.

- `SendRequest` refactored to delegate to `SendRequestWithTags`.

- `SendResponse` updated to use the new `makeEnvelope` signature (with `tags=""`).

- `RpcClient.CallWithSession` now delegates to `CallWithSessionWithTags`.

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-go/issues/1425

### Checklist

- [ ] Tests included
- [X] Build pass
- [ ] Documentation
- [X] Code format and docstring
