### PR TITLE
add calculated public node to the deployed network object

### DIFF
--- a/grid-client/deployer/network_deployer.go
+++ b/grid-client/deployer/network_deployer.go
@@ -125,6 +125,9 @@ func (d *NetworkDeployer) Deploy(ctx context.Context, znet workloads.Network) er
 		nodesUsed = append(nodesUsed, znet.GetPublicNodeID())
 	}
 
+	// update nodes to include the calculated public node if any
+	znet.SetNodes(nodesUsed)
+
 	for _, nodeID := range nodesUsed {
 		if contractID, ok := znet.GetNodeDeploymentID()[nodeID]; ok && contractID != 0 {
 			d.tfPluginClient.State.Networks.UpdateNetworkSubnets(znet.GetName(), znet.GetNodesIPRange())


### PR DESCRIPTION
**Problem**

in case a public node was calculated while deploying a node for first time, the public node is added in the fields (NodeDeploymentIDs, WGPorts, Keys, ..) but not in `Nodes`

in case an update happens to the network, constructing the peers fails cause ip wasn't fetched for the public node, only we have it's ip. so it ends up with endpoint like this `":<port>" 

this gives the error 
```
failed to configure network resource: failed to configure wireguard interface: failed to configure wireguard interface: wglinux: invalid endpoint IP: <nil>
```

**Solution**

just making sure the calculated public node is added to the znet object after the deployment is done