### PR TITLE
Use atomic load to prevent race condition in relay sorting

### DIFF
--- a/rmb-sdk-go/peer/relay_retry_set.go
+++ b/rmb-sdk-go/peer/relay_retry_set.go
@@ -31,7 +31,13 @@ func (s *CooldownRelaySet) Sorted(now time.Time) []RelayPenalty {
 	}
 
 	items := make([]sortableRelay, len(s.Relays))
-	for i, r := range s.Relays {
+	for i := range s.Relays {
+		// Must atomically load LastErrorAt to avoid racing with MarkSuccess/MarkFailure
+		lastErr := atomic.LoadInt64(&s.Relays[i].LastErrorAt)
+		r := RelayPenalty{
+			Relay:       s.Relays[i].Relay,
+			LastErrorAt: lastErr,
+		}
 		items[i] = sortableRelay{
 			RelayPenalty:   r,
 			effectiveError: s.effectiveError(r, now),


### PR DESCRIPTION
### Description
Now all accesses to `LastErrorAt` use atomic operations guarantees proper memory synchronization with atomic stores

### Changes

- `Sorted()`: now use `atomic.LoadInt64()` (fixed)

### Related Issues

- https://github.com/threefoldtech/tfgrid-sdk-go/issues/1463

### Checklist

- [ ] Tests included
- [X] Build pass
- [ ] Documentation
- [X] Code format and docstring
