### PR TITLE
Adding substrate missing methods

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -927,6 +927,7 @@ github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofiber/fiber/v2 v2.52.2/go.mod h1:KEOE+cXMhXG0zHc9d8+E38hoX+ZN7bhOtgeF2oT6jrQ=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
+github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
 github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/googleapis v1.4.1/go.mod h1:2lpHqI5OcWCtVElxXnPt+s8oJvMpySlOyM6xDCrzib4=
@@ -1069,6 +1070,7 @@ github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHW
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/joncrlsn/dque v0.0.0-20200702023911-3e80e3146ce5/go.mod h1:dNKs71rs2VJGBAmttu7fouEsRQlRjxy0p1Sx+T5wbpY=
 github.com/josharian/native v0.0.0-20200817173448-b6b71def0850/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jsimonetti/rtnetlink v0.0.0-20201009170750-9c6f07d100c1/go.mod h1:hqoO/u39cqLeBLebZ8fWdE96O7FxrAsRYhnVOdgHxok=
@@ -1425,8 +1427,6 @@ github.com/threefoldtech/0-fs v1.3.1-0.20230829115549-fb4c502d6d93/go.mod h1:6CV
 github.com/threefoldtech/0-fs v1.3.1-0.20240424140157-b488dfedcc56/go.mod h1:lZjR32SiNo3dP70inVFxaLMyZjmKX1ucS+5O31dbPNM=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20241007205731-5e76664a3cc4/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
 github.com/threefoldtech/zosbase v0.1.4/go.mod h1:rxc49wA04S4IsBOYe0omVO7nu7GXridueh2PJh34gSo=
-github.com/threefoldtech/zosbase v1.0.3 h1:e03oz+KTvuu8Hsm2hDpf/nOIkCz1K6xsXsVvZaahVBc=
-github.com/threefoldtech/zosbase v1.0.3/go.mod h1:3tWVlnT9nZ0r/u1L1JCIZpwSlnvi20FG6Z/yTOCT/7U=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/tinylib/msgp v1.1.8/go.mod h1:qkpG+2ldGg4xRFmx+jfTvZPxfGFhi64BcnL9vkCm/Tw=
 github.com/tklauser/go-sysconf v0.3.5/go.mod h1:MkWzOF4RMCshBAMXuhXJs64Rte09mITnppBXY/rYEFI=

--- a/grid-client/mocks/substrate_manager_mock.go
+++ b/grid-client/mocks/substrate_manager_mock.go
@@ -279,36 +279,6 @@ func (mr *MockSubstrateExtMockRecorder) EnsureContractCanceled(identity, contrac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureContractCanceled", reflect.TypeOf((*MockSubstrateExt)(nil).EnsureContractCanceled), identity, contractID)
 }
 
-// FromTFTtoUSDMillicent mocks base method.
-func (m *MockSubstrateExt) FromTFTtoUSDMillicent(amount uint64) (uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FromTFTtoUSDMillicent", amount)
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FromTFTtoUSDMillicent indicates an expected call of FromTFTtoUSDMillicent.
-func (mr *MockSubstrateExtMockRecorder) FromTFTtoUSDMillicent(amount interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FromTFTtoUSDMillicent", reflect.TypeOf((*MockSubstrateExt)(nil).FromTFTtoUSDMillicent), amount)
-}
-
-// FromUSDMillicentToTFT mocks base method.
-func (m *MockSubstrateExt) FromUSDMillicentToTFT(amountMillicent uint64) (uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FromUSDMillicentToTFT", amountMillicent)
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FromUSDMillicentToTFT indicates an expected call of FromUSDMillicentToTFT.
-func (mr *MockSubstrateExtMockRecorder) FromUSDMillicentToTFT(amountMillicent interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FromUSDMillicentToTFT", reflect.TypeOf((*MockSubstrateExt)(nil).FromUSDMillicentToTFT), amountMillicent)
-}
-
 // GetAccount mocks base method.
 func (m *MockSubstrateExt) GetAccount(identity substrate.Identity) (substrate.AccountInfo, error) {
 	m.ctrl.T.Helper()
@@ -577,36 +547,6 @@ func (m *MockSubstrateExt) GetTwinPK(twinID uint32) ([]byte, error) {
 func (mr *MockSubstrateExtMockRecorder) GetTwinPK(twinID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTwinPK", reflect.TypeOf((*MockSubstrateExt)(nil).GetTwinPK), twinID)
-}
-
-// GetUserBalanceUSD mocks base method.
-func (m *MockSubstrateExt) GetUserBalanceUSD(userMnemonic string) (float64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserBalanceUSD", userMnemonic)
-	ret0, _ := ret[0].(float64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetUserBalanceUSD indicates an expected call of GetUserBalanceUSD.
-func (mr *MockSubstrateExtMockRecorder) GetUserBalanceUSD(userMnemonic interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserBalanceUSD", reflect.TypeOf((*MockSubstrateExt)(nil).GetUserBalanceUSD), userMnemonic)
-}
-
-// GetUserBalanceUSDMillicent mocks base method.
-func (m *MockSubstrateExt) GetUserBalanceUSDMillicent(userMnemonic string) (uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserBalanceUSDMillicent", userMnemonic)
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetUserBalanceUSDMillicent indicates an expected call of GetUserBalanceUSDMillicent.
-func (mr *MockSubstrateExtMockRecorder) GetUserBalanceUSDMillicent(userMnemonic interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserBalanceUSDMillicent", reflect.TypeOf((*MockSubstrateExt)(nil).GetUserBalanceUSDMillicent), userMnemonic)
 }
 
 // InvalidateNameContract mocks base method.

--- a/grid-client/mocks/substrate_manager_mock.go
+++ b/grid-client/mocks/substrate_manager_mock.go
@@ -609,21 +609,6 @@ func (mr *MockSubstrateExtMockRecorder) GetUserBalanceUSDMillicent(userMnemonic 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserBalanceUSDMillicent", reflect.TypeOf((*MockSubstrateExt)(nil).GetUserBalanceUSDMillicent), userMnemonic)
 }
 
-// GetUserTFTBalance mocks base method.
-func (m *MockSubstrateExt) GetUserTFTBalance(userMnemonic string) (uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserTFTBalance", userMnemonic)
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetUserTFTBalance indicates an expected call of GetUserTFTBalance.
-func (mr *MockSubstrateExtMockRecorder) GetUserTFTBalance(userMnemonic interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserTFTBalance", reflect.TypeOf((*MockSubstrateExt)(nil).GetUserTFTBalance), userMnemonic)
-}
-
 // InvalidateNameContract mocks base method.
 func (m *MockSubstrateExt) InvalidateNameContract(ctx context.Context, identity substrate.Identity, contractID uint64, name string) (uint64, error) {
 	m.ctrl.T.Helper()

--- a/grid-client/mocks/substrate_manager_mock.go
+++ b/grid-client/mocks/substrate_manager_mock.go
@@ -222,18 +222,18 @@ func (mr *MockSubstrateExtMockRecorder) CreateNodeContract(identity, node, body,
 }
 
 // CreateRentContract mocks base method.
-func (m *MockSubstrateExt) CreateRentContract(mnemonic string, nodeID uint32, solutionProviderID *uint64) (uint64, error) {
+func (m *MockSubstrateExt) CreateRentContract(identity substrate.Identity, nodeID uint32, solutionProviderID *uint64) (uint64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateRentContract", mnemonic, nodeID, solutionProviderID)
+	ret := m.ctrl.Call(m, "CreateRentContract", identity, nodeID, solutionProviderID)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateRentContract indicates an expected call of CreateRentContract.
-func (mr *MockSubstrateExtMockRecorder) CreateRentContract(mnemonic, nodeID, solutionProviderID interface{}) *gomock.Call {
+func (mr *MockSubstrateExtMockRecorder) CreateRentContract(identity, nodeID, solutionProviderID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRentContract", reflect.TypeOf((*MockSubstrateExt)(nil).CreateRentContract), mnemonic, nodeID, solutionProviderID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRentContract", reflect.TypeOf((*MockSubstrateExt)(nil).CreateRentContract), identity, nodeID, solutionProviderID)
 }
 
 // CreateTwin mocks base method.
@@ -594,32 +594,18 @@ func (mr *MockSubstrateExtMockRecorder) NewIdentityFromSr25519Phrase(mnemonic in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewIdentityFromSr25519Phrase", reflect.TypeOf((*MockSubstrateExt)(nil).NewIdentityFromSr25519Phrase), mnemonic)
 }
 
-// TransferTFTsFromSystem mocks base method.
-func (m *MockSubstrateExt) TransferTFTsFromSystem(tftBalance uint64, userMnemonic, systemMnemonic string) error {
+// Transfer mocks base method.
+func (m *MockSubstrateExt) Transfer(amount uint64, source, destination substrate.Identity) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TransferTFTsFromSystem", tftBalance, userMnemonic, systemMnemonic)
+	ret := m.ctrl.Call(m, "Transfer", amount, source, destination)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// TransferTFTsFromSystem indicates an expected call of TransferTFTsFromSystem.
-func (mr *MockSubstrateExtMockRecorder) TransferTFTsFromSystem(tftBalance, userMnemonic, systemMnemonic interface{}) *gomock.Call {
+// Transfer indicates an expected call of Transfer.
+func (mr *MockSubstrateExtMockRecorder) Transfer(amount, source, destination interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransferTFTsFromSystem", reflect.TypeOf((*MockSubstrateExt)(nil).TransferTFTsFromSystem), tftBalance, userMnemonic, systemMnemonic)
-}
-
-// TransferTFTsToSystem mocks base method.
-func (m *MockSubstrateExt) TransferTFTsToSystem(tftBalance uint64, userMnemonic, systemMnemonic string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TransferTFTsToSystem", tftBalance, userMnemonic, systemMnemonic)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// TransferTFTsToSystem indicates an expected call of TransferTFTsToSystem.
-func (mr *MockSubstrateExtMockRecorder) TransferTFTsToSystem(tftBalance, userMnemonic, systemMnemonic interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransferTFTsToSystem", reflect.TypeOf((*MockSubstrateExt)(nil).TransferTFTsToSystem), tftBalance, userMnemonic, systemMnemonic)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transfer", reflect.TypeOf((*MockSubstrateExt)(nil).Transfer), amount, source, destination)
 }
 
 // UpdateNodeContract mocks base method.

--- a/grid-client/mocks/substrate_manager_mock.go
+++ b/grid-client/mocks/substrate_manager_mock.go
@@ -106,6 +106,20 @@ func (m *MockSubstrateExt) EXPECT() *MockSubstrateExtMockRecorder {
 	return m.recorder
 }
 
+// AcceptTermsAndConditions mocks base method.
+func (m *MockSubstrateExt) AcceptTermsAndConditions(identity substrate.Identity, docLink, docHash string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AcceptTermsAndConditions", identity, docLink, docHash)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AcceptTermsAndConditions indicates an expected call of AcceptTermsAndConditions.
+func (mr *MockSubstrateExtMockRecorder) AcceptTermsAndConditions(identity, docLink, docHash interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptTermsAndConditions", reflect.TypeOf((*MockSubstrateExt)(nil).AcceptTermsAndConditions), identity, docLink, docHash)
+}
+
 // BatchAllCreateContract mocks base method.
 func (m *MockSubstrateExt) BatchAllCreateContract(identity substrate.Identity, contractsData []substrate.BatchCreateContractData) ([]uint64, error) {
 	m.ctrl.T.Helper()
@@ -207,6 +221,36 @@ func (mr *MockSubstrateExtMockRecorder) CreateNodeContract(identity, node, body,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNodeContract", reflect.TypeOf((*MockSubstrateExt)(nil).CreateNodeContract), identity, node, body, hash, publicIPs, solutionProviderID)
 }
 
+// CreateRentContract mocks base method.
+func (m *MockSubstrateExt) CreateRentContract(mnemonic string, nodeID uint32, solutionProviderID *uint64) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateRentContract", mnemonic, nodeID, solutionProviderID)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateRentContract indicates an expected call of CreateRentContract.
+func (mr *MockSubstrateExtMockRecorder) CreateRentContract(mnemonic, nodeID, solutionProviderID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRentContract", reflect.TypeOf((*MockSubstrateExt)(nil).CreateRentContract), mnemonic, nodeID, solutionProviderID)
+}
+
+// CreateTwin mocks base method.
+func (m *MockSubstrateExt) CreateTwin(identity substrate.Identity, relay string, pk []byte) (uint32, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateTwin", identity, relay, pk)
+	ret0, _ := ret[0].(uint32)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTwin indicates an expected call of CreateTwin.
+func (mr *MockSubstrateExtMockRecorder) CreateTwin(identity, relay, pk interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTwin", reflect.TypeOf((*MockSubstrateExt)(nil).CreateTwin), identity, relay, pk)
+}
+
 // DeleteInvalidContracts mocks base method.
 func (m *MockSubstrateExt) DeleteInvalidContracts(contracts map[uint32]uint64) error {
 	m.ctrl.T.Helper()
@@ -233,6 +277,36 @@ func (m *MockSubstrateExt) EnsureContractCanceled(identity substrate.Identity, c
 func (mr *MockSubstrateExtMockRecorder) EnsureContractCanceled(identity, contractID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureContractCanceled", reflect.TypeOf((*MockSubstrateExt)(nil).EnsureContractCanceled), identity, contractID)
+}
+
+// FromTFTtoUSDMillicent mocks base method.
+func (m *MockSubstrateExt) FromTFTtoUSDMillicent(amount uint64) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FromTFTtoUSDMillicent", amount)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FromTFTtoUSDMillicent indicates an expected call of FromTFTtoUSDMillicent.
+func (mr *MockSubstrateExtMockRecorder) FromTFTtoUSDMillicent(amount interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FromTFTtoUSDMillicent", reflect.TypeOf((*MockSubstrateExt)(nil).FromTFTtoUSDMillicent), amount)
+}
+
+// FromUSDMillicentToTFT mocks base method.
+func (m *MockSubstrateExt) FromUSDMillicentToTFT(amountMillicent uint64) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FromUSDMillicentToTFT", amountMillicent)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FromUSDMillicentToTFT indicates an expected call of FromUSDMillicentToTFT.
+func (mr *MockSubstrateExtMockRecorder) FromUSDMillicentToTFT(amountMillicent interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FromUSDMillicentToTFT", reflect.TypeOf((*MockSubstrateExt)(nil).FromUSDMillicentToTFT), amountMillicent)
 }
 
 // GetAccount mocks base method.
@@ -505,6 +579,51 @@ func (mr *MockSubstrateExtMockRecorder) GetTwinPK(twinID interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTwinPK", reflect.TypeOf((*MockSubstrateExt)(nil).GetTwinPK), twinID)
 }
 
+// GetUserBalanceUSD mocks base method.
+func (m *MockSubstrateExt) GetUserBalanceUSD(userMnemonic string) (float64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserBalanceUSD", userMnemonic)
+	ret0, _ := ret[0].(float64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserBalanceUSD indicates an expected call of GetUserBalanceUSD.
+func (mr *MockSubstrateExtMockRecorder) GetUserBalanceUSD(userMnemonic interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserBalanceUSD", reflect.TypeOf((*MockSubstrateExt)(nil).GetUserBalanceUSD), userMnemonic)
+}
+
+// GetUserBalanceUSDMillicent mocks base method.
+func (m *MockSubstrateExt) GetUserBalanceUSDMillicent(userMnemonic string) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserBalanceUSDMillicent", userMnemonic)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserBalanceUSDMillicent indicates an expected call of GetUserBalanceUSDMillicent.
+func (mr *MockSubstrateExtMockRecorder) GetUserBalanceUSDMillicent(userMnemonic interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserBalanceUSDMillicent", reflect.TypeOf((*MockSubstrateExt)(nil).GetUserBalanceUSDMillicent), userMnemonic)
+}
+
+// GetUserTFTBalance mocks base method.
+func (m *MockSubstrateExt) GetUserTFTBalance(userMnemonic string) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserTFTBalance", userMnemonic)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserTFTBalance indicates an expected call of GetUserTFTBalance.
+func (mr *MockSubstrateExtMockRecorder) GetUserTFTBalance(userMnemonic interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserTFTBalance", reflect.TypeOf((*MockSubstrateExt)(nil).GetUserTFTBalance), userMnemonic)
+}
+
 // InvalidateNameContract mocks base method.
 func (m *MockSubstrateExt) InvalidateNameContract(ctx context.Context, identity substrate.Identity, contractID uint64, name string) (uint64, error) {
 	m.ctrl.T.Helper()
@@ -533,6 +652,49 @@ func (m *MockSubstrateExt) IsValidContract(contractID uint64) (bool, error) {
 func (mr *MockSubstrateExtMockRecorder) IsValidContract(contractID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidContract", reflect.TypeOf((*MockSubstrateExt)(nil).IsValidContract), contractID)
+}
+
+// NewIdentityFromSr25519Phrase mocks base method.
+func (m *MockSubstrateExt) NewIdentityFromSr25519Phrase(mnemonic string) (substrate.Identity, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewIdentityFromSr25519Phrase", mnemonic)
+	ret0, _ := ret[0].(substrate.Identity)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NewIdentityFromSr25519Phrase indicates an expected call of NewIdentityFromSr25519Phrase.
+func (mr *MockSubstrateExtMockRecorder) NewIdentityFromSr25519Phrase(mnemonic interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewIdentityFromSr25519Phrase", reflect.TypeOf((*MockSubstrateExt)(nil).NewIdentityFromSr25519Phrase), mnemonic)
+}
+
+// TransferTFTsFromSystem mocks base method.
+func (m *MockSubstrateExt) TransferTFTsFromSystem(tftBalance uint64, userMnemonic, systemMnemonic string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TransferTFTsFromSystem", tftBalance, userMnemonic, systemMnemonic)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TransferTFTsFromSystem indicates an expected call of TransferTFTsFromSystem.
+func (mr *MockSubstrateExtMockRecorder) TransferTFTsFromSystem(tftBalance, userMnemonic, systemMnemonic interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransferTFTsFromSystem", reflect.TypeOf((*MockSubstrateExt)(nil).TransferTFTsFromSystem), tftBalance, userMnemonic, systemMnemonic)
+}
+
+// TransferTFTsToSystem mocks base method.
+func (m *MockSubstrateExt) TransferTFTsToSystem(tftBalance uint64, userMnemonic, systemMnemonic string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TransferTFTsToSystem", tftBalance, userMnemonic, systemMnemonic)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TransferTFTsToSystem indicates an expected call of TransferTFTsToSystem.
+func (mr *MockSubstrateExtMockRecorder) TransferTFTsToSystem(tftBalance, userMnemonic, systemMnemonic interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransferTFTsToSystem", reflect.TypeOf((*MockSubstrateExt)(nil).TransferTFTsToSystem), tftBalance, userMnemonic, systemMnemonic)
 }
 
 // UpdateNodeContract mocks base method.

--- a/grid-client/mocks/substrate_manager_mock.go
+++ b/grid-client/mocks/substrate_manager_mock.go
@@ -595,17 +595,17 @@ func (mr *MockSubstrateExtMockRecorder) NewIdentityFromSr25519Phrase(mnemonic in
 }
 
 // Transfer mocks base method.
-func (m *MockSubstrateExt) Transfer(amount uint64, source, destination substrate.Identity) error {
+func (m *MockSubstrateExt) Transfer(amount uint64, source substrate.Identity, destinationPk []byte) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Transfer", amount, source, destination)
+	ret := m.ctrl.Call(m, "Transfer", amount, source, destinationPk)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Transfer indicates an expected call of Transfer.
-func (mr *MockSubstrateExtMockRecorder) Transfer(amount, source, destination interface{}) *gomock.Call {
+func (mr *MockSubstrateExtMockRecorder) Transfer(amount, source, destinationPk interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transfer", reflect.TypeOf((*MockSubstrateExt)(nil).Transfer), amount, source, destination)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transfer", reflect.TypeOf((*MockSubstrateExt)(nil).Transfer), amount, source, destinationPk)
 }
 
 // UpdateNodeContract mocks base method.

--- a/grid-client/subi/substrate_manager.go
+++ b/grid-client/subi/substrate_manager.go
@@ -36,8 +36,8 @@ func (m *Manager) SubstrateExt() (*SubstrateImpl, error) {
 
 // SubstrateExt interface for substrate client
 type SubstrateExt interface {
-
-	// SetupUserOnTFChain() (mnemonic string, twinID uint32, err error)
+	AcceptTermsAndConditions(identity substrate.Identity, docLink string, docHash string) error
+	CreateTwin(identity substrate.Identity, relay string, pk []byte) (uint32, error)
 	NewIdentityFromSr25519Phrase(mnemonic string) (substrate.Identity, error)
 	TransferTFTsFromSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error
 	TransferTFTsToSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error
@@ -97,9 +97,19 @@ type SubstrateImpl struct {
 
 var _ SubstrateExt = (*SubstrateImpl)(nil)
 
-// NewIdentityFromSr25519Phrase returns the identity from
+// NewIdentityFromSr25519Phrase returns the identity from mnemonic
 func (s *SubstrateImpl) NewIdentityFromSr25519Phrase(mnemonic string) (substrate.Identity, error) {
 	return substrate.NewIdentityFromSr25519Phrase(mnemonic)
+}
+
+// AcceptTermsAndConditions accepts terms and conditions
+func (s *SubstrateImpl) AcceptTermsAndConditions(identity substrate.Identity, docLink string, docHash string) error {
+	return s.Substrate.AcceptTermsAndConditions(identity, docLink, docHash)
+}
+
+// CreateTwin creates a twin and returns its twin ID
+func (s *SubstrateImpl) CreateTwin(identity substrate.Identity, relay string, pk []byte) (uint32, error) {
+	return s.Substrate.CreateTwin(identity, relay, pk)
 }
 
 // CreateRentContract creates a rent contract

--- a/grid-client/subi/substrate_manager.go
+++ b/grid-client/subi/substrate_manager.go
@@ -3,7 +3,6 @@ package subi
 
 import (
 	"context"
-	"math"
 	"sync"
 
 	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
@@ -41,12 +40,6 @@ type SubstrateExt interface {
 	NewIdentityFromSr25519Phrase(mnemonic string) (substrate.Identity, error)
 	TransferTFTsFromSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error
 	TransferTFTsToSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error
-
-	GetUserBalanceUSDMillicent(userMnemonic string) (uint64, error)
-	GetUserBalanceUSD(userMnemonic string) (float64, error)
-
-	FromTFTtoUSDMillicent(amount uint64) (uint64, error)
-	FromUSDMillicentToTFT(amountMillicent uint64) (uint64, error)
 
 	CreateRentContract(mnemonic string, nodeID uint32, solutionProviderID *uint64) (uint64, error)
 
@@ -153,62 +146,6 @@ func (s *SubstrateImpl) TransferTFTsToSystem(tftBalance uint64, userMnemonic str
 	}
 
 	return s.Transfer(userIdentity, tftBalance, substrate.AccountID(systemIdentity.PublicKey()))
-}
-
-// FromTFTtoUSDMillicent converts TFT amount to USD Millicent (1/1000 of a dollar)
-func (s *SubstrateImpl) FromTFTtoUSDMillicent(amount uint64) (uint64, error) {
-	price, err := s.GetTFTPrice()
-	if err != nil {
-		return 0, err
-	}
-
-	usdMillicentBalance := uint64(math.Round((float64(amount) / 1e7) * float64(price)))
-	return usdMillicentBalance, nil
-}
-
-// FromUSDMillicentToTFT converts USD Millicent to TFT amount
-// This avoids floating point precision issues by accepting an integer value
-func (s *SubstrateImpl) FromUSDMillicentToTFT(amountMillicent uint64) (uint64, error) {
-	price, err := s.GetTFTPrice()
-	if err != nil {
-		return 0, err
-	}
-
-	// Convert Millicent to dollars for the calculation
-	amountUSD := fromUSDMilliCentToUSD(amountMillicent)
-	tft := (amountUSD * 1e7) / (float64(price) / 1000)
-	return uint64(tft), nil
-}
-
-func fromUSDMilliCentToUSD(amountMillicent uint64) float64 {
-	return float64(amountMillicent) / 1000
-}
-
-// GetUserBalanceUSDMillicent gets balance of user in USD Millicent
-// This avoids floating point precision issues by returning an integer value
-func (s *SubstrateImpl) GetUserBalanceUSDMillicent(userMnemonic string) (uint64, error) {
-	// Create identity of user from mnemonic
-	userIdentity, err := substrate.NewIdentityFromSr25519Phrase(userMnemonic)
-	if err != nil {
-		return 0, err
-	}
-
-	tftBalance, err := s.GetBalance(userIdentity)
-	if err != nil {
-		return 0, err
-	}
-
-	return s.FromTFTtoUSDMillicent(tftBalance.Free.Uint64())
-}
-
-// GetUserBalanceUSD gets balance of user in USD
-func (s *SubstrateImpl) GetUserBalanceUSD(userMnemonic string) (float64, error) {
-	usdMillicentBalance, err := s.GetUserBalanceUSDMillicent(userMnemonic)
-	if err != nil {
-		return 0, err
-	}
-
-	return fromUSDMilliCentToUSD(usdMillicentBalance), nil
 }
 
 // GetAccount returns the user's account

--- a/grid-client/subi/substrate_manager.go
+++ b/grid-client/subi/substrate_manager.go
@@ -35,13 +35,12 @@ func (m *Manager) SubstrateExt() (*SubstrateImpl, error) {
 
 // SubstrateExt interface for substrate client
 type SubstrateExt interface {
+	NewIdentityFromSr25519Phrase(mnemonic string) (substrate.Identity, error)
 	AcceptTermsAndConditions(identity substrate.Identity, docLink string, docHash string) error
 	CreateTwin(identity substrate.Identity, relay string, pk []byte) (uint32, error)
-	NewIdentityFromSr25519Phrase(mnemonic string) (substrate.Identity, error)
-	TransferTFTsFromSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error
-	TransferTFTsToSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error
-
 	CreateRentContract(mnemonic string, nodeID uint32, solutionProviderID *uint64) (uint64, error)
+	TransferTFTsToSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error
+	TransferTFTsFromSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error
 
 	CancelContract(identity substrate.Identity, contractID uint64) error
 	CreateNodeContract(identity substrate.Identity, node uint32, body string, hash string, publicIPs uint32, solutionProviderID *uint64) (uint64, error)
@@ -96,12 +95,17 @@ func (s *SubstrateImpl) NewIdentityFromSr25519Phrase(mnemonic string) (substrate
 
 // AcceptTermsAndConditions accepts terms and conditions
 func (s *SubstrateImpl) AcceptTermsAndConditions(identity substrate.Identity, docLink string, docHash string) error {
+	s.m.Lock()
+	defer s.m.Unlock()
 	return s.Substrate.AcceptTermsAndConditions(identity, docLink, docHash)
 }
 
 // CreateTwin creates a twin and returns its twin ID
 func (s *SubstrateImpl) CreateTwin(identity substrate.Identity, relay string, pk []byte) (uint32, error) {
-	return s.Substrate.CreateTwin(identity, relay, pk)
+	s.m.Lock()
+	defer s.m.Unlock()
+	twin, err := s.Substrate.CreateTwin(identity, relay, pk)
+	return twin, normalizeNotFoundErrors(err)
 }
 
 // CreateRentContract creates a rent contract
@@ -110,41 +114,48 @@ func (s *SubstrateImpl) CreateRentContract(mnemonic string, nodeID uint32, solut
 	if err != nil {
 		return 0, err
 	}
+	s.m.Lock()
+	defer s.m.Unlock()
 
-	return s.Substrate.CreateRentContract(identity, nodeID, solutionProviderID)
+	contract, err := s.Substrate.CreateRentContract(identity, nodeID, solutionProviderID)
+	return contract, normalizeNotFoundErrors(err)
 }
 
 // TransferTFTsFromSystem transfer balance to users' account
 func (s *SubstrateImpl) TransferTFTsFromSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error {
 	// Create identity of user from mnemonic
-	userIdentity, err := substrate.NewIdentityFromSr25519Phrase(userMnemonic)
+	userIdentity, err := s.NewIdentityFromSr25519Phrase(userMnemonic)
 	if err != nil {
 		return err
 	}
 
 	// Create identity of system from mnemonic
-	systemIdentity, err := substrate.NewIdentityFromSr25519Phrase(systemMnemonic)
+	systemIdentity, err := s.NewIdentityFromSr25519Phrase(systemMnemonic)
 	if err != nil {
 		return err
 	}
 
+	s.m.Lock()
+	defer s.m.Unlock()
 	return s.Transfer(systemIdentity, tftBalance, substrate.AccountID(userIdentity.PublicKey()))
 }
 
 // TransferTFTsToSystem transfer balance to system account
 func (s *SubstrateImpl) TransferTFTsToSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error {
 	// Create identity of user from mnemonic
-	userIdentity, err := substrate.NewIdentityFromSr25519Phrase(userMnemonic)
+	userIdentity, err := s.NewIdentityFromSr25519Phrase(userMnemonic)
 	if err != nil {
 		return err
 	}
 
 	// Create identity of system from mnemonic
-	systemIdentity, err := substrate.NewIdentityFromSr25519Phrase(systemMnemonic)
+	systemIdentity, err := s.NewIdentityFromSr25519Phrase(systemMnemonic)
 	if err != nil {
 		return err
 	}
 
+	s.m.Lock()
+	defer s.m.Unlock()
 	return s.Transfer(userIdentity, tftBalance, substrate.AccountID(systemIdentity.PublicKey()))
 }
 

--- a/grid-client/subi/substrate_manager.go
+++ b/grid-client/subi/substrate_manager.go
@@ -44,7 +44,6 @@ type SubstrateExt interface {
 
 	GetUserBalanceUSDMillicent(userMnemonic string) (uint64, error)
 	GetUserBalanceUSD(userMnemonic string) (float64, error)
-	GetUserTFTBalance(userMnemonic string) (uint64, error)
 
 	FromTFTtoUSDMillicent(amount uint64) (uint64, error)
 	FromUSDMillicentToTFT(amountMillicent uint64) (uint64, error)
@@ -156,28 +155,6 @@ func (s *SubstrateImpl) TransferTFTsToSystem(tftBalance uint64, userMnemonic str
 	return s.Transfer(userIdentity, tftBalance, substrate.AccountID(systemIdentity.PublicKey()))
 }
 
-// GetUserBalanceUSD gets balance of user in TFT
-func (s *SubstrateImpl) GetUserTFTBalance(userMnemonic string) (uint64, error) {
-	// Create identity of user from mnemonic
-	userIdentity, err := substrate.NewIdentityFromSr25519Phrase(userMnemonic)
-	if err != nil {
-		return 0, err
-	}
-
-	account, err := substrate.FromAddress(userIdentity.Address())
-	if err != nil {
-		return 0, err
-	}
-
-	// get balance in TFT
-	tftBalance, err := s.Substrate.GetBalance(account)
-	if err != nil {
-		return 0, err
-	}
-
-	return tftBalance.Free.Uint64(), nil
-}
-
 // FromTFTtoUSDMillicent converts TFT amount to USD Millicent (1/1000 of a dollar)
 func (s *SubstrateImpl) FromTFTtoUSDMillicent(amount uint64) (uint64, error) {
 	price, err := s.GetTFTPrice()
@@ -210,12 +187,18 @@ func fromUSDMilliCentToUSD(amountMillicent uint64) float64 {
 // GetUserBalanceUSDMillicent gets balance of user in USD Millicent
 // This avoids floating point precision issues by returning an integer value
 func (s *SubstrateImpl) GetUserBalanceUSDMillicent(userMnemonic string) (uint64, error) {
-	tftBalance, err := s.GetUserTFTBalance(userMnemonic)
+	// Create identity of user from mnemonic
+	userIdentity, err := substrate.NewIdentityFromSr25519Phrase(userMnemonic)
 	if err != nil {
 		return 0, err
 	}
 
-	return s.FromTFTtoUSDMillicent(tftBalance)
+	tftBalance, err := s.GetBalance(userIdentity)
+	if err != nil {
+		return 0, err
+	}
+
+	return s.FromTFTtoUSDMillicent(tftBalance.Free.Uint64())
 }
 
 // GetUserBalanceUSD gets balance of user in USD

--- a/grid-client/subi/substrate_manager.go
+++ b/grid-client/subi/substrate_manager.go
@@ -38,9 +38,8 @@ type SubstrateExt interface {
 	NewIdentityFromSr25519Phrase(mnemonic string) (substrate.Identity, error)
 	AcceptTermsAndConditions(identity substrate.Identity, docLink string, docHash string) error
 	CreateTwin(identity substrate.Identity, relay string, pk []byte) (uint32, error)
-	CreateRentContract(mnemonic string, nodeID uint32, solutionProviderID *uint64) (uint64, error)
-	TransferTFTsToSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error
-	TransferTFTsFromSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error
+	CreateRentContract(identity substrate.Identity, nodeID uint32, solutionProviderID *uint64) (uint64, error)
+	Transfer(amount uint64, source substrate.Identity, destination substrate.Identity) error
 
 	CancelContract(identity substrate.Identity, contractID uint64) error
 	CreateNodeContract(identity substrate.Identity, node uint32, body string, hash string, publicIPs uint32, solutionProviderID *uint64) (uint64, error)
@@ -109,11 +108,7 @@ func (s *SubstrateImpl) CreateTwin(identity substrate.Identity, relay string, pk
 }
 
 // CreateRentContract creates a rent contract
-func (s *SubstrateImpl) CreateRentContract(mnemonic string, nodeID uint32, solutionProviderID *uint64) (uint64, error) {
-	identity, err := s.NewIdentityFromSr25519Phrase(mnemonic)
-	if err != nil {
-		return 0, err
-	}
+func (s *SubstrateImpl) CreateRentContract(identity substrate.Identity, nodeID uint32, solutionProviderID *uint64) (uint64, error) {
 	s.m.Lock()
 	defer s.m.Unlock()
 
@@ -121,42 +116,12 @@ func (s *SubstrateImpl) CreateRentContract(mnemonic string, nodeID uint32, solut
 	return contract, normalizeNotFoundErrors(err)
 }
 
-// TransferTFTsFromSystem transfer balance to users' account
-func (s *SubstrateImpl) TransferTFTsFromSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error {
-	// Create identity of user from mnemonic
-	userIdentity, err := s.NewIdentityFromSr25519Phrase(userMnemonic)
-	if err != nil {
-		return err
-	}
-
-	// Create identity of system from mnemonic
-	systemIdentity, err := s.NewIdentityFromSr25519Phrase(systemMnemonic)
-	if err != nil {
-		return err
-	}
-
+// Transfer transfers an amount from source to destination
+func (s *SubstrateImpl) Transfer(amount uint64, source substrate.Identity, destination substrate.Identity) error {
 	s.m.Lock()
 	defer s.m.Unlock()
-	return s.Transfer(systemIdentity, tftBalance, substrate.AccountID(userIdentity.PublicKey()))
-}
 
-// TransferTFTsToSystem transfer balance to system account
-func (s *SubstrateImpl) TransferTFTsToSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error {
-	// Create identity of user from mnemonic
-	userIdentity, err := s.NewIdentityFromSr25519Phrase(userMnemonic)
-	if err != nil {
-		return err
-	}
-
-	// Create identity of system from mnemonic
-	systemIdentity, err := s.NewIdentityFromSr25519Phrase(systemMnemonic)
-	if err != nil {
-		return err
-	}
-
-	s.m.Lock()
-	defer s.m.Unlock()
-	return s.Transfer(userIdentity, tftBalance, substrate.AccountID(systemIdentity.PublicKey()))
+	return s.Substrate.Transfer(source, amount, substrate.AccountID(destination.PublicKey()))
 }
 
 // GetAccount returns the user's account

--- a/grid-client/subi/substrate_manager.go
+++ b/grid-client/subi/substrate_manager.go
@@ -39,7 +39,7 @@ type SubstrateExt interface {
 	AcceptTermsAndConditions(identity substrate.Identity, docLink string, docHash string) error
 	CreateTwin(identity substrate.Identity, relay string, pk []byte) (uint32, error)
 	CreateRentContract(identity substrate.Identity, nodeID uint32, solutionProviderID *uint64) (uint64, error)
-	Transfer(amount uint64, source substrate.Identity, destination substrate.Identity) error
+	Transfer(amount uint64, source substrate.Identity, destinationPk []byte) error
 
 	CancelContract(identity substrate.Identity, contractID uint64) error
 	CreateNodeContract(identity substrate.Identity, node uint32, body string, hash string, publicIPs uint32, solutionProviderID *uint64) (uint64, error)
@@ -117,11 +117,11 @@ func (s *SubstrateImpl) CreateRentContract(identity substrate.Identity, nodeID u
 }
 
 // Transfer transfers an amount from source to destination
-func (s *SubstrateImpl) Transfer(amount uint64, source substrate.Identity, destination substrate.Identity) error {
+func (s *SubstrateImpl) Transfer(amount uint64, source substrate.Identity, destinationPk []byte) error {
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	return s.Substrate.Transfer(source, amount, substrate.AccountID(destination.PublicKey()))
+	return s.Substrate.Transfer(source, amount, substrate.AccountID(destinationPk))
 }
 
 // GetAccount returns the user's account

--- a/grid-client/subi/substrate_manager.go
+++ b/grid-client/subi/substrate_manager.go
@@ -136,7 +136,7 @@ func (s *SubstrateImpl) TransferTFTsFromSystem(tftBalance uint64, userMnemonic s
 		return err
 	}
 
-	return s.Substrate.Transfer(systemIdentity, tftBalance, substrate.AccountID(userIdentity.PublicKey()))
+	return s.Transfer(systemIdentity, tftBalance, substrate.AccountID(userIdentity.PublicKey()))
 }
 
 // TransferTFTsToSystem transfer balance to system account
@@ -153,7 +153,7 @@ func (s *SubstrateImpl) TransferTFTsToSystem(tftBalance uint64, userMnemonic str
 		return err
 	}
 
-	return s.Substrate.Transfer(userIdentity, tftBalance, substrate.AccountID(systemIdentity.PublicKey()))
+	return s.Transfer(userIdentity, tftBalance, substrate.AccountID(systemIdentity.PublicKey()))
 }
 
 // GetUserBalanceUSD gets balance of user in TFT

--- a/grid-client/subi/substrate_manager.go
+++ b/grid-client/subi/substrate_manager.go
@@ -3,6 +3,7 @@ package subi
 
 import (
 	"context"
+	"math"
 	"sync"
 
 	"github.com/centrifuge/go-substrate-rpc-client/v4/types"
@@ -35,6 +36,21 @@ func (m *Manager) SubstrateExt() (*SubstrateImpl, error) {
 
 // SubstrateExt interface for substrate client
 type SubstrateExt interface {
+
+	// SetupUserOnTFChain() (mnemonic string, twinID uint32, err error)
+	NewIdentityFromSr25519Phrase(mnemonic string) (substrate.Identity, error)
+	TransferTFTsFromSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error
+	TransferTFTsToSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error
+
+	GetUserBalanceUSDMillicent(userMnemonic string) (uint64, error)
+	GetUserBalanceUSD(userMnemonic string) (float64, error)
+	GetUserTFTBalance(userMnemonic string) (uint64, error)
+
+	FromTFTtoUSDMillicent(amount uint64) (uint64, error)
+	FromUSDMillicentToTFT(amountMillicent uint64) (uint64, error)
+
+	CreateRentContract(mnemonic string, nodeID uint32, solutionProviderID *uint64) (uint64, error)
+
 	CancelContract(identity substrate.Identity, contractID uint64) error
 	CreateNodeContract(identity substrate.Identity, node uint32, body string, hash string, publicIPs uint32, solutionProviderID *uint64) (uint64, error)
 	UpdateNodeContract(identity substrate.Identity, contract uint64, body string, hash string) (uint64, error)
@@ -77,6 +93,129 @@ type SubstrateExt interface {
 type SubstrateImpl struct {
 	*substrate.Substrate
 	m sync.Mutex
+}
+
+var _ SubstrateExt = (*SubstrateImpl)(nil)
+
+// NewIdentityFromSr25519Phrase returns the identity from
+func (s *SubstrateImpl) NewIdentityFromSr25519Phrase(mnemonic string) (substrate.Identity, error) {
+	return substrate.NewIdentityFromSr25519Phrase(mnemonic)
+}
+
+// CreateRentContract creates a rent contract
+func (s *SubstrateImpl) CreateRentContract(mnemonic string, nodeID uint32, solutionProviderID *uint64) (uint64, error) {
+	identity, err := s.NewIdentityFromSr25519Phrase(mnemonic)
+	if err != nil {
+		return 0, err
+	}
+
+	return s.Substrate.CreateRentContract(identity, nodeID, solutionProviderID)
+}
+
+// TransferTFTsFromSystem transfer balance to users' account
+func (s *SubstrateImpl) TransferTFTsFromSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error {
+	// Create identity of user from mnemonic
+	userIdentity, err := substrate.NewIdentityFromSr25519Phrase(userMnemonic)
+	if err != nil {
+		return err
+	}
+
+	// Create identity of system from mnemonic
+	systemIdentity, err := substrate.NewIdentityFromSr25519Phrase(systemMnemonic)
+	if err != nil {
+		return err
+	}
+
+	return s.Substrate.Transfer(systemIdentity, tftBalance, substrate.AccountID(userIdentity.PublicKey()))
+}
+
+// TransferTFTsToSystem transfer balance to system account
+func (s *SubstrateImpl) TransferTFTsToSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error {
+	// Create identity of user from mnemonic
+	userIdentity, err := substrate.NewIdentityFromSr25519Phrase(userMnemonic)
+	if err != nil {
+		return err
+	}
+
+	// Create identity of system from mnemonic
+	systemIdentity, err := substrate.NewIdentityFromSr25519Phrase(systemMnemonic)
+	if err != nil {
+		return err
+	}
+
+	return s.Substrate.Transfer(userIdentity, tftBalance, substrate.AccountID(systemIdentity.PublicKey()))
+}
+
+// GetUserBalanceUSD gets balance of user in TFT
+func (s *SubstrateImpl) GetUserTFTBalance(userMnemonic string) (uint64, error) {
+	// Create identity of user from mnemonic
+	userIdentity, err := substrate.NewIdentityFromSr25519Phrase(userMnemonic)
+	if err != nil {
+		return 0, err
+	}
+
+	account, err := substrate.FromAddress(userIdentity.Address())
+	if err != nil {
+		return 0, err
+	}
+
+	// get balance in TFT
+	tftBalance, err := s.Substrate.GetBalance(account)
+	if err != nil {
+		return 0, err
+	}
+
+	return tftBalance.Free.Uint64(), nil
+}
+
+// FromTFTtoUSDMillicent converts TFT amount to USD Millicent (1/1000 of a dollar)
+func (s *SubstrateImpl) FromTFTtoUSDMillicent(amount uint64) (uint64, error) {
+	price, err := s.GetTFTPrice()
+	if err != nil {
+		return 0, err
+	}
+
+	usdMillicentBalance := uint64(math.Round((float64(amount) / 1e7) * float64(price)))
+	return usdMillicentBalance, nil
+}
+
+// FromUSDMillicentToTFT converts USD Millicent to TFT amount
+// This avoids floating point precision issues by accepting an integer value
+func (s *SubstrateImpl) FromUSDMillicentToTFT(amountMillicent uint64) (uint64, error) {
+	price, err := s.GetTFTPrice()
+	if err != nil {
+		return 0, err
+	}
+
+	// Convert Millicent to dollars for the calculation
+	amountUSD := fromUSDMilliCentToUSD(amountMillicent)
+	tft := (amountUSD * 1e7) / (float64(price) / 1000)
+	return uint64(tft), nil
+}
+
+func fromUSDMilliCentToUSD(amountMillicent uint64) float64 {
+	return float64(amountMillicent) / 1000
+}
+
+// GetUserBalanceUSDMillicent gets balance of user in USD Millicent
+// This avoids floating point precision issues by returning an integer value
+func (s *SubstrateImpl) GetUserBalanceUSDMillicent(userMnemonic string) (uint64, error) {
+	tftBalance, err := s.GetUserTFTBalance(userMnemonic)
+	if err != nil {
+		return 0, err
+	}
+
+	return s.FromTFTtoUSDMillicent(tftBalance)
+}
+
+// GetUserBalanceUSD gets balance of user in USD
+func (s *SubstrateImpl) GetUserBalanceUSD(userMnemonic string) (float64, error) {
+	usdMillicentBalance, err := s.GetUserBalanceUSDMillicent(userMnemonic)
+	if err != nil {
+		return 0, err
+	}
+
+	return fromUSDMilliCentToUSD(usdMillicentBalance), nil
 }
 
 // GetAccount returns the user's account


### PR DESCRIPTION
### Description

Adding substrate missing methods to be able to unify the client in kubecloud

### Changes

Added these methods to interface and implementation, updated their mock:
```go
AcceptTermsAndConditions(identity substrate.Identity, docLink string, docHash string) error
CreateTwin(identity substrate.Identity, relay string, pk []byte) (uint32, error)
NewIdentityFromSr25519Phrase(mnemonic string) (substrate.Identity, error)
TransferTFTsFromSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error
TransferTFTsToSystem(tftBalance uint64, userMnemonic string, systemMnemonic string) error

CreateRentContract(mnemonic string, nodeID uint32, solutionProviderID *uint64) (uint64, error)
```

### Related Issues

https://github.com/threefoldtech/tfgrid-sdk-go/issues/1470

### Checklist

- [x] Tests included
- [x] Build pass
- [ ] Documentation
- [ ] Code format and docstring
