### PR TITLE
Fix rmb client peer process panic

### DIFF
--- a/rmb-sdk-go/peer/rpc.go
+++ b/rmb-sdk-go/peer/rpc.go
@@ -103,8 +103,6 @@ func (d *RpcClient) CallWithSessionWithTags(ctx context.Context, twin uint32, se
 
 	ch := make(chan incomingEnv, 1)
 	defer func() {
-		close(ch)
-
 		d.m.Lock()
 		delete(d.responses, id)
 		d.m.Unlock()


### PR DESCRIPTION
### Description

This PR fix a bug where two goroutines shared responsibility for the same channel:
`Call`: closed it,
`router`: sent to it,
without synchronization around close.

### Changes

- only delete the map entry; never close the per‑call channel.
That makes it impossible for `router` to hit a closed channel, while still allowing late responses to be ignored safely.

### Related Issues

- #1476

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
