### PR TITLE
chore: update zosbase@v1.0.4 and rmb-sdk-go@v0.17.5 

### DIFF
--- a/grid-cli/go.mod
+++ b/grid-cli/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/threefoldtech/tfgrid-sdk-go/grid-client v0.15.18
 	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0
-	github.com/threefoldtech/zosbase v1.0.3
+	github.com/threefoldtech/zosbase v1.0.4
 	github.com/vedhavyas/go-subkey v1.0.3
 )
 
@@ -50,7 +50,7 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30 // indirect
-	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.3 // indirect
+	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.5 // indirect
 	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect
 	golang.org/x/sync v0.13.0 // indirect

--- a/grid-cli/go.sum
+++ b/grid-cli/go.sum
@@ -125,8 +125,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30 h1:sH/hiHxCEpeIm2gJsmu4GxKskfQVPZMz9PAgDwk1BfY=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
-github.com/threefoldtech/zosbase v1.0.3 h1:e03oz+KTvuu8Hsm2hDpf/nOIkCz1K6xsXsVvZaahVBc=
-github.com/threefoldtech/zosbase v1.0.3/go.mod h1:3tWVlnT9nZ0r/u1L1JCIZpwSlnvi20FG6Z/yTOCT/7U=
+github.com/threefoldtech/zosbase v1.0.4 h1:A4kFukh4IO5r5e9F51aqKgXOyTG5cWknxqEVGtQ647w=
+github.com/threefoldtech/zosbase v1.0.4/go.mod h1:ZZ1M8SZVr7k4tH2URr5DMEbcwZoQDpBZWgboHdiNE+k=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/grid-client/go.mod
+++ b/grid-client/go.mod
@@ -19,8 +19,8 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30
 	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0
-	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.3
-	github.com/threefoldtech/zosbase v1.0.3
+	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.5
+	github.com/threefoldtech/zosbase v1.0.4
 	github.com/vedhavyas/go-subkey v1.0.3
 	golang.org/x/crypto v0.37.0
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c

--- a/grid-client/go.sum
+++ b/grid-client/go.sum
@@ -129,8 +129,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30 h1:sH/hiHxCEpeIm2gJsmu4GxKskfQVPZMz9PAgDwk1BfY=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
-github.com/threefoldtech/zosbase v1.0.3 h1:e03oz+KTvuu8Hsm2hDpf/nOIkCz1K6xsXsVvZaahVBc=
-github.com/threefoldtech/zosbase v1.0.3/go.mod h1:3tWVlnT9nZ0r/u1L1JCIZpwSlnvi20FG6Z/yTOCT/7U=
+github.com/threefoldtech/zosbase v1.0.4 h1:A4kFukh4IO5r5e9F51aqKgXOyTG5cWknxqEVGtQ647w=
+github.com/threefoldtech/zosbase v1.0.4/go.mod h1:ZZ1M8SZVr7k4tH2URr5DMEbcwZoQDpBZWgboHdiNE+k=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/grid-proxy/go.mod
+++ b/grid-proxy/go.mod
@@ -19,8 +19,8 @@ require (
 	github.com/swaggo/http-swagger v1.3.4
 	github.com/swaggo/swag v1.16.4
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30
-	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.3
-	github.com/threefoldtech/zosbase v1.0.3
+	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.5
+	github.com/threefoldtech/zosbase v1.0.4
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	gorm.io/driver/postgres v1.5.7
 	gorm.io/gorm v1.25.10

--- a/grid-proxy/go.sum
+++ b/grid-proxy/go.sum
@@ -193,8 +193,8 @@ github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
 github.com/threefoldtech/zbus v1.0.1 h1:3KaEpyOiDYAw+lrAyoQUGIvY9BcjVRXlQ1beBRqhRNk=
 github.com/threefoldtech/zbus v1.0.1/go.mod h1:E/v/xEvG/l6z/Oj0aDkuSUXFm/1RVJkhKBwDTAIdsHo=
-github.com/threefoldtech/zosbase v1.0.3 h1:e03oz+KTvuu8Hsm2hDpf/nOIkCz1K6xsXsVvZaahVBc=
-github.com/threefoldtech/zosbase v1.0.3/go.mod h1:3tWVlnT9nZ0r/u1L1JCIZpwSlnvi20FG6Z/yTOCT/7U=
+github.com/threefoldtech/zosbase v1.0.4 h1:A4kFukh4IO5r5e9F51aqKgXOyTG5cWknxqEVGtQ647w=
+github.com/threefoldtech/zosbase v1.0.4/go.mod h1:ZZ1M8SZVr7k4tH2URr5DMEbcwZoQDpBZWgboHdiNE+k=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/grid-proxy/internal/indexer/speed.go
+++ b/grid-proxy/internal/indexer/speed.go
@@ -79,7 +79,11 @@ func (w *SpeedWork) Get(ctx context.Context, rmb *peer.RpcClient, twinId uint32)
 }
 
 func (w *SpeedWork) Upsert(ctx context.Context, db db.Database, batch []types.Speed) error {
-	return db.UpsertNetworkSpeed(ctx, batch)
+	// to prevent having multiple data for the same twin from different finders
+	unique := removeDuplicates(batch, func(n types.Speed) uint32 {
+		return n.NodeTwinId
+	})
+	return db.UpsertNetworkSpeed(ctx, unique)
 }
 
 func updateWithFirstNonZero(current, newValue float64) float64 {

--- a/gridify/go.mod
+++ b/gridify/go.mod
@@ -64,8 +64,8 @@ require (
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30 // indirect
-	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.3 // indirect
-	github.com/threefoldtech/zosbase v1.0.3 // indirect
+	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.5 // indirect
+	github.com/threefoldtech/zosbase v1.0.4 // indirect
 	github.com/vedhavyas/go-subkey v1.0.3 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/crypto v0.37.0 // indirect

--- a/gridify/go.sum
+++ b/gridify/go.sum
@@ -175,8 +175,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30 h1:sH/hiHxCEpeIm2gJsmu4GxKskfQVPZMz9PAgDwk1BfY=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
-github.com/threefoldtech/zosbase v1.0.3 h1:e03oz+KTvuu8Hsm2hDpf/nOIkCz1K6xsXsVvZaahVBc=
-github.com/threefoldtech/zosbase v1.0.3/go.mod h1:3tWVlnT9nZ0r/u1L1JCIZpwSlnvi20FG6Z/yTOCT/7U=
+github.com/threefoldtech/zosbase v1.0.4 h1:A4kFukh4IO5r5e9F51aqKgXOyTG5cWknxqEVGtQ647w=
+github.com/threefoldtech/zosbase v1.0.4/go.mod h1:ZZ1M8SZVr7k4tH2URr5DMEbcwZoQDpBZWgboHdiNE+k=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/tfrobot/go.mod
+++ b/tfrobot/go.mod
@@ -59,8 +59,8 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.3 // indirect
-	github.com/threefoldtech/zosbase v1.0.3 // indirect
+	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.5 // indirect
+	github.com/threefoldtech/zosbase v1.0.4 // indirect
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/text v0.24.0 // indirect

--- a/tfrobot/go.sum
+++ b/tfrobot/go.sum
@@ -145,8 +145,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30 h1:sH/hiHxCEpeIm2gJsmu4GxKskfQVPZMz9PAgDwk1BfY=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
-github.com/threefoldtech/zosbase v1.0.3 h1:e03oz+KTvuu8Hsm2hDpf/nOIkCz1K6xsXsVvZaahVBc=
-github.com/threefoldtech/zosbase v1.0.3/go.mod h1:3tWVlnT9nZ0r/u1L1JCIZpwSlnvi20FG6Z/yTOCT/7U=
+github.com/threefoldtech/zosbase v1.0.4 h1:A4kFukh4IO5r5e9F51aqKgXOyTG5cWknxqEVGtQ647w=
+github.com/threefoldtech/zosbase v1.0.4/go.mod h1:ZZ1M8SZVr7k4tH2URr5DMEbcwZoQDpBZWgboHdiNE+k=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/user-contracts-mon/go.mod
+++ b/user-contracts-mon/go.mod
@@ -45,8 +45,8 @@ require (
 	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30 // indirect
 	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0 // indirect
-	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.3 // indirect
-	github.com/threefoldtech/zosbase v1.0.3 // indirect
+	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.5 // indirect
+	github.com/threefoldtech/zosbase v1.0.4 // indirect
 	github.com/vedhavyas/go-subkey v1.0.3 // indirect
 	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/sync v0.13.0 // indirect

--- a/user-contracts-mon/go.sum
+++ b/user-contracts-mon/go.sum
@@ -115,8 +115,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30 h1:sH/hiHxCEpeIm2gJsmu4GxKskfQVPZMz9PAgDwk1BfY=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
-github.com/threefoldtech/zosbase v1.0.3 h1:e03oz+KTvuu8Hsm2hDpf/nOIkCz1K6xsXsVvZaahVBc=
-github.com/threefoldtech/zosbase v1.0.3/go.mod h1:3tWVlnT9nZ0r/u1L1JCIZpwSlnvi20FG6Z/yTOCT/7U=
+github.com/threefoldtech/zosbase v1.0.4 h1:A4kFukh4IO5r5e9F51aqKgXOyTG5cWknxqEVGtQ647w=
+github.com/threefoldtech/zosbase v1.0.4/go.mod h1:ZZ1M8SZVr7k4tH2URr5DMEbcwZoQDpBZWgboHdiNE+k=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=


### PR DESCRIPTION
- update zosbase@v1.0.4 and rmb-sdk-go@v0.17.5 
- fix speed upsert conflict
