### PR TITLE
Feat implement node slice

### DIFF
--- a/grid-client/mocks/grid_client_mock.go
+++ b/grid-client/mocks/grid_client_mock.go
@@ -383,3 +383,17 @@ func (mr *MockClientMockRecorder) Twins(ctx, filter, pagination interface{}) *go
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Twins", reflect.TypeOf((*MockClient)(nil).Twins), ctx, filter, pagination)
 }
+
+// UpdateNodeSlice mocks base method.
+func (m *MockClient) UpdateNodeSlice(ctx context.Context, nodeID uint32, sliceReq types.UpdateNodeSliceRequest, twinID uint32, mnemonic string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateNodeSlice", ctx, nodeID, sliceReq, twinID, mnemonic)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateNodeSlice indicates an expected call of UpdateNodeSlice.
+func (mr *MockClientMockRecorder) UpdateNodeSlice(ctx, nodeID, sliceReq, twinID, mnemonic interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNodeSlice", reflect.TypeOf((*MockClient)(nil).UpdateNodeSlice), ctx, nodeID, sliceReq, twinID, mnemonic)
+}

--- a/grid-proxy/docs/docs.go
+++ b/grid-proxy/docs/docs.go
@@ -482,7 +482,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "farm region",
+                        "description": "Node continent (america, europe, africa, asia, ...)",
                         "name": "region",
                         "in": "query"
                     }
@@ -632,7 +632,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "node region",
+                        "description": "Node continent (america, europe, africa, asia, ...)",
                         "name": "region",
                         "in": "query"
                     },
@@ -956,7 +956,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Node region",
+                        "description": "Node continent (america, europe, africa, asia, ...)",
                         "name": "region",
                         "in": "query"
                     },
@@ -1210,6 +1210,84 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/nodes/{node_id}/slice": {
+            "patch": {
+                "description": "Update the slice capacity configuration for a specific node (farm owner only)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "NodeSlice"
+                ],
+                "summary": "Update node slice configuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Authentication format: Base64(\u003cunix_timestamp\u003e:\u003ctwin_id\u003e):Base64(signature)",
+                        "name": "X-Auth",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Node ID",
+                        "name": "node_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Slice configuration and farm ID",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.UpdateNodeSliceRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.UpdateNodeSliceRequest"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "type": "string"
                         }
@@ -1943,6 +2021,9 @@ const docTemplate = `{
                 "serialNumber": {
                     "type": "string"
                 },
+                "slice": {
+                    "$ref": "#/definitions/types.Capacity"
+                },
                 "speed": {
                     "$ref": "#/definitions/types.Speed"
                 },
@@ -2156,6 +2237,9 @@ const docTemplate = `{
                 "serialNumber": {
                     "type": "string"
                 },
+                "slice": {
+                    "$ref": "#/definitions/types.Capacity"
+                },
                 "speed": {
                     "$ref": "#/definitions/types.Speed"
                 },
@@ -2349,6 +2433,22 @@ const docTemplate = `{
                 },
                 "overall_consumption": {
                     "type": "number"
+                }
+            }
+        },
+        "types.UpdateNodeSliceRequest": {
+            "type": "object",
+            "required": [
+                "slice"
+            ],
+            "properties": {
+                "slice": {
+                    "description": "slice configuration",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.Capacity"
+                        }
+                    ]
                 }
             }
         }

--- a/grid-proxy/docs/swagger.json
+++ b/grid-proxy/docs/swagger.json
@@ -474,7 +474,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "farm region",
+                        "description": "Node continent (america, europe, africa, asia, ...)",
                         "name": "region",
                         "in": "query"
                     }
@@ -624,7 +624,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "node region",
+                        "description": "Node continent (america, europe, africa, asia, ...)",
                         "name": "region",
                         "in": "query"
                     },
@@ -948,7 +948,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Node region",
+                        "description": "Node continent (america, europe, africa, asia, ...)",
                         "name": "region",
                         "in": "query"
                     },
@@ -1202,6 +1202,84 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/nodes/{node_id}/slice": {
+            "patch": {
+                "description": "Update the slice capacity configuration for a specific node (farm owner only)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "NodeSlice"
+                ],
+                "summary": "Update node slice configuration",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Authentication format: Base64(\u003cunix_timestamp\u003e:\u003ctwin_id\u003e):Base64(signature)",
+                        "name": "X-Auth",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Node ID",
+                        "name": "node_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Slice configuration and farm ID",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.UpdateNodeSliceRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.UpdateNodeSliceRequest"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "type": "string"
                         }
@@ -1935,6 +2013,9 @@
                 "serialNumber": {
                     "type": "string"
                 },
+                "slice": {
+                    "$ref": "#/definitions/types.Capacity"
+                },
                 "speed": {
                     "$ref": "#/definitions/types.Speed"
                 },
@@ -2148,6 +2229,9 @@
                 "serialNumber": {
                     "type": "string"
                 },
+                "slice": {
+                    "$ref": "#/definitions/types.Capacity"
+                },
                 "speed": {
                     "$ref": "#/definitions/types.Speed"
                 },
@@ -2341,6 +2425,22 @@
                 },
                 "overall_consumption": {
                     "type": "number"
+                }
+            }
+        },
+        "types.UpdateNodeSliceRequest": {
+            "type": "object",
+            "required": [
+                "slice"
+            ],
+            "properties": {
+                "slice": {
+                    "description": "slice configuration",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.Capacity"
+                        }
+                    ]
                 }
             }
         }

--- a/grid-proxy/docs/swagger.yaml
+++ b/grid-proxy/docs/swagger.yaml
@@ -214,6 +214,8 @@ definitions:
         type: integer
       serialNumber:
         type: string
+      slice:
+        $ref: '#/definitions/types.Capacity'
       speed:
         $ref: '#/definitions/types.Speed'
       status:
@@ -354,6 +356,8 @@ definitions:
         type: integer
       serialNumber:
         type: string
+      slice:
+        $ref: '#/definitions/types.Capacity'
       speed:
         $ref: '#/definitions/types.Speed'
       status:
@@ -484,6 +488,15 @@ definitions:
         type: number
       overall_consumption:
         type: number
+    type: object
+  types.UpdateNodeSliceRequest:
+    properties:
+      slice:
+        allOf:
+        - $ref: '#/definitions/types.Capacity'
+        description: slice configuration
+    required:
+    - slice
     type: object
 info:
   contact: {}
@@ -807,7 +820,7 @@ paths:
         in: query
         name: country
         type: string
-      - description: farm region
+      - description: Node continent (america, europe, africa, asia, ...)
         in: query
         name: region
         type: string
@@ -914,7 +927,7 @@ paths:
         in: query
         name: country
         type: string
-      - description: node region
+      - description: Node continent (america, europe, africa, asia, ...)
         in: query
         name: region
         type: string
@@ -1138,7 +1151,7 @@ paths:
         in: query
         name: country
         type: string
-      - description: Node region
+      - description: Node continent (america, europe, africa, asia, ...)
         in: query
         name: region
         type: string
@@ -1323,6 +1336,59 @@ paths:
       summary: Show node GPUs information
       tags:
       - NodeGPUs
+  /nodes/{node_id}/slice:
+    patch:
+      consumes:
+      - application/json
+      description: Update the slice capacity configuration for a specific node (farm
+        owner only)
+      parameters:
+      - description: 'Authentication format: Base64(<unix_timestamp>:<twin_id>):Base64(signature)'
+        in: header
+        name: X-Auth
+        required: true
+        type: string
+      - description: Node ID
+        in: path
+        name: node_id
+        required: true
+        type: integer
+      - description: Slice configuration and farm ID
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/types.UpdateNodeSliceRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.UpdateNodeSliceRequest'
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "403":
+          description: Forbidden
+          schema:
+            type: string
+        "404":
+          description: Not Found
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      summary: Update node slice configuration
+      tags:
+      - NodeSlice
   /nodes/{node_id}/statistics:
     get:
       consumes:

--- a/grid-proxy/go.mod
+++ b/grid-proxy/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20250929084418-b950278ead30
 	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.5
 	github.com/threefoldtech/zosbase v1.0.4
+	github.com/vedhavyas/go-subkey/v2 v2.0.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/trace v1.38.0
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c

--- a/grid-proxy/go.sum
+++ b/grid-proxy/go.sum
@@ -201,6 +201,8 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/vedhavyas/go-subkey v1.0.3 h1:iKR33BB/akKmcR2PMlXPBeeODjWLM90EL98OrOGs8CA=
 github.com/vedhavyas/go-subkey v1.0.3/go.mod h1:CloUaFQSSTdWnINfBRFjVMkWXZANW+nd8+TI5jYcl6Y=
+github.com/vedhavyas/go-subkey/v2 v2.0.0 h1:LemDIsrVtRSOkp0FA8HxP6ynfKjeOj3BY2U9UNfeDMA=
+github.com/vedhavyas/go-subkey/v2 v2.0.0/go.mod h1:95aZ+XDCWAUUynjlmi7BtPExjXgXxByE0WfBwbmIRH4=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852 h1:cPXZWzzG0NllBLdjWoD1nDfaqu98YMv+OneaKc8sPOA=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=

--- a/grid-proxy/internal/explorer/converters.go
+++ b/grid-proxy/internal/explorer/converters.go
@@ -12,47 +12,7 @@ import (
 	"github.com/threefoldtech/zosbase/pkg/gridtypes"
 )
 
-func calculateAvailableSlices(freeMru, freeSru, freeHru, freeCru int64, sliceMru, sliceSru, sliceHru, sliceCru int64) uint64 {
-	if sliceMru == 0 {
-		return 0
-	}
-
-	// Calculate how many complete slices each resource can provide
-	slicesByMru := uint64(freeMru / sliceMru)
-	var slicesBySru, slicesByHru, slicesByCru uint64
-
-	if sliceSru > 0 && freeSru > 0 {
-		slicesBySru = uint64(freeSru / sliceSru)
-	}
-	if sliceHru > 0 && freeHru > 0 {
-		slicesByHru = uint64(freeHru / sliceHru)
-	}
-	if sliceCru > 0 && freeCru > 0 {
-		slicesByCru = uint64(freeCru / sliceCru)
-	}
-
-	// Return the minimum (bottleneck resource)
-	minSlices := slicesByMru
-	if slicesBySru < minSlices {
-		minSlices = slicesBySru
-	}
-	if slicesByHru < minSlices {
-		minSlices = slicesByHru
-	}
-	if slicesByCru < minSlices {
-		minSlices = slicesByCru
-	}
-
-	return minSlices
-}
-
 func nodeFromDBNode(info db.Node) types.Node {
-	// Calculate free resources
-	freeMru := info.TotalMru - info.UsedMru
-	freeSru := info.TotalSru - info.UsedSru
-	freeHru := info.TotalHru - info.UsedHru
-	freeCru := info.TotalCru - info.UsedCru
-
 	node := types.Node{
 		ID:              info.ID,
 		NodeID:          int(info.NodeID),
@@ -135,7 +95,6 @@ func nodeFromDBNode(info db.Node) types.Node {
 			HRU: gridtypes.Unit(info.SliceHru),
 			MRU: gridtypes.Unit(info.SliceMru),
 		},
-		AvailableSlices: calculateAvailableSlices(freeMru, freeSru, freeHru, freeCru, info.SliceMru, info.SliceSru, info.SliceHru, info.SliceCru),
 	}
 	node.Status = nodestatus.DecideNodeStatus(node.Power, node.UpdatedAt)
 	node.Dedicated = info.FarmDedicated || info.NodeContractsCount == 0 || info.Renter != 0 || info.ExtraFee > 0
@@ -163,12 +122,6 @@ func farmFromDBFarm(info db.Farm) (types.Farm, error) {
 }
 
 func nodeWithNestedCapacityFromDBNode(info db.Node) types.NodeWithNestedCapacity {
-	// Calculate free resources
-	freeMru := info.TotalMru - info.UsedMru
-	freeSru := info.TotalSru - info.UsedSru
-	freeHru := info.TotalHru - info.UsedHru
-	freeCru := info.TotalCru - info.UsedCru
-
 	node := types.NodeWithNestedCapacity{
 		ID:              info.ID,
 		NodeID:          int(info.NodeID),
@@ -254,7 +207,6 @@ func nodeWithNestedCapacityFromDBNode(info db.Node) types.NodeWithNestedCapacity
 			HRU: gridtypes.Unit(info.SliceHru),
 			MRU: gridtypes.Unit(info.SliceMru),
 		},
-		AvailableSlices: calculateAvailableSlices(freeMru, freeSru, freeHru, freeCru, info.SliceMru, info.SliceSru, info.SliceHru, info.SliceCru),
 	}
 	node.Status = nodestatus.DecideNodeStatus(node.Power, node.UpdatedAt)
 	node.Dedicated = info.FarmDedicated || info.NodeContractsCount == 0 || info.Renter != 0 || info.ExtraFee > 0

--- a/grid-proxy/internal/explorer/converters.go
+++ b/grid-proxy/internal/explorer/converters.go
@@ -12,7 +12,47 @@ import (
 	"github.com/threefoldtech/zosbase/pkg/gridtypes"
 )
 
+func calculateAvailableSlices(freeMru, freeSru, freeHru, freeCru int64, sliceMru, sliceSru, sliceHru, sliceCru int64) uint64 {
+	if sliceMru == 0 {
+		return 0
+	}
+
+	// Calculate how many complete slices each resource can provide
+	slicesByMru := uint64(freeMru / sliceMru)
+	var slicesBySru, slicesByHru, slicesByCru uint64
+
+	if sliceSru > 0 && freeSru > 0 {
+		slicesBySru = uint64(freeSru / sliceSru)
+	}
+	if sliceHru > 0 && freeHru > 0 {
+		slicesByHru = uint64(freeHru / sliceHru)
+	}
+	if sliceCru > 0 && freeCru > 0 {
+		slicesByCru = uint64(freeCru / sliceCru)
+	}
+
+	// Return the minimum (bottleneck resource)
+	minSlices := slicesByMru
+	if slicesBySru < minSlices {
+		minSlices = slicesBySru
+	}
+	if slicesByHru < minSlices {
+		minSlices = slicesByHru
+	}
+	if slicesByCru < minSlices {
+		minSlices = slicesByCru
+	}
+
+	return minSlices
+}
+
 func nodeFromDBNode(info db.Node) types.Node {
+	// Calculate free resources
+	freeMru := info.TotalMru - info.UsedMru
+	freeSru := info.TotalSru - info.UsedSru
+	freeHru := info.TotalHru - info.UsedHru
+	freeCru := info.TotalCru - info.UsedCru
+
 	node := types.Node{
 		ID:              info.ID,
 		NodeID:          int(info.NodeID),
@@ -89,6 +129,13 @@ func nodeFromDBNode(info db.Node) types.Node {
 		PriceUsd:    math.Round(info.PriceUsd*1000) / 1000,
 		FarmFreeIps: info.FarmFreeIps,
 		Features:    info.Features,
+		Slice: types.Capacity{
+			CRU: uint64(info.SliceCru),
+			SRU: gridtypes.Unit(info.SliceSru),
+			HRU: gridtypes.Unit(info.SliceHru),
+			MRU: gridtypes.Unit(info.SliceMru),
+		},
+		AvailableSlices: calculateAvailableSlices(freeMru, freeSru, freeHru, freeCru, info.SliceMru, info.SliceSru, info.SliceHru, info.SliceCru),
 	}
 	node.Status = nodestatus.DecideNodeStatus(node.Power, node.UpdatedAt)
 	node.Dedicated = info.FarmDedicated || info.NodeContractsCount == 0 || info.Renter != 0 || info.ExtraFee > 0
@@ -116,6 +163,12 @@ func farmFromDBFarm(info db.Farm) (types.Farm, error) {
 }
 
 func nodeWithNestedCapacityFromDBNode(info db.Node) types.NodeWithNestedCapacity {
+	// Calculate free resources
+	freeMru := info.TotalMru - info.UsedMru
+	freeSru := info.TotalSru - info.UsedSru
+	freeHru := info.TotalHru - info.UsedHru
+	freeCru := info.TotalCru - info.UsedCru
+
 	node := types.NodeWithNestedCapacity{
 		ID:              info.ID,
 		NodeID:          int(info.NodeID),
@@ -195,6 +248,13 @@ func nodeWithNestedCapacityFromDBNode(info db.Node) types.NodeWithNestedCapacity
 		PriceUsd:    math.Round(info.PriceUsd*1000) / 1000,
 		FarmFreeIps: info.FarmFreeIps,
 		Features:    info.Features,
+		Slice: types.Capacity{
+			CRU: uint64(info.SliceCru),
+			SRU: gridtypes.Unit(info.SliceSru),
+			HRU: gridtypes.Unit(info.SliceHru),
+			MRU: gridtypes.Unit(info.SliceMru),
+		},
+		AvailableSlices: calculateAvailableSlices(freeMru, freeSru, freeHru, freeCru, info.SliceMru, info.SliceSru, info.SliceHru, info.SliceCru),
 	}
 	node.Status = nodestatus.DecideNodeStatus(node.Power, node.UpdatedAt)
 	node.Dedicated = info.FarmDedicated || info.NodeContractsCount == 0 || info.Renter != 0 || info.ExtraFee > 0

--- a/grid-proxy/internal/explorer/converters.go
+++ b/grid-proxy/internal/explorer/converters.go
@@ -95,6 +95,7 @@ func nodeFromDBNode(info db.Node) types.Node {
 			HRU: gridtypes.Unit(info.SliceHru),
 			MRU: gridtypes.Unit(info.SliceMru),
 		},
+		SlicesNeeded: uint64(info.SlicesNeeded),
 	}
 	node.Status = nodestatus.DecideNodeStatus(node.Power, node.UpdatedAt)
 	node.Dedicated = info.FarmDedicated || info.NodeContractsCount == 0 || info.Renter != 0 || info.ExtraFee > 0

--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -471,23 +471,48 @@ func (d *PostgresDatabase) GetFarms(ctx context.Context, filter types.FarmFilter
 		Group(`resources_cache.farm_id, renter, resources_cache.extra_fee`)
 
 	// Validate resource requests align with slice boundaries for farm node filtering
-	if filter.NodeFreeMRU != nil {
-		nodeQuery = nodeQuery.Where(`
-			resources_cache.slice_mru > 0 AND
-			resources_cache.free_mru >= resources_cache.slice_mru * CEIL(?::numeric / resources_cache.slice_mru::numeric)
-		`, *filter.NodeFreeMRU)
-	}
-	if filter.NodeFreeSRU != nil {
-		nodeQuery = nodeQuery.Where(`
-			resources_cache.slice_sru > 0 AND
-			resources_cache.free_sru >= resources_cache.slice_sru * CEIL(?::numeric / resources_cache.slice_sru::numeric)
-		`, *filter.NodeFreeSRU)
-	}
-	if filter.NodeFreeHRU != nil {
-		nodeQuery = nodeQuery.Where(`
-			resources_cache.slice_hru > 0 AND
-			resources_cache.free_hru >= resources_cache.slice_hru * CEIL(?::numeric / resources_cache.slice_hru::numeric)
-		`, *filter.NodeFreeHRU)
+	if filter.NodeFreeMRU != nil || filter.NodeFreeSRU != nil || filter.NodeFreeHRU != nil {
+		mruVal := uint64(0)
+		sruVal := uint64(0)
+		hruVal := uint64(0)
+		if filter.NodeFreeMRU != nil {
+			mruVal = *filter.NodeFreeMRU
+		}
+		if filter.NodeFreeSRU != nil {
+			sruVal = *filter.NodeFreeSRU
+		}
+		if filter.NodeFreeHRU != nil {
+			hruVal = *filter.NodeFreeHRU
+		}
+
+		nodeQuery = nodeQuery.Joins(`
+			LEFT JOIN (
+				SELECT
+					rc.node_id,
+					CEIL(
+						GREATEST(
+							COALESCE(?::bigint::numeric / NULLIF(rc.slice_mru, 0), 0),
+							COALESCE(?::bigint::numeric / NULLIF(rc.slice_sru, 0), 0),
+							COALESCE(?::bigint::numeric / NULLIF(rc.slice_hru, 0), 0)
+						)
+					)::bigint AS slices_needed,
+					LEAST(
+						COALESCE(rc.free_mru / NULLIF(rc.slice_mru, 0), 1e18),
+						COALESCE(rc.free_sru / NULLIF(rc.slice_sru, 0), 1e18),
+						COALESCE(rc.free_hru / NULLIF(rc.slice_hru, 0), 1e18)
+					) AS slices_available
+				FROM resources_cache rc
+				WHERE
+					NOT (
+						(?::bigint > 0 AND rc.slice_mru = 0) OR
+						(?::bigint > 0 AND rc.slice_sru = 0) OR
+						(?::bigint > 0 AND rc.slice_hru = 0)
+					)
+			) AS node_slices ON node_slices.node_id = resources_cache.node_id
+		`, mruVal, sruVal, hruVal, mruVal, sruVal, hruVal).Where(`
+			node_slices.slices_needed > 0
+			AND node_slices.slices_needed <= node_slices.slices_available
+		`)
 	}
 	if filter.NodeTotalCRU != nil {
 		nodeQuery = nodeQuery.Where("resources_cache.total_cru >= ?", *filter.NodeTotalCRU)
@@ -676,23 +701,53 @@ func (d *PostgresDatabase) GetNodes(ctx context.Context, filter types.NodeFilter
 	if filter.HasIpv6 != nil {
 		q = q.Where("COALESCE(node_ipv6.has_ipv6, false) = ? ", *filter.HasIpv6)
 	}
-	if filter.FreeMRU != nil {
-		q = q.Where(`
-			resources_cache.slice_mru > 0 AND
-			resources_cache.free_mru >= resources_cache.slice_mru * CEIL(?::numeric / resources_cache.slice_mru::numeric)
-		`, *filter.FreeMRU)
-	}
-	if filter.FreeSRU != nil {
-		q = q.Where(`
-			resources_cache.slice_sru > 0 AND
-			resources_cache.free_sru >= resources_cache.slice_sru * CEIL(?::numeric / resources_cache.slice_sru::numeric)
-		`, *filter.FreeSRU)
-	}
-	if filter.FreeHRU != nil {
-		q = q.Where(`
-			resources_cache.slice_hru > 0 AND
-			resources_cache.free_hru >= resources_cache.slice_hru * CEIL(?::numeric / resources_cache.slice_hru::numeric)
-		`, *filter.FreeHRU)
+	if filter.FreeMRU != nil || filter.FreeSRU != nil || filter.FreeHRU != nil {
+		mruVal := uint64(0)
+		sruVal := uint64(0)
+		hruVal := uint64(0)
+		if filter.FreeMRU != nil {
+			mruVal = *filter.FreeMRU
+		}
+		if filter.FreeSRU != nil {
+			sruVal = *filter.FreeSRU
+		}
+		if filter.FreeHRU != nil {
+			hruVal = *filter.FreeHRU
+		}
+
+		q = q.Joins(`
+			LEFT JOIN (
+				SELECT
+					rc.node_id,
+					CEIL(
+						GREATEST(
+							COALESCE(?::bigint::numeric / NULLIF(rc.slice_mru, 0), 0),
+							COALESCE(?::bigint::numeric / NULLIF(rc.slice_sru, 0), 0),
+							COALESCE(?::bigint::numeric / NULLIF(rc.slice_hru, 0), 0)
+						)
+					)::bigint AS slices_needed,
+					LEAST(
+						COALESCE(rc.free_mru / NULLIF(rc.slice_mru, 0), 1e18),
+						COALESCE(rc.free_sru / NULLIF(rc.slice_sru, 0), 1e18),
+						COALESCE(rc.free_hru / NULLIF(rc.slice_hru, 0), 1e18)
+					) AS slices_available
+				FROM resources_cache rc
+				WHERE
+					NOT (
+						(?::bigint > 0 AND rc.slice_mru = 0) OR
+						(?::bigint > 0 AND rc.slice_sru = 0) OR
+						(?::bigint > 0 AND rc.slice_hru = 0)
+					)
+			) AS node_slices ON node_slices.node_id = resources_cache.node_id
+		`, mruVal, sruVal, hruVal, mruVal, sruVal, hruVal).
+			Where(`
+				node_slices.slices_needed > 0
+				AND node_slices.slices_needed <= node_slices.slices_available
+			`)
+
+		if stmt := q.Statement; stmt != nil && len(stmt.Selects) > 0 {
+			stmt.Selects = append(stmt.Selects, "node_slices.slices_needed AS slices_needed")
+		}
 	}
 	if filter.TotalCRU != nil {
 		q = q.Where("resources_cache.total_cru >= ?", *filter.TotalCRU)

--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -395,6 +395,10 @@ func (d *PostgresDatabase) nodeTableQuery(ctx context.Context, filter types.Node
 			"resources_cache.threads_cpu as threads",
 			"resources_cache.workloads_cpu as workloads",
 			"public_ips_cache.free_ips as farm_free_ips",
+			"resources_cache.slice_mru",
+			"resources_cache.slice_sru",
+			"resources_cache.slice_hru",
+			"resources_cache.slice_cru",
 			calculatedDiscountColumn,
 		).
 		Joins(`
@@ -466,14 +470,33 @@ func (d *PostgresDatabase) GetFarms(ctx context.Context, filter types.FarmFilter
 		`).
 		Group(`resources_cache.farm_id, renter, resources_cache.extra_fee`)
 
-	if filter.NodeFreeMRU != nil {
-		nodeQuery = nodeQuery.Where("resources_cache.free_mru >= ?", *filter.NodeFreeMRU)
-	}
-	if filter.NodeFreeHRU != nil {
-		nodeQuery = nodeQuery.Where("resources_cache.free_hru >= ?", *filter.NodeFreeHRU)
-	}
-	if filter.NodeFreeSRU != nil {
-		nodeQuery = nodeQuery.Where("resources_cache.free_sru >= ?", *filter.NodeFreeSRU)
+	// Validate resource requests align with slice boundaries for farm node filtering
+	if filter.NodeFreeMRU != nil || filter.NodeFreeSRU != nil || filter.NodeFreeHRU != nil {
+		sliceMruSize := int64(1073741824) // 1GB in bytes
+
+		// Calculate required number of slices based on MRU request (default to 1 if no MRU specified)
+		requiredSlices := int64(1)
+		if filter.NodeFreeMRU != nil {
+			requiredSlices = (int64(*filter.NodeFreeMRU) + sliceMruSize - 1) / sliceMruSize // ceil division
+			if requiredSlices == 0 {
+				requiredSlices = 1
+			}
+		}
+
+		// Check if node can provide the required number of complete slices
+		nodeQuery = nodeQuery.Where(`
+			(resources_cache.slice_mru > 0) AND
+			(resources_cache.free_mru >= resources_cache.slice_mru * ?)
+		`, requiredSlices)
+
+		if filter.NodeFreeSRU != nil {
+			nodeQuery = nodeQuery.Where(`(resources_cache.slice_sru = 0 OR resources_cache.free_sru >= resources_cache.slice_sru * ?)`, requiredSlices)
+		}
+		if filter.NodeFreeHRU != nil {
+			nodeQuery = nodeQuery.Where(`(resources_cache.slice_hru = 0 OR resources_cache.free_hru >= resources_cache.slice_hru * ?)`, requiredSlices)
+		}
+		// CRU is implicitly checked since it scales with slices
+		nodeQuery = nodeQuery.Where(`(resources_cache.slice_cru = 0 OR resources_cache.free_cru >= resources_cache.slice_cru * ?)`, requiredSlices)
 	}
 	if filter.NodeTotalCRU != nil {
 		nodeQuery = nodeQuery.Where("resources_cache.total_cru >= ?", *filter.NodeTotalCRU)
@@ -662,14 +685,34 @@ func (d *PostgresDatabase) GetNodes(ctx context.Context, filter types.NodeFilter
 	if filter.HasIpv6 != nil {
 		q = q.Where("COALESCE(node_ipv6.has_ipv6, false) = ? ", *filter.HasIpv6)
 	}
-	if filter.FreeMRU != nil {
-		q = q.Where("resources_cache.free_mru >= ?", *filter.FreeMRU)
-	}
-	if filter.FreeHRU != nil {
-		q = q.Where("resources_cache.free_hru >= ?", *filter.FreeHRU)
-	}
-	if filter.FreeSRU != nil {
-		q = q.Where("resources_cache.free_sru >= ?", *filter.FreeSRU)
+	// Validate resource requests align with slice boundaries
+	if filter.FreeMRU != nil || filter.FreeSRU != nil || filter.FreeHRU != nil {
+		sliceMruSize := int64(1073741824) // 1GB in bytes
+
+		// Calculate required number of slices based on MRU request (default to 1 if no MRU specified)
+		requiredSlices := int64(1)
+		if filter.FreeMRU != nil {
+			requiredSlices = (int64(*filter.FreeMRU) + sliceMruSize - 1) / sliceMruSize // ceil division
+			if requiredSlices == 0 {
+				requiredSlices = 1
+			}
+		}
+
+		// Check if node can provide the required number of complete slices
+		// Each resource must have enough capacity for N slices
+		q = q.Where(`
+			(resources_cache.slice_mru > 0) AND
+			(resources_cache.free_mru >= resources_cache.slice_mru * ?)
+		`, requiredSlices)
+
+		if filter.FreeSRU != nil {
+			q = q.Where(`(resources_cache.slice_sru = 0 OR resources_cache.free_sru >= resources_cache.slice_sru * ?)`, requiredSlices)
+		}
+		if filter.FreeHRU != nil {
+			q = q.Where(`(resources_cache.slice_hru = 0 OR resources_cache.free_hru >= resources_cache.slice_hru * ?)`, requiredSlices)
+		}
+		// CRU is implicitly checked since it scales with slices
+		q = q.Where(`(resources_cache.slice_cru = 0 OR resources_cache.free_cru >= resources_cache.slice_cru * ?)`, requiredSlices)
 	}
 	if filter.TotalCRU != nil {
 		q = q.Where("resources_cache.total_cru >= ?", *filter.TotalCRU)
@@ -1127,4 +1170,27 @@ func (d *PostgresDatabase) GetPublicIps(ctx context.Context, filter types.Public
 		return ips, uint(count), errors.Wrap(res.Error, "failed to scan returned ips from database")
 	}
 	return ips, uint(count), nil
+}
+
+// UpdateNodeSlice updates the slice configuration for a specific node
+func (d *PostgresDatabase) UpdateNodeSlice(ctx context.Context, nodeID uint32, sliceMru, sliceSru, sliceHru, sliceCru uint64) error {
+	result := d.gormDB.WithContext(ctx).
+		Table("resources_cache").
+		Where("node_id = ?", nodeID).
+		Updates(map[string]interface{}{
+			"slice_mru": sliceMru,
+			"slice_sru": sliceSru,
+			"slice_hru": sliceHru,
+			"slice_cru": sliceCru,
+		})
+
+	if result.Error != nil {
+		return errors.Wrap(result.Error, "failed to update node slice")
+	}
+
+	if result.RowsAffected == 0 {
+		return ErrNodeNotFound
+	}
+
+	return nil
 }

--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -471,32 +471,23 @@ func (d *PostgresDatabase) GetFarms(ctx context.Context, filter types.FarmFilter
 		Group(`resources_cache.farm_id, renter, resources_cache.extra_fee`)
 
 	// Validate resource requests align with slice boundaries for farm node filtering
-	if filter.NodeFreeMRU != nil || filter.NodeFreeSRU != nil || filter.NodeFreeHRU != nil {
-		sliceMruSize := int64(1073741824) // 1GB in bytes
-
-		// Calculate required number of slices based on MRU request (default to 1 if no MRU specified)
-		requiredSlices := int64(1)
-		if filter.NodeFreeMRU != nil {
-			requiredSlices = (int64(*filter.NodeFreeMRU) + sliceMruSize - 1) / sliceMruSize // ceil division
-			if requiredSlices == 0 {
-				requiredSlices = 1
-			}
-		}
-
-		// Check if node can provide the required number of complete slices
+	if filter.NodeFreeMRU != nil {
 		nodeQuery = nodeQuery.Where(`
-			(resources_cache.slice_mru > 0) AND
-			(resources_cache.free_mru >= resources_cache.slice_mru * ?)
-		`, requiredSlices)
-
-		if filter.NodeFreeSRU != nil {
-			nodeQuery = nodeQuery.Where(`(resources_cache.slice_sru = 0 OR resources_cache.free_sru >= resources_cache.slice_sru * ?)`, requiredSlices)
-		}
-		if filter.NodeFreeHRU != nil {
-			nodeQuery = nodeQuery.Where(`(resources_cache.slice_hru = 0 OR resources_cache.free_hru >= resources_cache.slice_hru * ?)`, requiredSlices)
-		}
-		// CRU is implicitly checked since it scales with slices
-		nodeQuery = nodeQuery.Where(`(resources_cache.slice_cru = 0 OR resources_cache.free_cru >= resources_cache.slice_cru * ?)`, requiredSlices)
+			resources_cache.slice_mru > 0 AND
+			resources_cache.free_mru >= resources_cache.slice_mru * CEIL(?::numeric / resources_cache.slice_mru::numeric)
+		`, *filter.NodeFreeMRU)
+	}
+	if filter.NodeFreeSRU != nil {
+		nodeQuery = nodeQuery.Where(`
+			resources_cache.slice_sru > 0 AND
+			resources_cache.free_sru >= resources_cache.slice_sru * CEIL(?::numeric / resources_cache.slice_sru::numeric)
+		`, *filter.NodeFreeSRU)
+	}
+	if filter.NodeFreeHRU != nil {
+		nodeQuery = nodeQuery.Where(`
+			resources_cache.slice_hru > 0 AND
+			resources_cache.free_hru >= resources_cache.slice_hru * CEIL(?::numeric / resources_cache.slice_hru::numeric)
+		`, *filter.NodeFreeHRU)
 	}
 	if filter.NodeTotalCRU != nil {
 		nodeQuery = nodeQuery.Where("resources_cache.total_cru >= ?", *filter.NodeTotalCRU)
@@ -685,34 +676,23 @@ func (d *PostgresDatabase) GetNodes(ctx context.Context, filter types.NodeFilter
 	if filter.HasIpv6 != nil {
 		q = q.Where("COALESCE(node_ipv6.has_ipv6, false) = ? ", *filter.HasIpv6)
 	}
-	// Validate resource requests align with slice boundaries
-	if filter.FreeMRU != nil || filter.FreeSRU != nil || filter.FreeHRU != nil {
-		sliceMruSize := int64(1073741824) // 1GB in bytes
-
-		// Calculate required number of slices based on MRU request (default to 1 if no MRU specified)
-		requiredSlices := int64(1)
-		if filter.FreeMRU != nil {
-			requiredSlices = (int64(*filter.FreeMRU) + sliceMruSize - 1) / sliceMruSize // ceil division
-			if requiredSlices == 0 {
-				requiredSlices = 1
-			}
-		}
-
-		// Check if node can provide the required number of complete slices
-		// Each resource must have enough capacity for N slices
+	if filter.FreeMRU != nil {
 		q = q.Where(`
-			(resources_cache.slice_mru > 0) AND
-			(resources_cache.free_mru >= resources_cache.slice_mru * ?)
-		`, requiredSlices)
-
-		if filter.FreeSRU != nil {
-			q = q.Where(`(resources_cache.slice_sru = 0 OR resources_cache.free_sru >= resources_cache.slice_sru * ?)`, requiredSlices)
-		}
-		if filter.FreeHRU != nil {
-			q = q.Where(`(resources_cache.slice_hru = 0 OR resources_cache.free_hru >= resources_cache.slice_hru * ?)`, requiredSlices)
-		}
-		// CRU is implicitly checked since it scales with slices
-		q = q.Where(`(resources_cache.slice_cru = 0 OR resources_cache.free_cru >= resources_cache.slice_cru * ?)`, requiredSlices)
+			resources_cache.slice_mru > 0 AND
+			resources_cache.free_mru >= resources_cache.slice_mru * CEIL(?::numeric / resources_cache.slice_mru::numeric)
+		`, *filter.FreeMRU)
+	}
+	if filter.FreeSRU != nil {
+		q = q.Where(`
+			resources_cache.slice_sru > 0 AND
+			resources_cache.free_sru >= resources_cache.slice_sru * CEIL(?::numeric / resources_cache.slice_sru::numeric)
+		`, *filter.FreeSRU)
+	}
+	if filter.FreeHRU != nil {
+		q = q.Where(`
+			resources_cache.slice_hru > 0 AND
+			resources_cache.free_hru >= resources_cache.slice_hru * CEIL(?::numeric / resources_cache.slice_hru::numeric)
+		`, *filter.FreeHRU)
 	}
 	if filter.TotalCRU != nil {
 		q = q.Where("resources_cache.total_cru >= ?", *filter.TotalCRU)

--- a/grid-proxy/internal/explorer/db/setup.sql
+++ b/grid-proxy/internal/explorer/db/setup.sql
@@ -42,6 +42,40 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
+-- Calculate default slice resources based on 1GB memory slices
+
+CREATE OR REPLACE FUNCTION calc_slice_resources(
+    total_mru NUMERIC,
+    total_sru NUMERIC,
+    total_hru NUMERIC,
+    total_cru NUMERIC,
+    OUT slice_mru NUMERIC,
+    OUT slice_sru NUMERIC,
+    OUT slice_hru NUMERIC,
+    OUT slice_cru NUMERIC
+) AS $$
+DECLARE
+    slice_mru_size NUMERIC := 1073741824; -- 1GB in bytes
+    slice_count NUMERIC;
+BEGIN
+    -- Calculate how many 1GB slices fit in total MRU
+    slice_count := FLOOR(total_mru / slice_mru_size);
+    
+    -- If node has less than 1GB, set slice_count to 1
+    IF slice_count = 0 THEN
+        slice_count := 1;
+    END IF;
+    
+    -- MRU is always 1GB per slice
+    slice_mru := slice_mru_size;
+    
+    -- Divide other resources proportionally by slice_count
+    slice_cru := FLOOR(total_cru / slice_count);
+    slice_sru := FLOOR(total_sru / slice_count);
+    slice_hru := FLOOR(total_hru / slice_count);
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
 CREATE OR REPLACE FUNCTION calc_price(
     cru NUMERIC,
     sru NUMERIC,
@@ -139,7 +173,11 @@ SELECT
     CASE WHEN farm.pricing_policy_id = 0 THEN 1 ELSE farm.pricing_policy_id END as policy_id,
     COALESCE(node.extra_fee, 0) as extra_fee,
     COALESCE(node_gpu_agg.gpus, '[]'),
-    COALESCE(node_gpu_agg.gpu_count, 0) as node_gpu_count
+    COALESCE(node_gpu_agg.gpu_count, 0) as node_gpu_count,
+    slice_calc.slice_mru,
+    slice_calc.slice_sru,
+    slice_calc.slice_hru,
+    slice_calc.slice_cru
 FROM node
     LEFT JOIN node_contract ON node.node_id = node_contract.node_id AND node_contract.state IN ('Created', 'GracePeriod')
     LEFT JOIN contract_resources ON node_contract.resources_used_id = contract_resources.id 
@@ -160,6 +198,15 @@ FROM node
         GROUP BY
             g1.node_twin_id
     ) node_gpu_agg on node_gpu_agg.node_twin_id = node.twin_id
+    -- calculate slice resources once
+    LEFT JOIN LATERAL (
+        SELECT * FROM calc_slice_resources(
+            COALESCE(node_resources_total.mru, 0),
+            COALESCE(node_resources_total.sru, 0),
+            COALESCE(node_resources_total.hru, 0),
+            COALESCE(node_resources_total.cru, 0)
+        )
+    ) slice_calc ON true
 GROUP BY
     node.node_id,
     node_resources_total.mru,
@@ -190,7 +237,11 @@ GROUP BY
     COALESCE(cpu_benchmark.workloads, 0),
     node.certification,
     node.extra_fee,
-    farm.pricing_policy_id;
+    farm.pricing_policy_id,
+    slice_calc.slice_mru,
+    slice_calc.slice_sru,
+    slice_calc.slice_hru,
+    slice_calc.slice_cru;
 
 DROP TABLE IF EXISTS resources_cache;
 CREATE TABLE IF NOT EXISTS resources_cache(
@@ -232,6 +283,10 @@ CREATE TABLE IF NOT EXISTS resources_cache(
     extra_fee NUMERIC,
     gpus jsonb,
     node_gpu_count INTEGER NOT NULL,
+    slice_mru NUMERIC NOT NULL DEFAULT 0,
+    slice_sru NUMERIC NOT NULL DEFAULT 0,
+    slice_hru NUMERIC NOT NULL DEFAULT 0,
+    slice_cru NUMERIC NOT NULL DEFAULT 0,
     price_usd NUMERIC GENERATED ALWAYS AS (
         calc_price(
             total_cru,
@@ -348,7 +403,12 @@ CREATE OR REPLACE TRIGGER tg_node
  */
 CREATE OR REPLACE FUNCTION reflect_total_resources_changes() RETURNS TRIGGER AS 
 $$ 
+DECLARE
+    slice_res RECORD;
 BEGIN
+    -- Calculate slice resources once
+    SELECT * INTO slice_res FROM calc_slice_resources(NEW.mru, NEW.sru, NEW.hru, NEW.cru);
+    
     BEGIN
         UPDATE resources_cache
         SET
@@ -361,7 +421,11 @@ BEGIN
             free_hru = free_hru + (NEW.hru-COALESCE(OLD.hru, 0)),
             free_sru = free_sru + (NEW.sru-COALESCE(OLD.sru, 0)),
             used_mru = used_mru - GREATEST(CAST((OLD.mru / 10) AS bigint), 2147483648) +
-                                    GREATEST(CAST((NEW.mru / 10) AS bigint), 2147483648)
+                                    GREATEST(CAST((NEW.mru / 10) AS bigint), 2147483648),
+            slice_mru = slice_res.slice_mru,
+            slice_sru = slice_res.slice_sru,
+            slice_hru = slice_res.slice_hru,
+            slice_cru = slice_res.slice_cru
         WHERE
             resources_cache.node_id = (
                 SELECT node.node_id FROM node WHERE node.id = New.node_id

--- a/grid-proxy/internal/explorer/db/setup.sql
+++ b/grid-proxy/internal/explorer/db/setup.sql
@@ -70,7 +70,11 @@ BEGIN
     slice_mru := slice_mru_size;
     
     -- Divide other resources proportionally by slice_count
-    slice_cru := FLOOR(total_cru / slice_count);
+    IF total_cru > 0 THEN
+        slice_cru := GREATEST(1, FLOOR((total_cru * 2) / slice_count));
+    ELSE
+        slice_cru := 0;
+    END IF;
     slice_sru := FLOOR(total_sru / slice_count);
     slice_hru := FLOOR(total_hru / slice_count);
 END;

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -133,6 +133,7 @@ type Node struct {
 	SliceSru           int64    `gorm:"slice_sru"`
 	SliceHru           int64    `gorm:"slice_hru"`
 	SliceCru           int64    `gorm:"slice_cru"`
+	SlicesNeeded       int64    `gorm:"slices_needed"`
 }
 
 // NodePower struct is the farmerbot report for node status

--- a/grid-proxy/internal/explorer/db/types.go
+++ b/grid-proxy/internal/explorer/db/types.go
@@ -28,6 +28,9 @@ type Database interface {
 	GetContractsTotalBilledAmount(ctx context.Context, contractIds []uint32) (uint64, error)
 	GetPublicIps(ctx context.Context, filter types.PublicIpFilter, limit types.Limit) ([]types.PublicIP, uint, error)
 
+	// node slice management
+	UpdateNodeSlice(ctx context.Context, nodeID uint32, sliceMru, sliceSru, sliceHru, sliceCru uint64) error
+
 	// indexer utils
 	DeleteOldGpus(ctx context.Context, nodeTwinIds []uint32, expiration int64) error
 	GetLastNodeTwinID(ctx context.Context) (uint32, error)
@@ -126,6 +129,10 @@ type Node struct {
 	PriceUsd           float64
 	FarmFreeIps        uint
 	Features           []string `gorm:"type:jsonb;serializer:json"`
+	SliceMru           int64    `gorm:"slice_mru"`
+	SliceSru           int64    `gorm:"slice_sru"`
+	SliceHru           int64    `gorm:"slice_hru"`
+	SliceCru           int64    `gorm:"slice_cru"`
 }
 
 // NodePower struct is the farmerbot report for node status

--- a/grid-proxy/internal/explorer/db_client.go
+++ b/grid-proxy/internal/explorer/db_client.go
@@ -131,6 +131,18 @@ func (c *DBClient) Stats(ctx context.Context, filter types.StatsFilter) (types.S
 	return c.DB.GetStats(ctx, filter)
 }
 
+func (c *DBClient) GetNode(ctx context.Context, nodeID uint32) (db.Node, error) {
+	return c.DB.GetNode(ctx, nodeID)
+}
+
+func (c *DBClient) GetFarm(ctx context.Context, farmID uint32) (db.Farm, error) {
+	return c.DB.GetFarm(ctx, farmID)
+}
+
+func (c *DBClient) UpdateNodeSlice(ctx context.Context, nodeID uint32, sliceMru, sliceSru, sliceHru, sliceCru uint64) error {
+	return c.DB.UpdateNodeSlice(ctx, nodeID, sliceMru, sliceSru, sliceHru, sliceCru)
+}
+
 func (c *DBClient) GetTwinConsumption(ctx context.Context, twinId uint64) (types.TwinConsumption, error) {
 	// get all twin contracts
 	maxContractSize := uint64(999999999)

--- a/grid-proxy/internal/explorer/mw/auth.go
+++ b/grid-proxy/internal/explorer/mw/auth.go
@@ -1,0 +1,134 @@
+package mw
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
+)
+
+const (
+	// AuthHeader is the name of the authentication header
+	AuthHeader = "X-Auth"
+	// ChallengeValidity is the duration a challenge remains valid
+	ChallengeValidity = 1 * time.Minute
+)
+
+// twinIDKey is the context key for storing authenticated twin ID
+type twinIDKey struct{}
+
+// TwinDB interface for getting twin public keys
+type TwinDB interface {
+	Twins(ctx context.Context, filter types.TwinFilter, limit types.Limit) ([]types.Twin, int, error)
+}
+
+// AuthMiddleware creates a middleware that authenticates requests based on X-Auth header
+// Header format: <timestamp>:<twin_id>:<signature_base64>
+// The signature is over the challenge message (timestamp:twin_id)
+func AuthMiddleware(twinDB TwinDB) func(Action) Action {
+	return func(next Action) Action {
+		return func(r *http.Request) (interface{}, Response) {
+			// Extract and validate auth header
+			authHeader := r.Header.Get(AuthHeader)
+			if authHeader == "" {
+				return nil, UnAuthorized(errors.New("X-Auth header required"))
+			}
+
+			parts := strings.Split(authHeader, ":")
+			if len(parts) != 3 {
+				return nil, BadRequest(errors.New("invalid X-Auth header format, expected 'timestamp:twin_id:signature'"))
+			}
+
+			timestampStr, twinIDStr, signatureB64 := parts[0], parts[1], parts[2]
+
+			// Validate timestamp
+			timestamp, err := strconv.ParseInt(timestampStr, 10, 64)
+			if err != nil {
+				log.Debug().Err(err).Msg("invalid timestamp")
+				return nil, BadRequest(errors.New("invalid timestamp"))
+			}
+
+			if time.Since(time.Unix(timestamp, 0)) > ChallengeValidity {
+				return nil, UnAuthorized(errors.New("expired challenge"))
+			}
+
+			// Parse twin ID
+			twinID, err := strconv.ParseUint(twinIDStr, 10, 64)
+			if err != nil {
+				log.Debug().Err(err).Msg("invalid twin ID format")
+				return nil, BadRequest(errors.New("invalid twin ID format"))
+			}
+
+			// Create challenge message
+			challenge := fmt.Sprintf("%s:%s", timestampStr, twinIDStr)
+
+			// Get twin's public key from database
+			filter := types.TwinFilter{TwinID: &twinID}
+			twins, _, err := twinDB.Twins(r.Context(), filter, types.Limit{Size: 1, Page: 1})
+			if err != nil {
+				log.Debug().Err(err).Uint64("twinID", twinID).Msg("failed to get twin")
+				return nil, UnAuthorized(errors.New("twin not found"))
+			}
+			if len(twins) == 0 {
+				return nil, UnAuthorized(errors.New("twin not found"))
+			}
+
+			// Decode stored public key
+			storedPK, err := base64.StdEncoding.DecodeString(twins[0].PublicKey)
+			if err != nil {
+				log.Debug().Err(err).Msg("invalid stored public key")
+				return nil, BadRequest(errors.New("invalid stored public key"))
+			}
+
+			// Decode signature
+			sig, err := base64.StdEncoding.DecodeString(signatureB64)
+			if err != nil {
+				log.Debug().Err(err).Msg("invalid signature encoding")
+				return nil, BadRequest(errors.New("invalid signature encoding"))
+			}
+
+			// Verify signature (auto-detect ed25519 or sr25519)
+			if err := verifySignature(storedPK, []byte(challenge), sig); err != nil {
+				log.Debug().Err(err).Msg("signature verification failed")
+				return nil, UnAuthorized(err)
+			}
+
+			// Store verified twin ID in context
+			ctx := context.WithValue(r.Context(), twinIDKey{}, twinID)
+			r = r.WithContext(ctx)
+
+			// Call next handler
+			return next(r)
+		}
+	}
+}
+
+// GetAuthenticatedTwinID extracts the authenticated twin ID from the request context
+// Returns 0 if not authenticated
+func GetAuthenticatedTwinID(r *http.Request) uint64 {
+	twinID, ok := r.Context().Value(twinIDKey{}).(uint64)
+	if !ok {
+		return 0
+	}
+	return twinID
+}
+
+// EnsureOwner checks if the authenticated twin ID matches the expected twin ID
+// Returns a Response error if not authorized, nil if authorized
+func EnsureOwner(r *http.Request, expectedTwinID uint64) Response {
+	authTwinID := GetAuthenticatedTwinID(r)
+	if authTwinID == 0 {
+		return UnAuthorized(errors.New("not authenticated"))
+	}
+	if authTwinID != expectedTwinID || expectedTwinID == 0 {
+		return Forbidden(errors.New("not authorized to access this resource"))
+	}
+	return nil
+}

--- a/grid-proxy/internal/explorer/mw/sig.go
+++ b/grid-proxy/internal/explorer/mw/sig.go
@@ -1,0 +1,53 @@
+package mw
+
+import (
+	"github.com/pkg/errors"
+	"github.com/vedhavyas/go-subkey/v2"
+	"github.com/vedhavyas/go-subkey/v2/ed25519"
+	"github.com/vedhavyas/go-subkey/v2/sr25519"
+)
+
+const (
+	PubKeySize = 32
+)
+
+var (
+	ErrInvalidInput = errors.New("invalid input")
+	ErrVerifyFailed = errors.New("signature verification failed")
+)
+
+// verifyWithScheme verifies a signature using the given scheme (ed25519 or sr25519)
+func verifyWithScheme(scheme subkey.Scheme, publicKey, message, signature []byte) bool {
+	key, err := scheme.FromPublicKey(publicKey)
+	if err != nil {
+		return false
+	}
+	return key.Verify(message, signature)
+}
+
+func verifySignature(publicKey, message, signature []byte) error {
+	// Validate public key length
+	if len(publicKey) != PubKeySize {
+		return errors.Wrapf(ErrInvalidInput, "invalid public key size: expected %d, got %d", PubKeySize, len(publicKey))
+	}
+
+	if len(message) == 0 {
+		return errors.Wrap(ErrInvalidInput, "invalid message size, not expected to be zero")
+	}
+
+	if len(signature) == 0 {
+		return errors.Wrap(ErrInvalidInput, "invalid signature size, not expected to be zero")
+	}
+
+	// Try ED25519 verification first (most common)
+	if verifyWithScheme(ed25519.Scheme{}, publicKey, message, signature) {
+		return nil
+	}
+
+	// Fallback to SR25519 verification
+	if verifyWithScheme(sr25519.Scheme{}, publicKey, message, signature) {
+		return nil
+	}
+
+	return ErrVerifyFailed
+}

--- a/grid-proxy/internal/explorer/server.go
+++ b/grid-proxy/internal/explorer/server.go
@@ -535,11 +535,6 @@ func (a *App) updateNodeSlice(r *http.Request) (interface{}, mw.Response) {
 		return nil, mw.Error(err)
 	}
 
-	// Verify that the node belongs to the specified farm
-	if uint64(node.FarmID) != req.FarmID {
-		return nil, mw.Forbidden(errors.New("node does not belong to the specified farm"))
-	}
-
 	// Validate slice resources don't exceed node's total capacity
 	if err := req.ValidateAgainstNodeCapacity(
 		node.TotalMru,
@@ -551,7 +546,7 @@ func (a *App) updateNodeSlice(r *http.Request) (interface{}, mw.Response) {
 	}
 
 	// Get farm to verify ownership
-	farm, err := a.cl.GetFarm(r.Context(), uint32(req.FarmID))
+	farm, err := a.cl.GetFarm(r.Context(), uint32(node.FarmID))
 	if err != nil {
 		return nil, errorReply(err)
 	}

--- a/grid-proxy/internal/explorer/server.go
+++ b/grid-proxy/internal/explorer/server.go
@@ -1,12 +1,14 @@
 package explorer
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	httpSwagger "github.com/swaggo/http-swagger"
 
@@ -490,6 +492,84 @@ func (a *App) version(r *http.Request) (interface{}, mw.Response) {
 	}, response
 }
 
+// updateNodeSlice godoc
+// @Summary Update node slice configuration
+// @Description Update the slice capacity configuration for a specific node (farm owner only)
+// @Tags NodeSlice
+// @Param X-Auth header string true "Authentication format: Base64(<unix_timestamp>:<twin_id>):Base64(signature)"
+// @Param node_id path int true "Node ID"
+// @Param request body types.UpdateNodeSliceRequest true "Slice configuration and farm ID"
+// @Accept  json
+// @Produce  json
+// @Success 200 {object} types.UpdateNodeSliceRequest
+// @Failure 400 {object} string
+// @Failure 401 {object} string
+// @Failure 403 {object} string
+// @Failure 404 {object} string
+// @Failure 500 {object} string
+// @Router /nodes/{node_id}/slice [patch]
+func (a *App) updateNodeSlice(r *http.Request) (interface{}, mw.Response) {
+	nodeIDStr := mux.Vars(r)["node_id"]
+	nodeID, err := strconv.ParseUint(nodeIDStr, 10, 32)
+	if err != nil {
+		return nil, mw.BadRequest(err)
+	}
+
+	// Parse request body
+	var req types.UpdateNodeSliceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, mw.BadRequest(errors.Wrap(err, "invalid request body"))
+	}
+
+	// Validate request
+	if err := req.Validate(); err != nil {
+		return nil, mw.BadRequest(err)
+	}
+
+	// Get node to verify it exists and belongs to the specified farm
+	node, err := a.cl.GetNode(r.Context(), uint32(nodeID))
+	if err != nil {
+		if err == ErrNodeNotFound {
+			return nil, errorReply(ErrNodeNotFound)
+		}
+		return nil, mw.Error(err)
+	}
+
+	// Verify that the node belongs to the specified farm
+	if uint64(node.FarmID) != req.FarmID {
+		return nil, mw.Forbidden(errors.New("node does not belong to the specified farm"))
+	}
+
+	// Validate slice resources don't exceed node's total capacity
+	if err := req.ValidateAgainstNodeCapacity(
+		node.TotalMru,
+		node.TotalSru,
+		node.TotalHru,
+		uint64(node.TotalCru),
+	); err != nil {
+		return nil, mw.BadRequest(err)
+	}
+
+	// Get farm to verify ownership
+	farm, err := a.cl.GetFarm(r.Context(), uint32(req.FarmID))
+	if err != nil {
+		return nil, errorReply(err)
+	}
+
+	// Verify that the authenticated user owns the farm
+	if resp := mw.EnsureOwner(r, uint64(farm.TwinID)); resp != nil {
+		return nil, resp
+	}
+
+	// Update the slice configuration
+	err = a.cl.UpdateNodeSlice(r.Context(), uint32(nodeID), uint64(req.Slice.MRU), uint64(req.Slice.SRU), uint64(req.Slice.HRU), req.Slice.CRU)
+	if err != nil {
+		return nil, mw.Error(err)
+	}
+
+	return nil, mw.Ok()
+}
+
 func (a *App) health(r *http.Request) (interface{}, mw.Response) {
 	response := mw.Ok()
 	return createReport(
@@ -649,6 +729,9 @@ func Setup(router *mux.Router, gitCommit string, cl DBClient, relayClient rmb.Cl
 	router.HandleFunc("/nodes/{node_id:[0-9]+}/status", mw.AsHandlerFunc(a.getNodeStatus))
 	router.HandleFunc("/nodes/{node_id:[0-9]+}/statistics", mw.AsHandlerFunc(a.getNodeStatistics))
 	router.HandleFunc("/nodes/{node_id:[0-9]+}/gpu", mw.AsHandlerFunc(a.getNodeGpus))
+	// Protected endpoint: requires authentication
+	authMiddleware := mw.AuthMiddleware(&a.cl)
+	router.HandleFunc("/nodes/{node_id:[0-9]+}/slice", mw.AsHandlerFunc(authMiddleware(a.updateNodeSlice))).Methods("PATCH")
 
 	router.HandleFunc("/gateways", mw.AsHandlerFunc(a.getGateways))
 	router.HandleFunc("/gateways/{node_id:[0-9]+}", mw.AsHandlerFunc(a.getGateway))

--- a/grid-proxy/pkg/client/grid_client.go
+++ b/grid-proxy/pkg/client/grid_client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -618,4 +619,75 @@ func (g *Clientimpl) httpGet(path string, params ...interface{}) (resp *http.Res
 	}
 
 	return
+}
+
+func (g *Clientimpl) httpRequest(ctx context.Context, method, path string, body []byte, headers http.Header, params ...interface{}) (*http.Response, error) {
+	client := g.newHTTPClient()
+
+	url, err := g.prepareURL(path, params...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to prepare url")
+	}
+
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, reader)
+	if err != nil {
+		return nil, err
+	}
+
+	for k, vals := range headers {
+		for _, v := range vals {
+			req.Header.Add(k, v)
+		}
+	}
+
+	return client.Do(req)
+}
+
+// UpdateNodeSlice updates the slice configuration for a specific node
+func (g *Clientimpl) UpdateNodeSlice(ctx context.Context, nodeID uint32, sliceReq types.UpdateNodeSliceRequest, twinID uint32, mnemonic string) error {
+	_, span := g.tracer.Start(ctx, "Proxy.UpdateNodeSlice")
+	defer span.End()
+
+	path := fmt.Sprintf("nodes/%d/slice", nodeID)
+
+	body, err := json.Marshal(sliceReq)
+	if err != nil {
+		err = errors.Wrap(err, "failed to marshal UpdateNodeSlice request body")
+		recordSpanError(span, "failed to marshal UpdateNodeSlice request body", err)
+		return err
+	}
+
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json")
+
+	if mnemonic != "" {
+		authHeader, err := createAuthHeaderFromMnemonic(mnemonic, twinID)
+		if err != nil {
+			recordSpanError(span, "failed to create X-Auth header", err)
+			return err
+		}
+		headers.Set("X-Auth", authHeader)
+	}
+
+	resp, err := g.httpRequest(ctx, http.MethodPatch, path, body, headers)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		recordSpanError(span, "failed to call UpdateNodeSlice endpoint", err)
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		err = parseError(resp.Body)
+		recordSpanError(span, "UpdateNodeSlice returned non-OK status", err)
+		return err
+	}
+
+	return nil
 }

--- a/grid-proxy/pkg/client/grid_client.go
+++ b/grid-proxy/pkg/client/grid_client.go
@@ -56,6 +56,7 @@ type DBClient interface {
 type Client interface {
 	Ping() error
 	DBClient
+	UpdateNodeSlice(ctx context.Context, nodeID uint32, sliceReq types.UpdateNodeSliceRequest, twinID uint32, mnemonic string) error
 }
 
 // Clientimpl concrete implementation of the client to communicate with the grid proxy

--- a/grid-proxy/pkg/client/retrying_grid_client.go
+++ b/grid-proxy/pkg/client/retrying_grid_client.go
@@ -147,3 +147,13 @@ func (g *RetryingClient) PublicIps(ctx context.Context, filter types.PublicIpFil
 	err = backoff.RetryNotify(f, bf(g.timeout), notify("public_ips"))
 	return
 }
+
+// UpdateNodeSlice updates the slice configuration for a specific node
+func (g *RetryingClient) UpdateNodeSlice(ctx context.Context, nodeID uint32, sliceReq types.UpdateNodeSliceRequest, twinID uint32, mnemonic string) (err error) {
+	f := func() error {
+		err = g.cl.UpdateNodeSlice(ctx, nodeID, sliceReq, twinID, mnemonic)
+		return err
+	}
+	err = backoff.RetryNotify(f, bf(g.timeout), notify("update_node_slice"))
+	return err
+}

--- a/grid-proxy/pkg/client/retrying_grid_client_test.go
+++ b/grid-proxy/pkg/client/retrying_grid_client_test.go
@@ -66,6 +66,11 @@ func (r *requestCounter) PublicIps(ctx context.Context, filter types.PublicIpFil
 	return nil, 0, errors.New("error")
 }
 
+func (r *requestCounter) UpdateNodeSlice(ctx context.Context, nodeID uint32, sliceReq types.UpdateNodeSliceRequest, twinID uint32, mnemonic string) error {
+	r.Counter++
+	return errors.New("error")
+}
+
 func retryingConstructor(opts ...ClientOption) Client {
 	return NewRetryingClientWithTimeout(NewClient(opts...), 1*time.Millisecond)
 }
@@ -101,6 +106,9 @@ func TestCalledMultipleTimes(t *testing.T) {
 		},
 		"node_status": func() {
 			_, _ = proxy.NodeStatus(context.Background(), 1)
+		},
+		"update_node_slice": func() {
+			_ = proxy.UpdateNodeSlice(context.Background(), 1, types.UpdateNodeSliceRequest{}, 1, "//Alice")
 		},
 	}
 	for endpoint, f := range methods {

--- a/grid-proxy/pkg/client/utils.go
+++ b/grid-proxy/pkg/client/utils.go
@@ -1,9 +1,13 @@
 package client
 
 import (
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
+	substrate "github.com/threefoldtech/tfchain/clients/tfchain-client-go"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
 )
 
@@ -72,4 +76,21 @@ func newContractFromRawContract(rContract types.RawContract) (types.Contract, er
 	default:
 		return types.Contract{}, errors.Errorf("Unknown contract type: %s", rContract.Type)
 	}
+}
+
+func createAuthHeaderFromMnemonic(mnemonic string, twinID uint32) (string, error) {
+	identity, err := substrate.NewIdentityFromSr25519Phrase(mnemonic)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create identity from mnemonic")
+	}
+	timestamp := time.Now().Unix()
+	challenge := fmt.Sprintf("%d:%d", timestamp, twinID)
+
+	sig, err := identity.Sign([]byte(challenge))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to sign challenge")
+	}
+
+	sigB64 := base64.StdEncoding.EncodeToString(sig)
+	return fmt.Sprintf("%d:%d:%s", timestamp, twinID, sigB64), nil
 }

--- a/grid-proxy/pkg/types/nodes.go
+++ b/grid-proxy/pkg/types/nodes.go
@@ -1,6 +1,10 @@
 package types
 
-import "github.com/threefoldtech/zosbase/pkg/gridtypes"
+import (
+	"fmt"
+
+	"github.com/threefoldtech/zosbase/pkg/gridtypes"
+)
 
 // Location represent the geographic info about the node
 type Location struct {
@@ -55,6 +59,8 @@ type Node struct {
 	PriceUsd          float64      `json:"price_usd" sort:"price_usd"`
 	FarmFreeIps       uint         `json:"farm_free_ips"`
 	Features          []string     `json:"features"`
+	Slice             Capacity     `json:"slice"`
+	AvailableSlices   uint64       `json:"available_slices" sort:"available_slices"`
 	_                 string       `sort:"free_cru"`
 }
 
@@ -101,6 +107,8 @@ type NodeWithNestedCapacity struct {
 	PriceUsd          float64        `json:"price_usd"`
 	FarmFreeIps       uint           `json:"farm_free_ips"`
 	Features          []string       `json:"features"`
+	Slice             Capacity       `json:"slice"`
+	AvailableSlices   uint64         `json:"available_slices"`
 }
 
 // PublicConfig node public config
@@ -177,4 +185,43 @@ func (f NodeFilter) IsGpuFilterRequested() bool {
 	return f.HasGPU != nil || f.GpuDeviceName != nil ||
 		f.GpuVendorName != nil || f.GpuVendorID != nil ||
 		f.GpuDeviceID != nil || f.GpuAvailable != nil
+}
+
+// UpdateNodeSliceRequest represents a request to update a node's slice configuration
+type UpdateNodeSliceRequest struct {
+	Slice  Capacity `json:"slice" binding:"required"`
+	FarmID uint64   `json:"farm_id" binding:"required,min=1"` // To check the farmer twin if it really owns the farm which has the node
+}
+
+// Validate validates the UpdateNodeSliceRequest basic constraints
+func (r UpdateNodeSliceRequest) Validate() error {
+	if r.Slice.MRU < 1073741824 {
+		return fmt.Errorf("slice.mru must be at least 1GB (1073741824 bytes), got %d", r.Slice.MRU)
+	}
+	if r.Slice.CRU == 0 {
+		return fmt.Errorf("slice.cru must be at least 1")
+	}
+
+	return nil
+}
+
+// ValidateAgainstNodeCapacity validates that slice resources don't exceed node's total resources
+func (r UpdateNodeSliceRequest) ValidateAgainstNodeCapacity(totalMRU, totalSRU, totalHRU int64, totalCRU uint64) error {
+	if uint64(r.Slice.MRU) > uint64(totalMRU) {
+		return fmt.Errorf("slice.mru (%d) cannot exceed node's total MRU (%d)", r.Slice.MRU, totalMRU)
+	}
+
+	if uint64(r.Slice.SRU) > uint64(totalSRU) {
+		return fmt.Errorf("slice.sru (%d) cannot exceed node's total SRU (%d)", r.Slice.SRU, totalSRU)
+	}
+
+	if uint64(r.Slice.HRU) > uint64(totalHRU) {
+		return fmt.Errorf("slice.hru (%d) cannot exceed node's total HRU (%d)", r.Slice.HRU, totalHRU)
+	}
+
+	if r.Slice.CRU > totalCRU {
+		return fmt.Errorf("slice.cru (%d) cannot exceed node's total CRU (%d)", r.Slice.CRU, totalCRU)
+	}
+
+	return nil
 }

--- a/grid-proxy/pkg/types/nodes.go
+++ b/grid-proxy/pkg/types/nodes.go
@@ -63,6 +63,7 @@ type Node struct {
 	FarmFreeIps       uint         `json:"farm_free_ips"`
 	Features          []string     `json:"features"`
 	Slice             Capacity     `json:"slice"`
+	SlicesNeeded      uint64       `json:"slices_needed,omitempty"`
 	_                 string       `sort:"free_cru"`
 }
 

--- a/grid-proxy/pkg/types/nodes.go
+++ b/grid-proxy/pkg/types/nodes.go
@@ -60,7 +60,6 @@ type Node struct {
 	FarmFreeIps       uint         `json:"farm_free_ips"`
 	Features          []string     `json:"features"`
 	Slice             Capacity     `json:"slice"`
-	AvailableSlices   uint64       `json:"available_slices" sort:"available_slices"`
 	_                 string       `sort:"free_cru"`
 }
 
@@ -108,7 +107,6 @@ type NodeWithNestedCapacity struct {
 	FarmFreeIps       uint           `json:"farm_free_ips"`
 	Features          []string       `json:"features"`
 	Slice             Capacity       `json:"slice"`
-	AvailableSlices   uint64         `json:"available_slices"`
 }
 
 // PublicConfig node public config
@@ -189,8 +187,7 @@ func (f NodeFilter) IsGpuFilterRequested() bool {
 
 // UpdateNodeSliceRequest represents a request to update a node's slice configuration
 type UpdateNodeSliceRequest struct {
-	Slice  Capacity `json:"slice" binding:"required"`
-	FarmID uint64   `json:"farm_id" binding:"required,min=1"` // To check the farmer twin if it really owns the farm which has the node
+	Slice Capacity `json:"slice" binding:"required"` // slice configuration
 }
 
 // Validate validates the UpdateNodeSliceRequest basic constraints

--- a/grid-proxy/pkg/types/nodes.go
+++ b/grid-proxy/pkg/types/nodes.go
@@ -6,6 +6,9 @@ import (
 	"github.com/threefoldtech/zosbase/pkg/gridtypes"
 )
 
+// SliceMRUSizeBytes is the base MRU size (in bytes) used for slice calculations (1 GiB).
+const SliceMRUSizeBytes uint64 = 1_073_741_824
+
 // Location represent the geographic info about the node
 type Location struct {
 	Country   string   `json:"country"`
@@ -192,8 +195,8 @@ type UpdateNodeSliceRequest struct {
 
 // Validate validates the UpdateNodeSliceRequest basic constraints
 func (r UpdateNodeSliceRequest) Validate() error {
-	if r.Slice.MRU < 1073741824 {
-		return fmt.Errorf("slice.mru must be at least 1GB (1073741824 bytes), got %d", r.Slice.MRU)
+	if uint64(r.Slice.MRU) < SliceMRUSizeBytes {
+		return fmt.Errorf("slice.mru must be at least 1GB (%d bytes), got %d", SliceMRUSizeBytes, r.Slice.MRU)
 	}
 	if r.Slice.CRU == 0 {
 		return fmt.Errorf("slice.cru must be at least 1")

--- a/grid-proxy/tests/queries/mock_client/farms.go
+++ b/grid-proxy/tests/queries/mock_client/farms.go
@@ -130,11 +130,10 @@ func (f *Farm) satisfyFarmNodesFilter(data *DBData, filter types.FarmFilter) boo
 		free := CalcFreeResources(total, used)
 
 		// Derive default slice sizes (must match server resources_cache slice_* logic)
-		const sliceMruSize uint64 = 1073741824 // 1GB
 		var sliceMru, sliceSru, sliceHru uint64
 		if total.MRU > 0 {
-			sliceMru = sliceMruSize
-			sliceCount := total.MRU / sliceMruSize
+			sliceMru = types.SliceMRUSizeBytes
+			sliceCount := total.MRU / types.SliceMRUSizeBytes
 			if sliceCount == 0 {
 				sliceCount = 1
 			}

--- a/grid-proxy/tests/queries/mock_client/farms.go
+++ b/grid-proxy/tests/queries/mock_client/farms.go
@@ -128,16 +128,49 @@ func (f *Farm) satisfyFarmNodesFilter(data *DBData, filter types.FarmFilter) boo
 		total := data.NodeTotalResources[node.NodeID]
 		used := data.NodeUsedResources[node.NodeID]
 		free := CalcFreeResources(total, used)
-		if filter.NodeFreeHRU != nil && int64(free.HRU) < int64(*filter.NodeFreeHRU) {
-			continue
+
+		// Derive default slice sizes (must match server resources_cache slice_* logic)
+		const sliceMruSize uint64 = 1073741824 // 1GB
+		var sliceMru, sliceSru, sliceHru uint64
+		if total.MRU > 0 {
+			sliceMru = sliceMruSize
+			sliceCount := total.MRU / sliceMruSize
+			if sliceCount == 0 {
+				sliceCount = 1
+			}
+			sliceSru = total.SRU / sliceCount
+			sliceHru = total.HRU / sliceCount
 		}
 
-		if filter.NodeFreeMRU != nil && int64(free.MRU) < int64(*filter.NodeFreeMRU) {
-			continue
+		// Apply slice-aligned node free filters
+		if filter.NodeFreeMRU != nil {
+			if sliceMru == 0 {
+				continue
+			}
+			requiredSlices := (*filter.NodeFreeMRU + sliceMru - 1) / sliceMru
+			if free.MRU < sliceMru*requiredSlices {
+				continue
+			}
 		}
 
-		if filter.NodeFreeSRU != nil && int64(free.SRU) < int64(*filter.NodeFreeSRU) {
-			continue
+		if filter.NodeFreeSRU != nil {
+			if sliceSru == 0 {
+				continue
+			}
+			requiredSlices := (*filter.NodeFreeSRU + sliceSru - 1) / sliceSru
+			if free.SRU < sliceSru*requiredSlices {
+				continue
+			}
+		}
+
+		if filter.NodeFreeHRU != nil {
+			if sliceHru == 0 {
+				continue
+			}
+			requiredSlices := (*filter.NodeFreeHRU + sliceHru - 1) / sliceHru
+			if free.HRU < sliceHru*requiredSlices {
+				continue
+			}
 		}
 
 		if filter.NodeTotalCRU != nil && total.CRU < *filter.NodeTotalCRU {

--- a/grid-proxy/tests/queries/mock_client/farms.go
+++ b/grid-proxy/tests/queries/mock_client/farms.go
@@ -141,33 +141,21 @@ func (f *Farm) satisfyFarmNodesFilter(data *DBData, filter types.FarmFilter) boo
 			sliceHru = total.HRU / sliceCount
 		}
 
-		// Apply slice-aligned node free filters
-		if filter.NodeFreeMRU != nil {
-			if sliceMru == 0 {
-				continue
+		if filter.NodeFreeMRU != nil || filter.NodeFreeSRU != nil || filter.NodeFreeHRU != nil {
+			mruVal := uint64(0)
+			sruVal := uint64(0)
+			hruVal := uint64(0)
+			if filter.NodeFreeMRU != nil {
+				mruVal = *filter.NodeFreeMRU
 			}
-			requiredSlices := (*filter.NodeFreeMRU + sliceMru - 1) / sliceMru
-			if free.MRU < sliceMru*requiredSlices {
-				continue
+			if filter.NodeFreeSRU != nil {
+				sruVal = *filter.NodeFreeSRU
 			}
-		}
+			if filter.NodeFreeHRU != nil {
+				hruVal = *filter.NodeFreeHRU
+			}
 
-		if filter.NodeFreeSRU != nil {
-			if sliceSru == 0 {
-				continue
-			}
-			requiredSlices := (*filter.NodeFreeSRU + sliceSru - 1) / sliceSru
-			if free.SRU < sliceSru*requiredSlices {
-				continue
-			}
-		}
-
-		if filter.NodeFreeHRU != nil {
-			if sliceHru == 0 {
-				continue
-			}
-			requiredSlices := (*filter.NodeFreeHRU + sliceHru - 1) / sliceHru
-			if free.HRU < sliceHru*requiredSlices {
+			if !satisfiesFreeCapacityFilter(mruVal, sruVal, hruVal, sliceMru, sliceSru, sliceHru, free) {
 				continue
 			}
 		}

--- a/grid-proxy/tests/queries/mock_client/nodes.go
+++ b/grid-proxy/tests/queries/mock_client/nodes.go
@@ -142,7 +142,12 @@ func (g *GridProxyMockClient) Nodes(ctx context.Context, filter types.NodeFilter
 				if sliceCount == 0 {
 					sliceCount = 1
 				}
-				sliceCru = total.CRU / sliceCount
+				if total.CRU > 0 {
+					sliceCru = (total.CRU * 2) / sliceCount
+					if sliceCru == 0 {
+						sliceCru = 1
+					}
+				}
 				sliceSru = total.SRU / sliceCount
 				sliceHru = total.HRU / sliceCount
 			}
@@ -273,7 +278,12 @@ func (g *GridProxyMockClient) Node(ctx context.Context, nodeID uint32) (res type
 		if sliceCount == 0 {
 			sliceCount = 1
 		}
-		sliceCru = total.CRU / sliceCount
+		if total.CRU > 0 {
+			sliceCru = (total.CRU * 2) / sliceCount
+			if sliceCru == 0 {
+				sliceCru = 1
+			}
+		}
 		sliceSru = total.SRU / sliceCount
 		sliceHru = total.HRU / sliceCount
 	}

--- a/grid-proxy/tests/queries/mock_client/nodes.go
+++ b/grid-proxy/tests/queries/mock_client/nodes.go
@@ -128,6 +128,24 @@ func (g *GridProxyMockClient) Nodes(ctx context.Context, filter types.NodeFilter
 				Target: node.Power.Target,
 			}
 			status := nodestatus.DecideNodeStatus(nodePower, int64(node.UpdatedAt))
+
+			total := g.data.NodeTotalResources[node.NodeID]
+
+			const sliceMruSize uint64 = 1073741824 // 1GB in bytes
+			sliceCru := uint64(0)
+			sliceMru := uint64(0)
+			sliceSru := uint64(0)
+			sliceHru := uint64(0)
+			if total.MRU > 0 {
+				sliceMru = sliceMruSize
+				sliceCount := total.MRU / sliceMruSize
+				if sliceCount == 0 {
+					sliceCount = 1
+				}
+				sliceCru = total.CRU / sliceCount
+				sliceSru = total.SRU / sliceCount
+				sliceHru = total.HRU / sliceCount
+			}
 			res = append(res, types.Node{
 				ID:              node.ID,
 				NodeID:          int(node.NodeID),
@@ -204,6 +222,12 @@ func (g *GridProxyMockClient) Nodes(ctx context.Context, filter types.NodeFilter
 				PriceUsd:    calcDiscount(calcNodePrice(g.data, node), limit.Balance),
 				FarmFreeIps: uint(g.data.FreeIPs[node.FarmID]),
 				Features:    g.data.NodeFeatures[uint32(node.TwinID)],
+				Slice: types.Capacity{
+					CRU: sliceCru,
+					SRU: gridtypes.Unit(sliceSru),
+					HRU: gridtypes.Unit(sliceHru),
+					MRU: gridtypes.Unit(sliceMru),
+				},
 			})
 		}
 	}
@@ -236,6 +260,24 @@ func (g *GridProxyMockClient) Node(ctx context.Context, nodeID uint32) (res type
 		Target: node.Power.Target,
 	}
 	status := nodestatus.DecideNodeStatus(nodePower, int64(node.UpdatedAt))
+
+	total := g.data.NodeTotalResources[node.NodeID]
+
+	const sliceMruSize uint64 = 1073741824 // 1GB in bytes
+	sliceCru := uint64(0)
+	sliceMru := uint64(0)
+	sliceSru := uint64(0)
+	sliceHru := uint64(0)
+	if total.MRU > 0 {
+		sliceMru = sliceMruSize
+		sliceCount := total.MRU / sliceMruSize
+		if sliceCount == 0 {
+			sliceCount = 1
+		}
+		sliceCru = total.CRU / sliceCount
+		sliceSru = total.SRU / sliceCount
+		sliceHru = total.HRU / sliceCount
+	}
 	res = types.NodeWithNestedCapacity{
 		ID:              node.ID,
 		NodeID:          int(node.NodeID),
@@ -314,6 +356,12 @@ func (g *GridProxyMockClient) Node(ctx context.Context, nodeID uint32) (res type
 		PriceUsd:    calcNodePrice(g.data, node),
 		FarmFreeIps: uint(g.data.FreeIPs[node.FarmID]),
 		Features:    g.data.NodeFeatures[uint32(node.TwinID)],
+		Slice: types.Capacity{
+			CRU: sliceCru,
+			SRU: gridtypes.Unit(sliceSru),
+			HRU: gridtypes.Unit(sliceHru),
+			MRU: gridtypes.Unit(sliceMru),
+		},
 	}
 	return
 }

--- a/grid-proxy/tests/queries/mock_client/nodes.go
+++ b/grid-proxy/tests/queries/mock_client/nodes.go
@@ -131,14 +131,13 @@ func (g *GridProxyMockClient) Nodes(ctx context.Context, filter types.NodeFilter
 
 			total := g.data.NodeTotalResources[node.NodeID]
 
-			const sliceMruSize uint64 = 1073741824 // 1GB in bytes
 			sliceCru := uint64(0)
 			sliceMru := uint64(0)
 			sliceSru := uint64(0)
 			sliceHru := uint64(0)
 			if total.MRU > 0 {
-				sliceMru = sliceMruSize
-				sliceCount := total.MRU / sliceMruSize
+				sliceMru = types.SliceMRUSizeBytes
+				sliceCount := total.MRU / types.SliceMRUSizeBytes
 				if sliceCount == 0 {
 					sliceCount = 1
 				}
@@ -267,7 +266,7 @@ func (g *GridProxyMockClient) Node(ctx context.Context, nodeID uint32) (res type
 	status := nodestatus.DecideNodeStatus(nodePower, int64(node.UpdatedAt))
 
 	total := g.data.NodeTotalResources[node.NodeID]
-	const sliceMruSize uint64 = 1073741824 // 1GB in bytes
+	const sliceMruSize = types.SliceMRUSizeBytes // 1GB in bytes
 	sliceCru := uint64(0)
 	sliceMru := uint64(0)
 	sliceSru := uint64(0)
@@ -400,7 +399,7 @@ func (n *Node) satisfies(f types.NodeFilter, data *DBData) bool {
 	used := data.NodeUsedResources[n.NodeID]
 	free := CalcFreeResources(total, used)
 
-	const sliceMruSize uint64 = 1073741824 // 1GB
+	const sliceMruSize = types.SliceMRUSizeBytes // 1GB
 	var sliceMru, sliceSru, sliceHru uint64
 	if total.MRU > 0 {
 		sliceMru = sliceMruSize

--- a/grid-proxy/tests/queries/mock_client/nodes.go
+++ b/grid-proxy/tests/queries/mock_client/nodes.go
@@ -262,7 +262,6 @@ func (g *GridProxyMockClient) Node(ctx context.Context, nodeID uint32) (res type
 	status := nodestatus.DecideNodeStatus(nodePower, int64(node.UpdatedAt))
 
 	total := g.data.NodeTotalResources[node.NodeID]
-
 	const sliceMruSize uint64 = 1073741824 // 1GB in bytes
 	sliceCru := uint64(0)
 	sliceMru := uint64(0)
@@ -278,6 +277,7 @@ func (g *GridProxyMockClient) Node(ctx context.Context, nodeID uint32) (res type
 		sliceSru = total.SRU / sliceCount
 		sliceHru = total.HRU / sliceCount
 	}
+
 	res = types.NodeWithNestedCapacity{
 		ID:              node.ID,
 		NodeID:          int(node.NodeID),
@@ -390,17 +390,43 @@ func (n *Node) satisfies(f types.NodeFilter, data *DBData) bool {
 	used := data.NodeUsedResources[n.NodeID]
 	free := CalcFreeResources(total, used)
 
+	const sliceMruSize uint64 = 1073741824 // 1GB
+	var sliceMru, sliceSru, sliceHru uint64
+	if total.MRU > 0 {
+		sliceMru = sliceMruSize
+		sliceCount := total.MRU / sliceMruSize
+		if sliceCount == 0 {
+			sliceCount = 1
+		}
+		sliceSru = total.SRU / sliceCount
+		sliceHru = total.HRU / sliceCount
+	}
+
 	nodeStatus := nodestatus.DecideNodeStatus(nodePower, int64(n.UpdatedAt))
 	if len(f.Status) != 0 && !slices.Contains(f.Status, nodeStatus) {
 		return false
 	}
 
-	if f.FreeMRU != nil && int64(*f.FreeMRU) > int64(free.MRU) {
-		return false
+	if f.FreeMRU != nil {
+		// Require enough whole slices of MRU
+		if sliceMru == 0 {
+			return false
+		}
+		requiredSlices := (*f.FreeMRU + sliceMru - 1) / sliceMru
+		if free.MRU < sliceMru*requiredSlices {
+			return false
+		}
 	}
 
-	if f.FreeHRU != nil && int64(*f.FreeHRU) > int64(free.HRU) {
-		return false
+	if f.FreeHRU != nil {
+		// Require enough whole slices of HRU
+		if sliceHru == 0 {
+			return false
+		}
+		requiredSlices := (*f.FreeHRU + sliceHru - 1) / sliceHru
+		if free.HRU < sliceHru*requiredSlices {
+			return false
+		}
 	}
 
 	if f.Healthy != nil && *f.Healthy != data.HealthReports[uint32(n.TwinID)] {
@@ -415,8 +441,15 @@ func (n *Node) satisfies(f types.NodeFilter, data *DBData) bool {
 		return false
 	}
 
-	if f.FreeSRU != nil && int64(*f.FreeSRU) > int64(free.SRU) {
-		return false
+	if f.FreeSRU != nil {
+		// Require enough whole slices of SRU
+		if sliceSru == 0 {
+			return false
+		}
+		requiredSlices := (*f.FreeSRU + sliceSru - 1) / sliceSru
+		if free.SRU < sliceSru*requiredSlices {
+			return false
+		}
 	}
 
 	if f.TotalCRU != nil && *f.TotalCRU > total.CRU {

--- a/grid-proxy/tests/queries/mock_client/nodes.go
+++ b/grid-proxy/tests/queries/mock_client/nodes.go
@@ -150,6 +150,45 @@ func (g *GridProxyMockClient) Nodes(ctx context.Context, filter types.NodeFilter
 				sliceSru = total.SRU / sliceCount
 				sliceHru = total.HRU / sliceCount
 			}
+
+			var slicesNeeded uint64
+			if filter.FreeMRU != nil || filter.FreeSRU != nil || filter.FreeHRU != nil {
+				mruVal := uint64(0)
+				sruVal := uint64(0)
+				hruVal := uint64(0)
+				if filter.FreeMRU != nil {
+					mruVal = *filter.FreeMRU
+				}
+				if filter.FreeSRU != nil {
+					sruVal = *filter.FreeSRU
+				}
+				if filter.FreeHRU != nil {
+					hruVal = *filter.FreeHRU
+				}
+
+				free := CalcFreeResources(total, g.data.NodeUsedResources[node.NodeID])
+				if satisfiesFreeCapacityFilter(mruVal, sruVal, hruVal, sliceMru, sliceSru, sliceHru, free) {
+					var slicesNeededMRU, slicesNeededSRU, slicesNeededHRU uint64
+					if sliceMru > 0 {
+						slicesNeededMRU = (mruVal + sliceMru - 1) / sliceMru
+					}
+					if sliceSru > 0 {
+						slicesNeededSRU = (sruVal + sliceSru - 1) / sliceSru
+					}
+					if sliceHru > 0 {
+						slicesNeededHRU = (hruVal + sliceHru - 1) / sliceHru
+					}
+
+					slicesNeeded = slicesNeededMRU
+					if slicesNeededSRU > slicesNeeded {
+						slicesNeeded = slicesNeededSRU
+					}
+					if slicesNeededHRU > slicesNeeded {
+						slicesNeeded = slicesNeededHRU
+					}
+				}
+			}
+
 			res = append(res, types.Node{
 				ID:              node.ID,
 				NodeID:          int(node.NodeID),
@@ -232,6 +271,7 @@ func (g *GridProxyMockClient) Nodes(ctx context.Context, filter types.NodeFilter
 					HRU: gridtypes.Unit(sliceHru),
 					MRU: gridtypes.Unit(sliceMru),
 				},
+				SlicesNeeded: slicesNeeded,
 			})
 		}
 	}
@@ -416,24 +456,21 @@ func (n *Node) satisfies(f types.NodeFilter, data *DBData) bool {
 		return false
 	}
 
-	if f.FreeMRU != nil {
-		// Require enough whole slices of MRU
-		if sliceMru == 0 {
-			return false
+	if f.FreeMRU != nil || f.FreeSRU != nil || f.FreeHRU != nil {
+		mruVal := uint64(0)
+		sruVal := uint64(0)
+		hruVal := uint64(0)
+		if f.FreeMRU != nil {
+			mruVal = *f.FreeMRU
 		}
-		requiredSlices := (*f.FreeMRU + sliceMru - 1) / sliceMru
-		if free.MRU < sliceMru*requiredSlices {
-			return false
+		if f.FreeSRU != nil {
+			sruVal = *f.FreeSRU
 		}
-	}
+		if f.FreeHRU != nil {
+			hruVal = *f.FreeHRU
+		}
 
-	if f.FreeHRU != nil {
-		// Require enough whole slices of HRU
-		if sliceHru == 0 {
-			return false
-		}
-		requiredSlices := (*f.FreeHRU + sliceHru - 1) / sliceHru
-		if free.HRU < sliceHru*requiredSlices {
+		if !satisfiesFreeCapacityFilter(mruVal, sruVal, hruVal, sliceMru, sliceSru, sliceHru, free) {
 			return false
 		}
 	}
@@ -448,17 +485,6 @@ func (n *Node) satisfies(f types.NodeFilter, data *DBData) bool {
 
 	if len(f.Features) != 0 && !sliceContains(data.NodeFeatures[uint32(n.TwinID)], f.Features) {
 		return false
-	}
-
-	if f.FreeSRU != nil {
-		// Require enough whole slices of SRU
-		if sliceSru == 0 {
-			return false
-		}
-		requiredSlices := (*f.FreeSRU + sliceSru - 1) / sliceSru
-		if free.SRU < sliceSru*requiredSlices {
-			return false
-		}
 	}
 
 	if f.TotalCRU != nil && *f.TotalCRU > total.CRU {

--- a/grid-proxy/tests/queries/mock_client/nodes.go
+++ b/grid-proxy/tests/queries/mock_client/nodes.go
@@ -647,3 +647,7 @@ func gpuSatisfied(gpu types.NodeGPU, f types.NodeFilter) bool {
 func contains(s string, sub string) bool {
 	return strings.Contains(strings.ToLower(s), sub)
 }
+
+func (g *GridProxyMockClient) UpdateNodeSlice(ctx context.Context, nodeID uint32, sliceReq types.UpdateNodeSliceRequest, twinID uint32, mnemonic string) error {
+	return nil
+}

--- a/grid-proxy/tests/queries/mock_client/utils.go
+++ b/grid-proxy/tests/queries/mock_client/utils.go
@@ -65,3 +65,49 @@ func sliceContains(set []string, subset []string) bool {
 
 	return true
 }
+
+func satisfiesFreeCapacityFilter(mruVal, sruVal, hruVal uint64, sliceMru, sliceSru, sliceHru uint64, free NodeResourcesTotal) bool {
+	if (mruVal > 0 && sliceMru == 0) || (sruVal > 0 && sliceSru == 0) || (hruVal > 0 && sliceHru == 0) {
+		return false
+	}
+
+	var slicesNeededMRU, slicesNeededSRU, slicesNeededHRU uint64
+	if sliceMru > 0 {
+		slicesNeededMRU = (mruVal + sliceMru - 1) / sliceMru
+	}
+	if sliceSru > 0 {
+		slicesNeededSRU = (sruVal + sliceSru - 1) / sliceSru
+	}
+	if sliceHru > 0 {
+		slicesNeededHRU = (hruVal + sliceHru - 1) / sliceHru
+	}
+
+	slicesNeeded := slicesNeededMRU
+	if slicesNeededSRU > slicesNeeded {
+		slicesNeeded = slicesNeededSRU
+	}
+	if slicesNeededHRU > slicesNeeded {
+		slicesNeeded = slicesNeededHRU
+	}
+
+	var slicesAvailableMRU, slicesAvailableSRU, slicesAvailableHRU uint64 = 1e18, 1e18, 1e18
+	if sliceMru > 0 {
+		slicesAvailableMRU = free.MRU / sliceMru
+	}
+	if sliceSru > 0 {
+		slicesAvailableSRU = free.SRU / sliceSru
+	}
+	if sliceHru > 0 {
+		slicesAvailableHRU = free.HRU / sliceHru
+	}
+
+	slicesAvailable := slicesAvailableMRU
+	if slicesAvailableSRU < slicesAvailable {
+		slicesAvailable = slicesAvailableSRU
+	}
+	if slicesAvailableHRU < slicesAvailable {
+		slicesAvailable = slicesAvailableHRU
+	}
+
+	return slicesNeeded > 0 && slicesNeeded <= slicesAvailable
+}

--- a/grid-proxy/tests/queries/node_test.go
+++ b/grid-proxy/tests/queries/node_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -12,9 +13,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	substrate "github.com/threefoldtech/tfchain/clients/tfchain-client-go"
 	proxyclient "github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/client"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
 	mock "github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/tests/queries/mock_client"
+	gridtypes "github.com/threefoldtech/zosbase/pkg/gridtypes"
 )
 
 type NodesAggregate struct {
@@ -471,6 +474,102 @@ func TestNode(t *testing.T) {
 		assert.NoError(t, err)
 
 		require.True(t, reflect.DeepEqual(want, got), "failed on testing staking discount", fmt.Sprintf("Difference:\n%s", cmp.Diff(want, got)))
+	})
+
+	t.Run("update node slice", func(t *testing.T) {
+		require.NotEmpty(t, data.Farms, "expected at least one farm in test data")
+
+		var (
+			farmID uint64
+			farm   mock.Farm
+		)
+		for id, f := range data.Farms {
+			farmID, farm = id, f
+			break
+		}
+
+		var nodeID uint64
+		for id, n := range data.Nodes {
+			if n.FarmID == farmID {
+				nodeID = id
+				break
+			}
+		}
+		require.NotZero(t, nodeID, "expected at least one node for selected farm")
+
+		twinID := farm.TwinID
+		require.NotZero(t, twinID, "farm must have a twin owner")
+
+		const testMnemonic = "//Alice"
+
+		var originalPubKey string
+		err := data.DB.QueryRow(`SELECT public_key FROM twin WHERE twin_id = $1`, twinID).Scan(&originalPubKey)
+		require.NoError(t, err)
+
+		identity, err := substrate.NewIdentityFromSr25519Phrase(testMnemonic)
+		require.NoError(t, err)
+
+		pubKey := identity.PublicKey()
+		pubKeyB64 := base64.StdEncoding.EncodeToString(pubKey)
+
+		_, err = data.DB.Exec(`UPDATE twin SET public_key = $1 WHERE twin_id = $2`, pubKeyB64, twinID)
+		require.NoError(t, err)
+
+		// read current slice and total resources
+		before, err := gridProxyClient.Node(context.Background(), uint32(nodeID))
+		require.NoError(t, err)
+
+		newSlice := before.Slice
+
+		// adjust MRU within total bounds, ensure >= 1 GiB and changed if possible
+		const oneGiB = 1_073_741_824
+		total := before.Capacity.Total
+
+		if uint64(newSlice.MRU)+oneGiB <= uint64(total.MRU) {
+			newSlice.MRU = newSlice.MRU + gridtypes.Unit(oneGiB)
+		} else if uint64(newSlice.MRU) >= 2*oneGiB {
+			newSlice.MRU = newSlice.MRU - gridtypes.Unit(oneGiB)
+		}
+
+		// adjust CRU within total bounds, ensure >=1 and changed if possible
+		if newSlice.CRU < total.CRU {
+			newSlice.CRU++
+		} else if newSlice.CRU > 1 {
+			newSlice.CRU--
+		}
+
+		// ensure we actually changed something; if not, skip test
+		if newSlice == before.Slice {
+			t.Skip("could not find a safe slice mutation within total resources")
+		}
+
+		sliceReq := types.UpdateNodeSliceRequest{
+			Slice: newSlice,
+		}
+
+		err = gridProxyClient.UpdateNodeSlice(context.Background(), uint32(nodeID), sliceReq, uint32(twinID), testMnemonic)
+		require.NoError(t, err)
+
+		got, err := gridProxyClient.Node(context.Background(), uint32(nodeID))
+		require.NoError(t, err)
+
+		require.Equal(t, newSlice, got.Slice)
+		require.NotEqual(t, before.Slice, got.Slice)
+
+		// restore original slice so other tests comparing with the mock remain valid
+		restoreErr := DBClient.UpdateNodeSlice(
+			context.Background(),
+			uint32(nodeID),
+			uint64(before.Slice.MRU),
+			uint64(before.Slice.SRU),
+			uint64(before.Slice.HRU),
+			before.Slice.CRU,
+		)
+		require.NoError(t, restoreErr)
+
+		// restore original twin public key so twin-related tests stay in sync with mock data
+		_, err = data.DB.Exec(`UPDATE twin SET public_key = $1 WHERE twin_id = $2`, originalPubKey, twinID)
+		require.NoError(t, err)
 	})
 }
 

--- a/grid-proxy/tests/queries/node_test.go
+++ b/grid-proxy/tests/queries/node_test.go
@@ -522,7 +522,7 @@ func TestNode(t *testing.T) {
 		newSlice := before.Slice
 
 		// adjust MRU within total bounds, ensure >= 1 GiB and changed if possible
-		const oneGiB = 1_073_741_824
+		const oneGiB = types.SliceMRUSizeBytes
 		total := before.Capacity.Total
 
 		if uint64(newSlice.MRU)+oneGiB <= uint64(total.MRU) {

--- a/grid-proxy/tests/queries/node_test.go
+++ b/grid-proxy/tests/queries/node_test.go
@@ -515,6 +515,11 @@ func TestNode(t *testing.T) {
 		_, err = data.DB.Exec(`UPDATE twin SET public_key = $1 WHERE twin_id = $2`, pubKeyB64, twinID)
 		require.NoError(t, err)
 
+		defer func() {
+			_, err := data.DB.Exec(`UPDATE twin SET public_key = $1 WHERE twin_id = $2`, originalPubKey, twinID)
+			require.NoError(t, err)
+		}()
+
 		// read current slice and total resources
 		before, err := gridProxyClient.Node(context.Background(), uint32(nodeID))
 		require.NoError(t, err)
@@ -566,10 +571,6 @@ func TestNode(t *testing.T) {
 			before.Slice.CRU,
 		)
 		require.NoError(t, restoreErr)
-
-		// restore original twin public key so twin-related tests stay in sync with mock data
-		_, err = data.DB.Exec(`UPDATE twin SET public_key = $1 WHERE twin_id = $2`, originalPubKey, twinID)
-		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
### Description


### Changes
- Add node slice capacity to types and DB: Nodes now have a Slice Capacity field (MRU/SRU/HRU/CRU) persisted in resources_cache and exposed via the API.
- Make resource filters slice-aware: Node and farm filters for free MRU/SRU/HRU now use slice-aligned formulas so requests respect configured slice sizes.
- Implement UpdateNodeSlice backend logic: New DB method UpdateNodeSlice updates resources_cache.slice_* for a node and returns appropriate errors.
- Expose UpdateNodeSlice over HTTP + client: Added authenticated PATCH /nodes/{id}/slice endpoint, client/retrying-client methods, utilities, and tests to call it using a twin mnemonic.

### Related Issues

#1487 

### Checklist

- [x] Tests included
- [x] Build pass
- [ ] Documentation
- [ ] Code format and docstring
