### PR TITLE
Migrate zosbase -> zos_base dependency (v1.1.0)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 version: "2"
 linters:
   enable:
-    - goconst
     - misspell
     - unconvert
   exclusions:

--- a/farmerbot/go.mod
+++ b/farmerbot/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	github.com/threefoldtech/zosbase v1.0.9 // indirect
+	github.com/threefoldtech/zos_base v1.1.0 // indirect
 	github.com/vedhavyas/go-subkey/v2 v2.0.0 // indirect
 	go.opentelemetry.io/otel v1.39.0 // indirect
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect

--- a/farmerbot/go.sum
+++ b/farmerbot/go.sum
@@ -124,6 +124,7 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00 h1:Q/vkWlTfZBCo4SclrbpSV35sSg/EF2MIIi0LgxPdzCI=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
 github.com/threefoldtech/zos_base v1.1.0 h1:WpjxPCzEgHOkMorhkKcpqRKXnsvL4euXOBnR2IdI/AM=
+github.com/threefoldtech/zos_base v1.1.0/go.mod h1:pVOuEZ6lobb3XPmiZwrzdxahuM29hU7wKqfX+Vih1cI=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/farmerbot/go.sum
+++ b/farmerbot/go.sum
@@ -123,8 +123,7 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00 h1:Q/vkWlTfZBCo4SclrbpSV35sSg/EF2MIIi0LgxPdzCI=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
-github.com/threefoldtech/zosbase v1.0.9 h1:jZ/km4PiOnJHSqpfg4cJRC3k9GE+vzX5LF1MaJnXOoU=
-github.com/threefoldtech/zosbase v1.0.9/go.mod h1:HIDT3p2LZsaUp4TQa5A/AB1MdW0YAPUEaK+lkc3gSsM=
+github.com/threefoldtech/zos_base v1.1.0 h1:WpjxPCzEgHOkMorhkKcpqRKXnsvL4euXOBnR2IdI/AM=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/grid-cli/cmd/deploy_gateway.go
+++ b/grid-cli/cmd/deploy_gateway.go
@@ -4,7 +4,7 @@ package cmd
 import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // deployGatewayCmd represents the deploy gateway command

--- a/grid-cli/cmd/deploy_zdb.go
+++ b/grid-cli/cmd/deploy_zdb.go
@@ -12,7 +12,7 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-cli/internal/filters"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/deployer"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // deployZDBCmd represents the deploy zdb command

--- a/grid-cli/go.mod
+++ b/grid-cli/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/threefoldtech/tfgrid-sdk-go/grid-client v0.15.18
 	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0
-	github.com/threefoldtech/zosbase v1.0.9
+	github.com/threefoldtech/zos_base v1.1.0
 	github.com/vedhavyas/go-subkey v1.0.3
 )
 

--- a/grid-cli/go.sum
+++ b/grid-cli/go.sum
@@ -132,8 +132,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00 h1:Q/vkWlTfZBCo4SclrbpSV35sSg/EF2MIIi0LgxPdzCI=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
-github.com/threefoldtech/zosbase v1.0.9 h1:jZ/km4PiOnJHSqpfg4cJRC3k9GE+vzX5LF1MaJnXOoU=
-github.com/threefoldtech/zosbase v1.0.9/go.mod h1:HIDT3p2LZsaUp4TQa5A/AB1MdW0YAPUEaK+lkc3gSsM=
+github.com/threefoldtech/zos_base v1.1.0 h1:WpjxPCzEgHOkMorhkKcpqRKXnsvL4euXOBnR2IdI/AM=
+github.com/threefoldtech/zos_base v1.1.0/go.mod h1:pVOuEZ6lobb3XPmiZwrzdxahuM29hU7wKqfX+Vih1cI=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/grid-client/deployer/deployer.go
+++ b/grid-client/deployer/deployer.go
@@ -19,7 +19,7 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
 	proxy "github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/client"
 	proxyTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"

--- a/grid-client/deployer/deployer_test.go
+++ b/grid-client/deployer/deployer_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
 	zosTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
 	proxyTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 	subkey "github.com/vedhavyas/go-subkey"
 )
 

--- a/grid-client/deployer/deployment_deployer_test.go
+++ b/grid-client/deployer/deployment_deployer_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/state"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
 	zosTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 var (

--- a/grid-client/deployer/deployment_utils.go
+++ b/grid-client/deployer/deployment_utils.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	zosTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // CountDeploymentPublicIPs counts the public IPs of a deployment

--- a/grid-client/deployer/gateway_fqdn_deployer_test.go
+++ b/grid-client/deployer/gateway_fqdn_deployer_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
 	zosTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
 	proxyTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 func constructTestFQDNDeployer(t *testing.T, mock bool) (

--- a/grid-client/deployer/gateway_name_deployer_test.go
+++ b/grid-client/deployer/gateway_name_deployer_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/state"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
 	zosTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 var nameContractID uint64 = 200

--- a/grid-client/deployer/k8s_deployer.go
+++ b/grid-client/deployer/k8s_deployer.go
@@ -12,8 +12,8 @@ import (
 	client "github.com/threefoldtech/tfgrid-sdk-go/grid-client/node"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
 	zosTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // K8sDeployer for deploying k8s

--- a/grid-client/deployer/k8s_deployer_test.go
+++ b/grid-client/deployer/k8s_deployer_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/subi"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
 	zosTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
 )
 
 func constructTestK8s(t *testing.T, mock bool) (

--- a/grid-client/deployer/node_filter.go
+++ b/grid-client/deployer/node_filter.go
@@ -15,8 +15,8 @@ import (
 	"github.com/rs/zerolog/log"
 	client "github.com/threefoldtech/tfgrid-sdk-go/grid-client/node"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 const requestedPagesPerIteration = 5

--- a/grid-client/deployer/node_filter_test.go
+++ b/grid-client/deployer/node_filter_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	client "github.com/threefoldtech/tfgrid-sdk-go/grid-client/node"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 func TestHasEnoughStorage(t *testing.T) {

--- a/grid-client/go.mod
+++ b/grid-client/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00
 	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0
 	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.6
-	github.com/threefoldtech/zosbase v1.0.9
+	github.com/threefoldtech/zos_base v1.1.0
 	github.com/vedhavyas/go-subkey v1.0.3
 	go.opentelemetry.io/otel v1.39.0
 	go.opentelemetry.io/otel/trace v1.39.0

--- a/grid-client/go.sum
+++ b/grid-client/go.sum
@@ -156,8 +156,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00 h1:Q/vkWlTfZBCo4SclrbpSV35sSg/EF2MIIi0LgxPdzCI=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
-github.com/threefoldtech/zosbase v1.0.9 h1:jZ/km4PiOnJHSqpfg4cJRC3k9GE+vzX5LF1MaJnXOoU=
-github.com/threefoldtech/zosbase v1.0.9/go.mod h1:HIDT3p2LZsaUp4TQa5A/AB1MdW0YAPUEaK+lkc3gSsM=
+github.com/threefoldtech/zos_base v1.1.0 h1:WpjxPCzEgHOkMorhkKcpqRKXnsvL4euXOBnR2IdI/AM=
+github.com/threefoldtech/zos_base v1.1.0/go.mod h1:pVOuEZ6lobb3XPmiZwrzdxahuM29hU7wKqfX+Vih1cI=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/grid-client/integration_tests/batch_gateway_name_test.go
+++ b/grid-client/integration_tests/batch_gateway_name_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/deployer"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
 
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 func TestBatchGatewayNameDeployment(t *testing.T) {

--- a/grid-client/integration_tests/gateway_name_test.go
+++ b/grid-client/integration_tests/gateway_name_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/deployer"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
 
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 func TestGatewayNameDeployment(t *testing.T) {

--- a/grid-client/integration_tests/gatway_fqdn_test.go
+++ b/grid-client/integration_tests/gatway_fqdn_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/deployer"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
 
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 func TestGatewayFQDNDeployment(t *testing.T) {

--- a/grid-client/integration_tests/qsfs_test.go
+++ b/grid-client/integration_tests/qsfs_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/deployer"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 const (

--- a/grid-client/integration_tests/zdb_test.go
+++ b/grid-client/integration_tests/zdb_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/deployer"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 func TestZDBDeployment(t *testing.T) {

--- a/grid-client/node/node.go
+++ b/grid-client/node/node.go
@@ -83,9 +83,9 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/subi"
 	zosTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
 	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go"
-	"github.com/threefoldtech/zosbase/pkg/capacity/dmi"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/capacity/dmi"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // ErrNoAccessibleInterfaceFound no accessible interface found

--- a/grid-client/state/state.go
+++ b/grid-client/state/state.go
@@ -14,8 +14,8 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/subi"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
 	zosTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 	"golang.org/x/exp/maps"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )

--- a/grid-client/state/state_test.go
+++ b/grid-client/state/state_test.go
@@ -14,8 +14,8 @@ import (
 	client "github.com/threefoldtech/tfgrid-sdk-go/grid-client/node"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/workloads"
 	zosTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 

--- a/grid-client/workloads/disk.go
+++ b/grid-client/workloads/disk.go
@@ -4,7 +4,7 @@ package workloads
 import (
 	"github.com/pkg/errors"
 	zosTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // Disk struct

--- a/grid-client/workloads/gateway_fqdn.go
+++ b/grid-client/workloads/gateway_fqdn.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 var fqdnRegex = regexp.MustCompile(`^([a-zA-Z0-9-_]+\.)+[a-zA-Z0-9-_]{2,}$`)

--- a/grid-client/workloads/gateway_fqdn_test.go
+++ b/grid-client/workloads/gateway_fqdn_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // GatewayWorkload for tests

--- a/grid-client/workloads/gateway_name.go
+++ b/grid-client/workloads/gateway_name.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // GatewayNameProxy struct for gateway name proxy

--- a/grid-client/workloads/gateway_name_test.go
+++ b/grid-client/workloads/gateway_name_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // GatewayWorkload for tests

--- a/grid-client/workloads/k8s.go
+++ b/grid-client/workloads/k8s.go
@@ -11,8 +11,8 @@ import (
 	"github.com/pkg/errors"
 	substrate "github.com/threefoldtech/tfchain/clients/tfchain-client-go"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/subi"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // old: https://hub.grid.tf/tf-official-apps/threefoldtech-k3s-latest.flist

--- a/grid-client/workloads/k8s_test.go
+++ b/grid-client/workloads/k8s_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // K8sWorkload to be used in tests

--- a/grid-client/workloads/qsfs.go
+++ b/grid-client/workloads/qsfs.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	zosTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // QSFS struct

--- a/grid-client/workloads/vm.go
+++ b/grid-client/workloads/vm.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/pkg/errors"
 	zosTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // VM is a virtual machine struct

--- a/grid-client/workloads/vm_light.go
+++ b/grid-client/workloads/vm_light.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
 )
 
 // VMLight is a virtual machine struct

--- a/grid-client/workloads/volume.go
+++ b/grid-client/workloads/volume.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	zosTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // Volume struct

--- a/grid-client/workloads/zdb.go
+++ b/grid-client/workloads/zdb.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	zosTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 const (

--- a/grid-client/workloads/zlog.go
+++ b/grid-client/workloads/zlog.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	zosTypes "github.com/threefoldtech/tfgrid-sdk-go/grid-client/zos"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // Zlog logger struct

--- a/grid-client/zos/deployment.go
+++ b/grid-client/zos/deployment.go
@@ -3,7 +3,7 @@ package zos
 import (
 	"io"
 
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
 )
 
 type ZosDeployment interface {

--- a/grid-client/zos/machine.go
+++ b/grid-client/zos/machine.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // ZMachine reservation data

--- a/grid-client/zos/machine_light.go
+++ b/grid-client/zos/machine_light.go
@@ -2,7 +2,7 @@ package zos
 
 import (
 	"github.com/pkg/errors"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 type ZMachineLight struct {

--- a/grid-client/zos/network.go
+++ b/grid-client/zos/network.go
@@ -2,7 +2,7 @@ package zos
 
 import (
 	"github.com/pkg/errors"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // Network is the description of a part of a network local to a specific node.

--- a/grid-client/zos/network_light.go
+++ b/grid-client/zos/network_light.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 
 	"github.com/pkg/errors"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes/zos"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes/zos"
 )
 
 // Bytes value that is represented as hex when serialized to json

--- a/grid-client/zos/workload.go
+++ b/grid-client/zos/workload.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"slices"
 
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
 )
 
 type Workload struct {

--- a/grid-proxy/go.mod
+++ b/grid-proxy/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/swaggo/swag v1.16.4
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00
 	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.6
-	github.com/threefoldtech/zosbase v1.0.9
+	github.com/threefoldtech/zos_base v1.1.0
 	go.opentelemetry.io/otel v1.39.0
 	go.opentelemetry.io/otel/trace v1.39.0
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c

--- a/grid-proxy/go.sum
+++ b/grid-proxy/go.sum
@@ -201,8 +201,8 @@ github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
 github.com/threefoldtech/zbus v1.0.1 h1:3KaEpyOiDYAw+lrAyoQUGIvY9BcjVRXlQ1beBRqhRNk=
 github.com/threefoldtech/zbus v1.0.1/go.mod h1:E/v/xEvG/l6z/Oj0aDkuSUXFm/1RVJkhKBwDTAIdsHo=
-github.com/threefoldtech/zosbase v1.0.9 h1:jZ/km4PiOnJHSqpfg4cJRC3k9GE+vzX5LF1MaJnXOoU=
-github.com/threefoldtech/zosbase v1.0.9/go.mod h1:HIDT3p2LZsaUp4TQa5A/AB1MdW0YAPUEaK+lkc3gSsM=
+github.com/threefoldtech/zos_base v1.1.0 h1:WpjxPCzEgHOkMorhkKcpqRKXnsvL4euXOBnR2IdI/AM=
+github.com/threefoldtech/zos_base v1.1.0/go.mod h1:pVOuEZ6lobb3XPmiZwrzdxahuM29hU7wKqfX+Vih1cI=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/grid-proxy/internal/explorer/converters.go
+++ b/grid-proxy/internal/explorer/converters.go
@@ -9,7 +9,7 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/nodestatus"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
 
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
 )
 
 func nodeFromDBNode(info db.Node) types.Node {

--- a/grid-proxy/internal/explorer/db/postgres.go
+++ b/grid-proxy/internal/explorer/db/postgres.go
@@ -10,7 +10,7 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/nodestatus"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"

--- a/grid-proxy/internal/explorer/param_parser.go
+++ b/grid-proxy/internal/explorer/param_parser.go
@@ -65,7 +65,7 @@ func parseQueryParams(r *http.Request, types_ ...interface{}) error {
 // returns a slice of all the possible params for this type
 func getSchemaTags(type_ interface{}) []string {
 	t := reflect.TypeOf(type_)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 

--- a/grid-proxy/internal/indexer/dmi.go
+++ b/grid-proxy/internal/indexer/dmi.go
@@ -7,7 +7,7 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/explorer/db"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
 	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go/peer"
-	zosDmiTypes "github.com/threefoldtech/zosbase/pkg/capacity/dmi"
+	zosDmiTypes "github.com/threefoldtech/zos_base/pkg/capacity/dmi"
 )
 
 const (

--- a/grid-proxy/internal/indexer/health.go
+++ b/grid-proxy/internal/indexer/health.go
@@ -7,7 +7,7 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/explorer/db"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
 	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go/peer"
-	"github.com/threefoldtech/zosbase/pkg/diagnostics"
+	"github.com/threefoldtech/zos_base/pkg/diagnostics"
 )
 
 const (

--- a/grid-proxy/internal/indexer/location.go
+++ b/grid-proxy/internal/indexer/location.go
@@ -7,7 +7,7 @@ import (
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/internal/explorer/db"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
 	"github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go/peer"
-	"github.com/threefoldtech/zosbase/pkg/geoip"
+	"github.com/threefoldtech/zos_base/pkg/geoip"
 )
 
 const locationCmd = "zos.location.get"

--- a/grid-proxy/pkg/types/nodes.go
+++ b/grid-proxy/pkg/types/nodes.go
@@ -1,6 +1,6 @@
 package types
 
-import "github.com/threefoldtech/zosbase/pkg/gridtypes"
+import "github.com/threefoldtech/zos_base/pkg/gridtypes"
 
 // Location represent the geographic info about the node
 type Location struct {

--- a/grid-proxy/tests/queries/mock_client/loader.go
+++ b/grid-proxy/tests/queries/mock_client/loader.go
@@ -6,7 +6,7 @@ import (
 	"math"
 
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
 	"gorm.io/gorm"
 )
 

--- a/grid-proxy/tests/queries/mock_client/nodes.go
+++ b/grid-proxy/tests/queries/mock_client/nodes.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/nodestatus"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
 	"golang.org/x/exp/slices"
 )
 

--- a/grid-proxy/tools/db/crafter/generator.go
+++ b/grid-proxy/tools/db/crafter/generator.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/threefoldtech/tfgrid-sdk-go/grid-proxy/pkg/types"
-	"github.com/threefoldtech/zosbase/pkg/gridtypes"
+	"github.com/threefoldtech/zos_base/pkg/gridtypes"
 )
 
 const deleted = "Deleted"

--- a/gridify/go.mod
+++ b/gridify/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00 // indirect
 	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.6 // indirect
-	github.com/threefoldtech/zosbase v1.0.9 // indirect
+	github.com/threefoldtech/zos_base v1.1.0 // indirect
 	github.com/vedhavyas/go-subkey v1.0.3 // indirect
 	github.com/vedhavyas/go-subkey/v2 v2.0.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/gridify/go.sum
+++ b/gridify/go.sum
@@ -180,8 +180,7 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00 h1:Q/vkWlTfZBCo4SclrbpSV35sSg/EF2MIIi0LgxPdzCI=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
-github.com/threefoldtech/zosbase v1.0.9 h1:jZ/km4PiOnJHSqpfg4cJRC3k9GE+vzX5LF1MaJnXOoU=
-github.com/threefoldtech/zosbase v1.0.9/go.mod h1:HIDT3p2LZsaUp4TQa5A/AB1MdW0YAPUEaK+lkc3gSsM=
+github.com/threefoldtech/zos_base v1.1.0 h1:WpjxPCzEgHOkMorhkKcpqRKXnsvL4euXOBnR2IdI/AM=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/gridify/go.sum
+++ b/gridify/go.sum
@@ -181,6 +181,7 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00 h1:Q/vkWlTfZBCo4SclrbpSV35sSg/EF2MIIi0LgxPdzCI=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
 github.com/threefoldtech/zos_base v1.1.0 h1:WpjxPCzEgHOkMorhkKcpqRKXnsvL4euXOBnR2IdI/AM=
+github.com/threefoldtech/zos_base v1.1.0/go.mod h1:pVOuEZ6lobb3XPmiZwrzdxahuM29hU7wKqfX+Vih1cI=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/tfrobot/go.mod
+++ b/tfrobot/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.6 // indirect
-	github.com/threefoldtech/zosbase v1.0.9 // indirect
+	github.com/threefoldtech/zos_base v1.1.0 // indirect
 	github.com/vedhavyas/go-subkey/v2 v2.0.0 // indirect
 	go.opentelemetry.io/otel v1.39.0 // indirect
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect

--- a/tfrobot/go.sum
+++ b/tfrobot/go.sum
@@ -152,8 +152,7 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00 h1:Q/vkWlTfZBCo4SclrbpSV35sSg/EF2MIIi0LgxPdzCI=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
-github.com/threefoldtech/zosbase v1.0.9 h1:jZ/km4PiOnJHSqpfg4cJRC3k9GE+vzX5LF1MaJnXOoU=
-github.com/threefoldtech/zosbase v1.0.9/go.mod h1:HIDT3p2LZsaUp4TQa5A/AB1MdW0YAPUEaK+lkc3gSsM=
+github.com/threefoldtech/zos_base v1.1.0 h1:WpjxPCzEgHOkMorhkKcpqRKXnsvL4euXOBnR2IdI/AM=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/tfrobot/go.sum
+++ b/tfrobot/go.sum
@@ -153,6 +153,7 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00 h1:Q/vkWlTfZBCo4SclrbpSV35sSg/EF2MIIi0LgxPdzCI=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
 github.com/threefoldtech/zos_base v1.1.0 h1:WpjxPCzEgHOkMorhkKcpqRKXnsvL4euXOBnR2IdI/AM=
+github.com/threefoldtech/zos_base v1.1.0/go.mod h1:pVOuEZ6lobb3XPmiZwrzdxahuM29hU7wKqfX+Vih1cI=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/user-contracts-mon/go.mod
+++ b/user-contracts-mon/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00 // indirect
 	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0 // indirect
 	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.6 // indirect
-	github.com/threefoldtech/zosbase v1.0.9 // indirect
+	github.com/threefoldtech/zos_base v1.1.0 // indirect
 	github.com/vedhavyas/go-subkey v1.0.3 // indirect
 	github.com/vedhavyas/go-subkey/v2 v2.0.0 // indirect
 	go.opentelemetry.io/otel v1.39.0 // indirect

--- a/user-contracts-mon/go.sum
+++ b/user-contracts-mon/go.sum
@@ -123,6 +123,7 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00 h1:Q/vkWlTfZBCo4SclrbpSV35sSg/EF2MIIi0LgxPdzCI=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
 github.com/threefoldtech/zos_base v1.1.0 h1:WpjxPCzEgHOkMorhkKcpqRKXnsvL4euXOBnR2IdI/AM=
+github.com/threefoldtech/zos_base v1.1.0/go.mod h1:pVOuEZ6lobb3XPmiZwrzdxahuM29hU7wKqfX+Vih1cI=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=

--- a/user-contracts-mon/go.sum
+++ b/user-contracts-mon/go.sum
@@ -122,8 +122,7 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00 h1:Q/vkWlTfZBCo4SclrbpSV35sSg/EF2MIIi0LgxPdzCI=
 github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00/go.mod h1:cOL5YgHUmDG5SAXrsZxFjUECRQQuAqOoqvXhZG5sEUw=
-github.com/threefoldtech/zosbase v1.0.9 h1:jZ/km4PiOnJHSqpfg4cJRC3k9GE+vzX5LF1MaJnXOoU=
-github.com/threefoldtech/zosbase v1.0.9/go.mod h1:HIDT3p2LZsaUp4TQa5A/AB1MdW0YAPUEaK+lkc3gSsM=
+github.com/threefoldtech/zos_base v1.1.0 h1:WpjxPCzEgHOkMorhkKcpqRKXnsvL4euXOBnR2IdI/AM=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=


### PR DESCRIPTION
Repoints the `zosbase` Go dependency to the renamed `github.com/threefoldtech/zos_base@v1.1.0` (threefoldtech/zos_base#119), removing the Go-import dependency on GitHub's rename redirect. This also **unblocks the grid_* consumers** (grid_terraform/pulumi/agent), which currently cannot migrate to zos_base because they share gridtypes with `grid-client` (was still on zosbase → incompatible duplicate types).

**Changed:** `grid-proxy`, `grid-client`, `grid-cli` (imports + `go.mod` `zosbase v1.0.9` -> `zos_base v1.1.0`); `go work sync` propagated the indirect require to `gridify`/`tfrobot`/`user-contracts-mon` and updated `go.work.sum`.

**Validated locally:** `go build ./...` passes for **all 11 workspace modules** (Go 1.25.4) — no API drift.

### ⚠️ Release cascade required for external consumers
The monorepo uses local `replace` directives, so the workspace builds, but **standalone tags** need a consistent set. After merge, re-tag in order and bump inter-module requires: **grid-proxy** -> **grid-client** (require new grid-proxy) -> **grid-cli** (require new grid-client). Only then can grid_terraform/pulumi/agent bump to the new grid-client + zos_base.

**Scope:** this is the `zosbase`->`zos_base` dependency migration only. The `tfgrid-sdk-go`->`zos_sdk_go` module-path rename is separate. Part of #2693.