### PR TITLE
grid-client: require grid-proxy v0.17.7 (zos_base)

### DIFF
--- a/grid-cli/go.mod
+++ b/grid-cli/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/threefoldtech/tfgrid-sdk-go/grid-client v0.15.18
-	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0
+	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.7
 	github.com/threefoldtech/zos_base v1.1.0
 	github.com/vedhavyas/go-subkey v1.0.3
 )

--- a/grid-client/go.mod
+++ b/grid-client/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/sethvargo/go-retry v0.3.0
 	github.com/stretchr/testify v1.11.1
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00
-	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0
+	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.7
 	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.6
 	github.com/threefoldtech/zos_base v1.1.0
 	github.com/vedhavyas/go-subkey v1.0.3

--- a/gridify/go.mod
+++ b/gridify/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/threefoldtech/tfgrid-sdk-go/grid-client v0.15.18
-	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0
+	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.7
 )
 
 require (

--- a/tfrobot/go.mod
+++ b/tfrobot/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00
 	github.com/threefoldtech/tfgrid-sdk-go/grid-client v0.15.18
-	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0
+	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.7
 	github.com/vedhavyas/go-subkey v1.0.3
 	golang.org/x/crypto v0.49.0
 	golang.org/x/sync v0.20.0

--- a/user-contracts-mon/go.mod
+++ b/user-contracts-mon/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00 // indirect
-	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.0 // indirect
+	github.com/threefoldtech/tfgrid-sdk-go/grid-proxy v0.17.7 // indirect
 	github.com/threefoldtech/tfgrid-sdk-go/rmb-sdk-go v0.17.6 // indirect
 	github.com/threefoldtech/zos_base v1.1.0 // indirect
 	github.com/vedhavyas/go-subkey v1.0.3 // indirect


### PR DESCRIPTION
Bumps grid-client's `grid-proxy` require to `v0.17.7` (the tag carrying the zos_base migration). The in-repo local `replace` is ignored by downstream consumers, so this require must point at the new tag — otherwise external repos importing `grid-client` would pull `grid-proxy@v0.17.0` (still zosbase) and hit incompatible duplicate types.

After this merges I will tag `grid-client/v0.17.7`, which unblocks grid_terraform/pulumi/agent. Part of the module-path migration — #2693.