### PR TITLE
Bump inter-submodule requires to v0.18.0 (zos_sdk_go path release)

### DIFF
--- a/farmerbot/go.mod
+++ b/farmerbot/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00
-	github.com/threefoldtech/zos_sdk_go/grid-proxy v0.17.5
-	github.com/threefoldtech/zos_sdk_go/rmb-sdk-go v0.17.6
+	github.com/threefoldtech/zos_sdk_go/grid-proxy v0.18.0
+	github.com/threefoldtech/zos_sdk_go/rmb-sdk-go v0.18.0
 	github.com/vedhavyas/go-subkey v1.0.3
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/grid-cli/go.mod
+++ b/grid-cli/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
-	github.com/threefoldtech/zos_sdk_go/grid-client v0.15.18
-	github.com/threefoldtech/zos_sdk_go/grid-proxy v0.17.7
+	github.com/threefoldtech/zos_sdk_go/grid-client v0.18.0
+	github.com/threefoldtech/zos_sdk_go/grid-proxy v0.18.0
 	github.com/threefoldtech/zos_base v1.1.0
 	github.com/vedhavyas/go-subkey v1.0.3
 )
@@ -49,7 +49,7 @@ require (
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00 // indirect
-	github.com/threefoldtech/zos_sdk_go/rmb-sdk-go v0.17.6 // indirect
+	github.com/threefoldtech/zos_sdk_go/rmb-sdk-go v0.18.0 // indirect
 	github.com/vedhavyas/go-subkey/v2 v2.0.0 // indirect
 	go.opentelemetry.io/otel v1.39.0 // indirect
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect

--- a/grid-client/go.mod
+++ b/grid-client/go.mod
@@ -16,8 +16,8 @@ require (
 	github.com/sethvargo/go-retry v0.3.0
 	github.com/stretchr/testify v1.11.1
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00
-	github.com/threefoldtech/zos_sdk_go/grid-proxy v0.17.7
-	github.com/threefoldtech/zos_sdk_go/rmb-sdk-go v0.17.6
+	github.com/threefoldtech/zos_sdk_go/grid-proxy v0.18.0
+	github.com/threefoldtech/zos_sdk_go/rmb-sdk-go v0.18.0
 	github.com/threefoldtech/zos_base v1.1.0
 	github.com/vedhavyas/go-subkey v1.0.3
 	go.opentelemetry.io/otel v1.39.0

--- a/grid-proxy/go.mod
+++ b/grid-proxy/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/swaggo/http-swagger v1.3.4
 	github.com/swaggo/swag v1.16.4
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00
-	github.com/threefoldtech/zos_sdk_go/rmb-sdk-go v0.17.6
+	github.com/threefoldtech/zos_sdk_go/rmb-sdk-go v0.18.0
 	github.com/threefoldtech/zos_base v1.1.0
 	go.opentelemetry.io/otel v1.39.0
 	go.opentelemetry.io/otel/trace v1.39.0

--- a/gridify/go.mod
+++ b/gridify/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
-	github.com/threefoldtech/zos_sdk_go/grid-client v0.15.18
-	github.com/threefoldtech/zos_sdk_go/grid-proxy v0.17.7
+	github.com/threefoldtech/zos_sdk_go/grid-client v0.18.0
+	github.com/threefoldtech/zos_sdk_go/grid-proxy v0.18.0
 )
 
 require (
@@ -63,7 +63,7 @@ require (
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00 // indirect
-	github.com/threefoldtech/zos_sdk_go/rmb-sdk-go v0.17.6 // indirect
+	github.com/threefoldtech/zos_sdk_go/rmb-sdk-go v0.18.0 // indirect
 	github.com/threefoldtech/zos_base v1.1.0 // indirect
 	github.com/vedhavyas/go-subkey v1.0.3 // indirect
 	github.com/vedhavyas/go-subkey/v2 v2.0.0 // indirect

--- a/monitoring-bot/go.mod
+++ b/monitoring-bot/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/stellar/go v0.0.0-20231121172327-69266de4154f
 	github.com/stretchr/testify v1.11.1
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00
-	github.com/threefoldtech/zos_sdk_go/rmb-sdk-go v0.16.1-0.20241229121208-76ac3fea5e67
+	github.com/threefoldtech/zos_sdk_go/rmb-sdk-go v0.18.0
 )
 
 require (

--- a/tfrobot/go.mod
+++ b/tfrobot/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00
-	github.com/threefoldtech/zos_sdk_go/grid-client v0.15.18
-	github.com/threefoldtech/zos_sdk_go/grid-proxy v0.17.7
+	github.com/threefoldtech/zos_sdk_go/grid-client v0.18.0
+	github.com/threefoldtech/zos_sdk_go/grid-proxy v0.18.0
 	github.com/vedhavyas/go-subkey v1.0.3
 	golang.org/x/crypto v0.49.0
 	golang.org/x/sync v0.20.0
@@ -58,7 +58,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	github.com/threefoldtech/zos_sdk_go/rmb-sdk-go v0.17.6 // indirect
+	github.com/threefoldtech/zos_sdk_go/rmb-sdk-go v0.18.0 // indirect
 	github.com/threefoldtech/zos_base v1.1.0 // indirect
 	github.com/vedhavyas/go-subkey/v2 v2.0.0 // indirect
 	go.opentelemetry.io/otel v1.39.0 // indirect

--- a/user-contracts-mon/go.mod
+++ b/user-contracts-mon/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
 	github.com/hashicorp/go-envparse v0.1.0
-	github.com/threefoldtech/zos_sdk_go/grid-client v0.11.2
+	github.com/threefoldtech/zos_sdk_go/grid-client v0.18.0
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 )
 
@@ -43,8 +43,8 @@ require (
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/threefoldtech/tfchain/clients/tfchain-client-go v0.0.0-20260302124210-526158ffbc00 // indirect
-	github.com/threefoldtech/zos_sdk_go/grid-proxy v0.17.7 // indirect
-	github.com/threefoldtech/zos_sdk_go/rmb-sdk-go v0.17.6 // indirect
+	github.com/threefoldtech/zos_sdk_go/grid-proxy v0.18.0 // indirect
+	github.com/threefoldtech/zos_sdk_go/rmb-sdk-go v0.18.0 // indirect
 	github.com/threefoldtech/zos_base v1.1.0 // indirect
 	github.com/vedhavyas/go-subkey v1.0.3 // indirect
 	github.com/vedhavyas/go-subkey/v2 v2.0.0 // indirect


### PR DESCRIPTION
Prep for tagging the renamed `zos_sdk_go/*` modules at a uniform **v0.18.0**. Sets every inter-submodule require (grid-proxy/grid-client/grid-cli/rmb-sdk-go) to v0.18.0 so that once tags are cut at this commit, external consumers resolve a consistent set (no mix of old tfgrid-sdk-go tags). Local `replace` directives keep in-repo builds green; validated workspace + standalone `go build ./...`.

After merge I will tag rmb-sdk-go/grid-proxy/grid-client/grid-cli @ v0.18.0. Part of #2693.