### PR TITLE
grid-proxy: retry rmb calls for newly found nodes

### DIFF
--- a/grid-proxy/internal/indexer/finders.go
+++ b/grid-proxy/internal/indexer/finders.go
@@ -16,9 +16,9 @@ var (
 	}
 )
 
-type Finder func(context.Context, time.Duration, db.Database, chan uint32)
+type Finder func(context.Context, time.Duration, db.Database, chan task)
 
-func upNodesFinder(ctx context.Context, interval time.Duration, db db.Database, idsChan chan uint32) {
+func upNodesFinder(ctx context.Context, interval time.Duration, db db.Database, idsChan chan task) {
 	ticker := time.NewTicker(interval)
 
 	queryUpNodes(ctx, db, idsChan)
@@ -32,7 +32,7 @@ func upNodesFinder(ctx context.Context, interval time.Duration, db db.Database, 
 	}
 }
 
-func healthyNodesFinder(ctx context.Context, interval time.Duration, db db.Database, idsChan chan uint32) {
+func healthyNodesFinder(ctx context.Context, interval time.Duration, db db.Database, idsChan chan task) {
 	ticker := time.NewTicker(interval)
 
 	queryHealthyNodes(ctx, db, idsChan)
@@ -46,7 +46,7 @@ func healthyNodesFinder(ctx context.Context, interval time.Duration, db db.Datab
 	}
 }
 
-func newNodesFinder(ctx context.Context, interval time.Duration, db db.Database, idsChan chan uint32) {
+func newNodesFinder(ctx context.Context, interval time.Duration, db db.Database, idsChan chan task) {
 	ticker := time.NewTicker(interval)
 	latestCheckedID, err := db.GetLastNodeTwinID(ctx)
 	if err != nil {
@@ -67,7 +67,7 @@ func newNodesFinder(ctx context.Context, interval time.Duration, db db.Database,
 
 			latestCheckedID = newIDs[0]
 			for _, id := range newIDs {
-				idsChan <- id
+				idsChan <- task{id: id, retryable: true}
 			}
 		case <-ctx.Done():
 			return

--- a/grid-proxy/internal/indexer/indexer.go
+++ b/grid-proxy/internal/indexer/indexer.go
@@ -86,56 +86,45 @@ func (i *Indexer[T]) get(ctx context.Context) {
 	for {
 		select {
 		case t := <-i.idChan:
-			// retryable tasks sleep between attempts, so they run off the worker pool.
-			// some indexers run with a single worker and would otherwise stall completely.
-			if t.retryable {
-				go i.handle(ctx, t)
+			res, err := i.work.Get(ctx, i.rmbClient, t.id)
+			if err == nil {
+				i.emit(ctx, t, res)
 				continue
 			}
 
-			i.handle(ctx, t)
+			// only the backoff sleeps leave the worker pool. some indexers run with a
+			// single worker and would otherwise stall for the whole retry window.
+			if t.retryable {
+				go i.retry(ctx, t)
+				continue
+			}
+
+			log.Debug().Err(err).Str("indexer", i.name).Uint32("twinId", t.id).Msg("failed to call")
 		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-func (i *Indexer[T]) handle(ctx context.Context, t task) {
-	res, err := i.call(ctx, t)
-	if err != nil {
-		log.Debug().Err(err).Str("indexer", i.name).Uint32("twinId", t.id).Msg("failed to call")
-		return
-	}
-
-	for _, item := range res {
-		log.Debug().Str("indexer", i.name).Uint32("twinId", t.id).Msgf("response: %+v", item)
-		i.resultChan <- item
-	}
-}
-
-// call queries the node, retrying with exponential backoff for up to retryTimeout. Only new
-// nodes are retried: they are commonly not answerable over rmb right after registration, and
-// would otherwise wait for the next full sweep, which is a whole day for some indexers.
-func (i *Indexer[T]) call(ctx context.Context, t task) ([]T, error) {
-	res, err := i.work.Get(ctx, i.rmbClient, t.id)
-	if err == nil || !t.retryable {
-		return res, err
-	}
-
+// retry re-queries the node with exponential backoff for up to retryTimeout. Only new nodes
+// are retried: they are commonly not answerable over rmb right after registration, and would
+// otherwise wait for the next full sweep, which is a whole day for some indexers.
+func (i *Indexer[T]) retry(ctx context.Context, t task) {
 	deadline := time.Now().Add(retryTimeout)
 	backoff := retryInitialBackoff
 	for time.Now().Add(backoff).Before(deadline) {
-		log.Debug().Err(err).Str("indexer", i.name).Uint32("twinId", t.id).Dur("backoff", backoff).Msg("retrying new node")
+		log.Debug().Str("indexer", i.name).Uint32("twinId", t.id).Dur("backoff", backoff).Msg("retrying new node")
 
 		select {
 		case <-time.After(backoff):
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return
 		}
 
-		res, err = i.work.Get(ctx, i.rmbClient, t.id)
+		res, err := i.work.Get(ctx, i.rmbClient, t.id)
 		if err == nil {
-			return res, nil
+			i.emit(ctx, t, res)
+			return
 		}
 
 		if backoff *= 2; backoff > retryMaxBackoff {
@@ -143,8 +132,18 @@ func (i *Indexer[T]) call(ctx context.Context, t task) ([]T, error) {
 		}
 	}
 
-	log.Warn().Err(err).Str("indexer", i.name).Uint32("twinId", t.id).Msg("giving up on new node")
-	return nil, err
+	log.Warn().Str("indexer", i.name).Uint32("twinId", t.id).Msg("giving up on new node")
+}
+
+func (i *Indexer[T]) emit(ctx context.Context, t task, res []T) {
+	for _, item := range res {
+		log.Debug().Str("indexer", i.name).Uint32("twinId", t.id).Msgf("response: %+v", item)
+		select {
+		case i.resultChan <- item:
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 func (i *Indexer[T]) batch(ctx context.Context) {

--- a/grid-proxy/internal/indexer/indexer.go
+++ b/grid-proxy/internal/indexer/indexer.go
@@ -15,7 +15,20 @@ const (
 	flushingBufferInterval = 60 * time.Second // upsert buffer in db if it didn't reach the batch size
 	newNodesCheckInterval  = 5 * time.Minute
 	batchSize              = 20
+
+	retryInitialBackoff = 30 * time.Second
+	retryMaxBackoff     = 5 * time.Minute
+	retryTimeout        = 20 * time.Minute // how long a new node keeps being retried
 )
+
+// task is a twin id to call. Only tasks from the "new" finder are retryable: a freshly
+// registered node is usually not answerable over rmb yet and has no other chance to be
+// indexed before the next full sweep, while nodes found by the "up"/"healthy" finders are
+// already re-queried every time those finders tick.
+type task struct {
+	id        uint32
+	retryable bool
+}
 
 type Work[T any] interface {
 	Finders() map[string]time.Duration
@@ -28,7 +41,7 @@ type Indexer[T any] struct {
 	work       Work[T]
 	dbClient   db.Database
 	rmbClient  *peer.RpcClient
-	idChan     chan uint32
+	idChan     chan task
 	resultChan chan T
 	batchChan  chan []T
 	workerNum  uint
@@ -47,7 +60,7 @@ func NewIndexer[T any](
 		dbClient:   db,
 		rmbClient:  rmb,
 		workerNum:  worker,
-		idChan:     make(chan uint32),
+		idChan:     make(chan task),
 		resultChan: make(chan T),
 		batchChan:  make(chan []T),
 	}
@@ -72,21 +85,66 @@ func (i *Indexer[T]) Start(ctx context.Context) {
 func (i *Indexer[T]) get(ctx context.Context) {
 	for {
 		select {
-		case id := <-i.idChan:
-			res, err := i.work.Get(ctx, i.rmbClient, id)
-			if err != nil {
-				log.Debug().Err(err).Str("indexer", i.name).Uint32("twinId", id).Msg("failed to call")
+		case t := <-i.idChan:
+			// retryable tasks sleep between attempts, so they run off the worker pool.
+			// some indexers run with a single worker and would otherwise stall completely.
+			if t.retryable {
+				go i.handle(ctx, t)
 				continue
 			}
 
-			for _, item := range res {
-				log.Debug().Str("indexer", i.name).Uint32("twinId", id).Msgf("response: %+v", item)
-				i.resultChan <- item
-			}
+			i.handle(ctx, t)
 		case <-ctx.Done():
 			return
 		}
 	}
+}
+
+func (i *Indexer[T]) handle(ctx context.Context, t task) {
+	res, err := i.call(ctx, t)
+	if err != nil {
+		log.Debug().Err(err).Str("indexer", i.name).Uint32("twinId", t.id).Msg("failed to call")
+		return
+	}
+
+	for _, item := range res {
+		log.Debug().Str("indexer", i.name).Uint32("twinId", t.id).Msgf("response: %+v", item)
+		i.resultChan <- item
+	}
+}
+
+// call queries the node, retrying with exponential backoff for up to retryTimeout. Only new
+// nodes are retried: they are commonly not answerable over rmb right after registration, and
+// would otherwise wait for the next full sweep, which is a whole day for some indexers.
+func (i *Indexer[T]) call(ctx context.Context, t task) ([]T, error) {
+	res, err := i.work.Get(ctx, i.rmbClient, t.id)
+	if err == nil || !t.retryable {
+		return res, err
+	}
+
+	deadline := time.Now().Add(retryTimeout)
+	backoff := retryInitialBackoff
+	for time.Now().Add(backoff).Before(deadline) {
+		log.Debug().Err(err).Str("indexer", i.name).Uint32("twinId", t.id).Dur("backoff", backoff).Msg("retrying new node")
+
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+
+		res, err = i.work.Get(ctx, i.rmbClient, t.id)
+		if err == nil {
+			return res, nil
+		}
+
+		if backoff *= 2; backoff > retryMaxBackoff {
+			backoff = retryMaxBackoff
+		}
+	}
+
+	log.Warn().Err(err).Str("indexer", i.name).Uint32("twinId", t.id).Msg("giving up on new node")
+	return nil, err
 }
 
 func (i *Indexer[T]) batch(ctx context.Context) {

--- a/grid-proxy/internal/indexer/utils.go
+++ b/grid-proxy/internal/indexer/utils.go
@@ -9,7 +9,7 @@ import (
 	"github.com/threefoldtech/zos_sdk_go/rmb-sdk-go/peer"
 )
 
-func queryUpNodes(ctx context.Context, database db.Database, nodeTwinIdChan chan uint32) {
+func queryUpNodes(ctx context.Context, database db.Database, nodeTwinIdChan chan task) {
 	filter := types.NodeFilter{
 		Status: []string{"up"},
 	}
@@ -26,21 +26,21 @@ func queryUpNodes(ctx context.Context, database db.Database, nodeTwinIdChan chan
 		}
 
 		for _, node := range nodes {
-			nodeTwinIdChan <- uint32(node.TwinID)
+			nodeTwinIdChan <- task{id: uint32(node.TwinID)}
 		}
 
 		limit.Page++
 	}
 }
 
-func queryHealthyNodes(ctx context.Context, database db.Database, nodeTwinIdChan chan uint32) {
+func queryHealthyNodes(ctx context.Context, database db.Database, nodeTwinIdChan chan task) {
 	ids, err := database.GetHealthyNodeTwinIds(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to query healthy nodes")
 	}
 
 	for _, id := range ids {
-		nodeTwinIdChan <- id
+		nodeTwinIdChan <- task{id: id}
 	}
 }
 


### PR DESCRIPTION
New nodes are often not answerable over rmb right after registration, so they were skipped until the next full sweep. Retry them with exponential backoff, off the worker pool so single-worker indexers do not stall.
