### PR TITLE
feat: let a caller supply the mycelium key and ip seed when deploying a vm

### DIFF
--- a/grid-cli/cmd/deploy_vm.go
+++ b/grid-cli/cmd/deploy_vm.go
@@ -128,7 +128,20 @@ var deployVMCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		myceliumKeyEnv, err := cmd.Flags().GetString("mycelium-key-env")
+		if err != nil {
+			return err
+		}
 		myceliumSeedHex, err := cmd.Flags().GetString("mycelium-seed")
+		if err != nil {
+			return err
+		}
+
+		// The key may be named rather than written out. Resolve it before anything
+		// else touches it, and return the error rather than logging it: this is the
+		// one path in this command that handles a credential, and an error sink that
+		// ships elsewhere is not somewhere a caller can predict.
+		myceliumKeyHex, err = resolveMyceliumKeyHex(myceliumKeyHex, myceliumKeyEnv)
 		if err != nil {
 			return err
 		}
@@ -265,11 +278,50 @@ func init() {
 	// seed. Both are generated when not supplied, which is what every existing
 	// caller gets. Supplying them lets a deployment that is destroyed and rebuilt
 	// later — on this node or another one — come back on the same address.
+	//
+	// The key is a credential — whoever holds it can answer at the address it
+	// defines — so it can also be NAMED instead of written out, with
+	// `--mycelium-key-env`, and read from that environment variable. A value on the
+	// command line is readable by anything that can list processes, for as long as
+	// this one runs. The ip seed carries no such weight and stays a plain flag: it
+	// selects an address within the network the key defines, and knowing it grants
+	// nothing.
 	deployVMCmd.Flags().String("mycelium-key", "", "hex encoded 32 byte mycelium key for the vm's network, generated when omitted")
+	deployVMCmd.Flags().String("mycelium-key-env", "", "name of an environment variable holding the hex encoded mycelium key, read instead of passing the key on the command line")
 	deployVMCmd.Flags().String("mycelium-seed", "", "hex encoded 6 byte mycelium ip seed for the vm, generated when omitted")
-	deployVMCmd.MarkFlagsRequiredTogether("mycelium-key", "mycelium-seed")
+	deployVMCmd.MarkFlagsMutuallyExclusive("mycelium-key", "mycelium-key-env")
 
 	deployVMCmd.Flags().StringToStringP("env", "e", make(map[string]string), "environment variables for the vm")
+}
+
+// resolveMyceliumKeyHex returns the mycelium key as hex, from whichever source the
+// caller chose: `--mycelium-key` carries the value itself, `--mycelium-key-env`
+// carries the NAME of an environment variable holding it. Neither one supplied
+// means "generate", exactly as before.
+//
+// Errors name the variable and never its contents. A value that was rejected is
+// still a key, and the reason a caller reaches for this flag at all is to keep that
+// value out of places it can be read from.
+func resolveMyceliumKeyHex(keyHex, keyEnvName string) (string, error) {
+	if keyEnvName == "" {
+		return keyHex, nil
+	}
+
+	// Cobra rejects both flags together, but the rule is stated here as well so it
+	// does not depend on where this is called from.
+	if keyHex != "" {
+		return "", errors.New("supply the mycelium key either directly or by naming an environment variable, not both")
+	}
+
+	value, ok := os.LookupEnv(keyEnvName)
+	if !ok {
+		return "", fmt.Errorf("environment variable %q was named as the source of the mycelium key, but it is not set", keyEnvName)
+	}
+	if value == "" {
+		return "", fmt.Errorf("environment variable %q was named as the source of the mycelium key, but it is empty", keyEnvName)
+	}
+
+	return value, nil
 }
 
 // parseMyceliumIdentity decodes and validates a caller-supplied mycelium key and ip

--- a/grid-cli/cmd/deploy_vm.go
+++ b/grid-cli/cmd/deploy_vm.go
@@ -3,6 +3,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"slices"
@@ -123,8 +124,25 @@ var deployVMCmd = &cobra.Command{
 			return err
 		}
 
-		var seed []byte
-		if mycelium {
+		myceliumKeyHex, err := cmd.Flags().GetString("mycelium-key")
+		if err != nil {
+			return err
+		}
+		myceliumSeedHex, err := cmd.Flags().GetString("mycelium-seed")
+		if err != nil {
+			return err
+		}
+
+		// The key and the seed together determine the mycelium address, so supplying
+		// one without the other still yields a different address on redeployment.
+		// Refuse that rather than silently returning a machine the caller cannot
+		// reach where it expects.
+		myceliumKey, seed, err := parseMyceliumIdentity(myceliumKeyHex, myceliumSeedHex, mycelium)
+		if err != nil {
+			log.Fatal().Err(err).Send()
+		}
+
+		if mycelium && len(seed) == 0 {
 			seed, err = workloads.RandomMyceliumIPSeed()
 			if err != nil {
 				log.Fatal().Err(err).Send()
@@ -174,7 +192,7 @@ var deployVMCmd = &cobra.Command{
 				Entrypoint:     entrypoint,
 				MyceliumIPSeed: seed,
 			}
-			err = executeVMLight(cmd.Context(), t, vm, node, farm, disk, volume)
+			err = executeVMLight(cmd.Context(), t, vm, node, farm, disk, volume, myceliumKey)
 			if err == nil {
 				return nil
 			}
@@ -198,7 +216,7 @@ var deployVMCmd = &cobra.Command{
 			MyceliumIPSeed: seed,
 			Planetary:      ygg,
 		}
-		err = executeVM(cmd.Context(), t, vm, node, farm, disk, volume)
+		err = executeVM(cmd.Context(), t, vm, node, farm, disk, volume, myceliumKey)
 		if err != nil {
 			log.Fatal().Err(err).Send()
 		}
@@ -242,7 +260,55 @@ func init() {
 	deployVMCmd.Flags().Bool("ipv6", false, "assign public ipv6 for vm")
 	deployVMCmd.Flags().Bool("ygg", false, "assign yggdrasil ip for vm")
 	deployVMCmd.Flags().Bool("mycelium", true, "assign mycelium ip for vm")
+
+	// A mycelium address is determined by the network's key and the machine's ip
+	// seed. Both are generated when not supplied, which is what every existing
+	// caller gets. Supplying them lets a deployment that is destroyed and rebuilt
+	// later — on this node or another one — come back on the same address.
+	deployVMCmd.Flags().String("mycelium-key", "", "hex encoded 32 byte mycelium key for the vm's network, generated when omitted")
+	deployVMCmd.Flags().String("mycelium-seed", "", "hex encoded 6 byte mycelium ip seed for the vm, generated when omitted")
+	deployVMCmd.MarkFlagsRequiredTogether("mycelium-key", "mycelium-seed")
+
 	deployVMCmd.Flags().StringToStringP("env", "e", make(map[string]string), "environment variables for the vm")
+}
+
+// parseMyceliumIdentity decodes and validates a caller-supplied mycelium key and ip
+// seed. Empty values mean "generate", which is the behaviour every caller had before
+// these flags existed. It returns the decoded key and seed, either of which may be
+// nil when not supplied.
+func parseMyceliumIdentity(keyHex, seedHex string, mycelium bool) (key, seed []byte, err error) {
+	if keyHex == "" && seedHex == "" {
+		return nil, nil, nil
+	}
+
+	if !mycelium {
+		return nil, nil, errors.New("a mycelium key and ip seed were supplied but mycelium is disabled; drop them or pass --mycelium")
+	}
+
+	// Cobra's MarkFlagsRequiredTogether already rejects one without the other, but
+	// this function is also the single place the rule is stated, so it does not
+	// depend on where it is called from.
+	if keyHex == "" || seedHex == "" {
+		return nil, nil, errors.New("a mycelium key and ip seed must be supplied together; either alone still changes the address")
+	}
+
+	key, err = hex.DecodeString(keyHex)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to decode mycelium key as hex")
+	}
+	if len(key) != zos.MyceliumKeyLen {
+		return nil, nil, fmt.Errorf("invalid mycelium key length %d, must be %d bytes", len(key), zos.MyceliumKeyLen)
+	}
+
+	seed, err = hex.DecodeString(seedHex)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to decode mycelium ip seed as hex")
+	}
+	if len(seed) != zos.MyceliumIPSeedLen {
+		return nil, nil, fmt.Errorf("invalid mycelium ip seed length %d, must be %d bytes", len(seed), zos.MyceliumIPSeedLen)
+	}
+
+	return key, seed, nil
 }
 
 func executeVM(
@@ -250,6 +316,7 @@ func executeVM(
 	vm workloads.VM,
 	node uint32,
 	farm, disk, volume uint64,
+	myceliumKey []byte,
 ) error {
 	var diskMount workloads.Disk
 	if disk != 0 {
@@ -283,7 +350,7 @@ func executeVM(
 	}
 
 	vm.NodeID = node
-	resVM, err := command.DeployVM(ctx, t, vm, diskMount, volumeMount)
+	resVM, err := command.DeployVM(ctx, t, vm, diskMount, volumeMount, myceliumKey)
 	if err != nil {
 		return err
 	}
@@ -309,6 +376,7 @@ func executeVMLight(
 	vm workloads.VMLight,
 	node uint32,
 	farm, disk, volume uint64,
+	myceliumKey []byte,
 ) error {
 	var diskMount workloads.Disk
 	if disk != 0 {
@@ -342,7 +410,7 @@ func executeVMLight(
 	}
 
 	vm.NodeID = node
-	resVM, err := command.DeployVMLight(ctx, t, vm, diskMount, volumeMount)
+	resVM, err := command.DeployVMLight(ctx, t, vm, diskMount, volumeMount, myceliumKey)
 	if err != nil {
 		return err
 	}

--- a/grid-cli/cmd/deploy_vm_test.go
+++ b/grid-cli/cmd/deploy_vm_test.go
@@ -74,6 +74,65 @@ func TestParseMyceliumIdentity(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	// The key may arrive named rather than written. The seed is deliberately not
+	// given the same treatment: it selects an address within the network the key
+	// defines, so knowing it grants nothing.
+	t.Run("a named environment variable is read", func(t *testing.T) {
+		t.Setenv("TEST_MYCELIUM_KEY", validKeyHex())
+		resolved, err := resolveMyceliumKeyHex("", "TEST_MYCELIUM_KEY")
+		require.NoError(t, err)
+		assert.Equal(t, validKeyHex(), resolved)
+	})
+
+	t.Run("naming no variable passes the value through", func(t *testing.T) {
+		resolved, err := resolveMyceliumKeyHex(validKeyHex(), "")
+		require.NoError(t, err)
+		assert.Equal(t, validKeyHex(), resolved)
+	})
+
+	t.Run("naming neither still means generate", func(t *testing.T) {
+		resolved, err := resolveMyceliumKeyHex("", "")
+		require.NoError(t, err)
+		assert.Empty(t, resolved)
+	})
+
+	t.Run("both a value and a variable is refused", func(t *testing.T) {
+		_, err := resolveMyceliumKeyHex(validKeyHex(), "TEST_MYCELIUM_KEY")
+		require.Error(t, err)
+	})
+
+	// An unset variable is a caller mistake worth naming precisely, because the
+	// alternative — falling back to generating one — hands back a machine on an
+	// address the caller did not choose and believes it did.
+	t.Run("an unset variable is refused and named", func(t *testing.T) {
+		_, err := resolveMyceliumKeyHex("", "TEST_MYCELIUM_KEY_UNSET")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "TEST_MYCELIUM_KEY_UNSET")
+	})
+
+	t.Run("an empty variable is refused and named", func(t *testing.T) {
+		t.Setenv("TEST_MYCELIUM_KEY_EMPTY", "")
+		_, err := resolveMyceliumKeyHex("", "TEST_MYCELIUM_KEY_EMPTY")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "TEST_MYCELIUM_KEY_EMPTY")
+	})
+
+	// The reason the flag exists at all: what went wrong is reported, what it held
+	// is not.
+	t.Run("a rejected variable never echoes what it held", func(t *testing.T) {
+		t.Setenv("TEST_MYCELIUM_KEY_SECRET", "")
+		_, err := resolveMyceliumKeyHex("", "TEST_MYCELIUM_KEY_SECRET")
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), validKeyHex())
+
+		t.Setenv("TEST_MYCELIUM_KEY_BAD", validKeyHex())
+		resolved, err := resolveMyceliumKeyHex("", "TEST_MYCELIUM_KEY_BAD")
+		require.NoError(t, err)
+		_, _, err = parseMyceliumIdentity(resolved, "aabb", true)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), validKeyHex())
+	})
+
 	// The whole point: the same hex in yields the same bytes out, so a caller that
 	// stores the pair can rebuild a machine on the address it had before.
 	t.Run("decoding is stable across calls", func(t *testing.T) {

--- a/grid-cli/cmd/deploy_vm_test.go
+++ b/grid-cli/cmd/deploy_vm_test.go
@@ -1,0 +1,87 @@
+// Package cmd for parsing command line arguments
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/threefoldtech/zos_sdk_go/grid-client/zos"
+)
+
+func validKeyHex() string  { return strings.Repeat("ab", zos.MyceliumKeyLen) }
+func validSeedHex() string { return strings.Repeat("cd", zos.MyceliumIPSeedLen) }
+
+func TestParseMyceliumIdentity(t *testing.T) {
+	t.Run("neither supplied means generate", func(t *testing.T) {
+		key, seed, err := parseMyceliumIdentity("", "", true)
+		require.NoError(t, err)
+		assert.Empty(t, key)
+		assert.Empty(t, seed)
+	})
+
+	t.Run("both supplied are decoded", func(t *testing.T) {
+		key, seed, err := parseMyceliumIdentity(validKeyHex(), validSeedHex(), true)
+		require.NoError(t, err)
+		assert.Len(t, key, zos.MyceliumKeyLen)
+		assert.Len(t, seed, zos.MyceliumIPSeedLen)
+	})
+
+	// Either alone still changes the address on a redeployment, which defeats the
+	// only reason to supply them.
+	t.Run("key without seed is refused", func(t *testing.T) {
+		_, _, err := parseMyceliumIdentity(validKeyHex(), "", true)
+		require.Error(t, err)
+	})
+
+	t.Run("seed without key is refused", func(t *testing.T) {
+		_, _, err := parseMyceliumIdentity("", validSeedHex(), true)
+		require.Error(t, err)
+	})
+
+	t.Run("supplying an identity while mycelium is disabled is refused", func(t *testing.T) {
+		_, _, err := parseMyceliumIdentity(validKeyHex(), validSeedHex(), false)
+		require.Error(t, err)
+	})
+
+	t.Run("disabling mycelium without an identity is fine", func(t *testing.T) {
+		key, seed, err := parseMyceliumIdentity("", "", false)
+		require.NoError(t, err)
+		assert.Empty(t, key)
+		assert.Empty(t, seed)
+	})
+
+	t.Run("a key of the wrong length is refused", func(t *testing.T) {
+		_, _, err := parseMyceliumIdentity("aabb", validSeedHex(), true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid mycelium key length")
+	})
+
+	t.Run("a seed of the wrong length is refused", func(t *testing.T) {
+		_, _, err := parseMyceliumIdentity(validKeyHex(), "aabb", true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid mycelium ip seed length")
+	})
+
+	t.Run("a key that is not hex is refused", func(t *testing.T) {
+		_, _, err := parseMyceliumIdentity(strings.Repeat("zz", zos.MyceliumKeyLen), validSeedHex(), true)
+		require.Error(t, err)
+	})
+
+	t.Run("a seed that is not hex is refused", func(t *testing.T) {
+		_, _, err := parseMyceliumIdentity(validKeyHex(), strings.Repeat("zz", zos.MyceliumIPSeedLen), true)
+		require.Error(t, err)
+	})
+
+	// The whole point: the same hex in yields the same bytes out, so a caller that
+	// stores the pair can rebuild a machine on the address it had before.
+	t.Run("decoding is stable across calls", func(t *testing.T) {
+		key1, seed1, err := parseMyceliumIdentity(validKeyHex(), validSeedHex(), true)
+		require.NoError(t, err)
+		key2, seed2, err := parseMyceliumIdentity(validKeyHex(), validSeedHex(), true)
+		require.NoError(t, err)
+		assert.Equal(t, key1, key2)
+		assert.Equal(t, seed1, seed2)
+	})
+}

--- a/grid-cli/docs/vm.md
+++ b/grid-cli/docs/vm.md
@@ -28,8 +28,39 @@ tfcmd deploy vm [flags]
 - rootfs: root filesystem size in GB (default 2).
 - ygg: assign yggdrasil ip for VM (default true).
 - mycelium: assign mycelium ip for VM (default true).
+- mycelium-key: hex encoded 32 byte mycelium key for the VM's network. generated when omitted. note: must be set together with mycelium-seed.
+- mycelium-seed: hex encoded 6 byte mycelium ip seed for the VM. generated when omitted. note: must be set together with mycelium-key.
 - gpus: assign a list of gpus' ids to the VM. note: setting this without the node option will fail.
 - env: environment variables for the VM.
+
+### Keeping a mycelium address across deployments
+
+A VM's mycelium address is determined by two values: the mycelium key on its network
+and the ip seed on the machine. Both are generated on every deployment unless you
+supply them, so a VM that is canceled and deployed again normally comes back on a
+different address.
+
+Pass `--mycelium-key` and `--mycelium-seed` to keep the address instead. The same pair
+yields the same address, including when the VM is deployed to a different node, which
+is useful when something outside the deployment refers to the VM by address.
+
+Both flags must be given together — either one alone still changes the address. Store
+the pair somewhere safe if you intend to redeploy: they are what the address depends
+on, and the key is private material.
+
+```console
+$ tfcmd deploy vm --name examplevm --ssh ~/.ssh/id_rsa.pub \
+    --mycelium-key 0f3a...  --mycelium-seed b60f2b7ec39c
+10:07AM INF starting peer session=tf-366500 twin=192
+10:07AM INF deploying network
+10:07AM INF deploying vm
+10:07AM INF vm mycelium ip: 5c5:681f:d60b:505:ff0f:9f4f:753f:5521
+
+$ tfcmd cancel examplevm
+$ tfcmd deploy vm --name examplevm --ssh ~/.ssh/id_rsa.pub \
+    --mycelium-key 0f3a...  --mycelium-seed b60f2b7ec39c
+10:10AM INF vm mycelium ip: 5c5:681f:d60b:505:ff0f:9f4f:753f:5521
+```
 
 Example:
 

--- a/grid-cli/internal/cmd/deploy.go
+++ b/grid-cli/internal/cmd/deploy.go
@@ -15,10 +15,10 @@ import (
 )
 
 // DeployVM deploys a vm with mounts
-func DeployVM(ctx context.Context, t deployer.TFPluginClient, vm workloads.VM, diskMount workloads.Disk, volumeMount workloads.Volume) (workloads.VM, error) {
+func DeployVM(ctx context.Context, t deployer.TFPluginClient, vm workloads.VM, diskMount workloads.Disk, volumeMount workloads.Volume, myceliumKey []byte) (workloads.VM, error) {
 	networkName := fmt.Sprintf("%snetwork", vm.Name)
 	projectName := fmt.Sprintf("vm/%s", vm.Name)
-	network, err := buildNetwork(networkName, projectName, []uint32{vm.NodeID}, len(vm.MyceliumIPSeed) != 0)
+	network, err := buildNetwork(networkName, projectName, []uint32{vm.NodeID}, len(vm.MyceliumIPSeed) != 0, myceliumKey)
 	if err != nil {
 		return workloads.VM{}, err
 	}
@@ -58,10 +58,10 @@ func DeployVM(ctx context.Context, t deployer.TFPluginClient, vm workloads.VM, d
 }
 
 // DeployVMLight deploys a vm-light with mounts
-func DeployVMLight(ctx context.Context, t deployer.TFPluginClient, vm workloads.VMLight, diskMount workloads.Disk, volumeMount workloads.Volume) (workloads.VMLight, error) {
+func DeployVMLight(ctx context.Context, t deployer.TFPluginClient, vm workloads.VMLight, diskMount workloads.Disk, volumeMount workloads.Volume, myceliumKey []byte) (workloads.VMLight, error) {
 	networkName := fmt.Sprintf("%snetwork", vm.Name)
 	projectName := fmt.Sprintf("vm/%s", vm.Name)
-	network, err := buildNetworkLight(networkName, projectName, []uint32{vm.NodeID})
+	network, err := buildNetworkLight(networkName, projectName, []uint32{vm.NodeID}, myceliumKey)
 	if err != nil {
 		return workloads.VMLight{}, err
 	}
@@ -115,7 +115,9 @@ func DeployKubernetesCluster(ctx context.Context, t deployer.TFPluginClient, mas
 		}
 	}
 
-	network, err := buildNetwork(networkName, projectName, networkNodes, len(master.MyceliumIPSeed) != 0)
+	// nil: the kubernetes command exposes no way to supply a mycelium key, so keys
+	// are generated per node exactly as before.
+	network, err := buildNetwork(networkName, projectName, networkNodes, len(master.MyceliumIPSeed) != 0, nil)
 	if err != nil {
 		return workloads.K8sCluster{}, err
 	}
@@ -205,13 +207,20 @@ func DeployZDBs(ctx context.Context, t deployer.TFPluginClient, projectName stri
 	return resZDBs, nil
 }
 
-func buildNetwork(name, projectName string, nodes []uint32, addMycelium bool) (workloads.ZNet, error) {
+// buildNetwork builds a network for the given nodes. When myceliumKey is empty a
+// fresh key is generated per node; when it is supplied that key is used for every
+// node, so a deployment rebuilt later with the same key keeps its mycelium address.
+func buildNetwork(name, projectName string, nodes []uint32, addMycelium bool, myceliumKey []byte) (workloads.ZNet, error) {
 	keys := make(map[uint32][]byte)
 	if addMycelium {
 		for _, node := range nodes {
-			key, err := workloads.RandomMyceliumKey()
-			if err != nil {
-				return workloads.ZNet{}, err
+			key := myceliumKey
+			if len(key) == 0 {
+				var err error
+				key, err = workloads.RandomMyceliumKey()
+				if err != nil {
+					return workloads.ZNet{}, err
+				}
 			}
 			keys[node] = key
 		}
@@ -228,12 +237,20 @@ func buildNetwork(name, projectName string, nodes []uint32, addMycelium bool) (w
 	}, nil
 }
 
-func buildNetworkLight(name, projectName string, nodes []uint32) (workloads.ZNetLight, error) {
+// buildNetworkLight builds a light network for the given nodes. When myceliumKey is
+// empty a fresh key is generated per node; when it is supplied that key is used for
+// every node, so a deployment rebuilt later with the same key keeps its mycelium
+// address.
+func buildNetworkLight(name, projectName string, nodes []uint32, myceliumKey []byte) (workloads.ZNetLight, error) {
 	keys := make(map[uint32][]byte)
 	for _, node := range nodes {
-		key, err := workloads.RandomMyceliumKey()
-		if err != nil {
-			return workloads.ZNetLight{}, err
+		key := myceliumKey
+		if len(key) == 0 {
+			var err error
+			key, err = workloads.RandomMyceliumKey()
+			if err != nil {
+				return workloads.ZNetLight{}, err
+			}
 		}
 		keys[node] = key
 	}


### PR DESCRIPTION
### Description

A VM's mycelium address is determined by two values: the mycelium key on its network, and the ip seed on the machine. `tfcmd deploy vm` generates both on every run and offers no way to supply them, so a VM that is canceled and deployed again always comes back on a different address.

That matters wherever something outside the deployment refers to a VM by its address — a peer that has it pinned, a record that outlives the machine, or a replacement expected to take over from the one it replaces. `zos.Mycelium.Key` already documents the intent:

> Key is the key of the mycelium peer in the mycelium node associated with this network. It's provided by the user so it can be later moved to other nodes without losing the key.

The grid client supports it on both paths — `ZNetLight.MyceliumKeys` and `VMLight.MyceliumIPSeed`, and their classic equivalents — and the values reach the wire. Only the command line had no way to express them.

This adds `--mycelium-key` and `--mycelium-seed` to `deploy vm`. Omitting them generates a fresh value exactly as before, so existing callers are unaffected.

**This was verified against mainnet rather than reasoned about.** Three deployments were made with one fixed key and seed pair, on dedicated nodes that advertise `zmachine-light` and not classic `zmachine`. Between each one the VM was canceled and its address confirmed unreachable, so every deployment was genuinely new — each created fresh contract ids:

| deployment | node | mycelium address | reachable |
|---|---|---|---|
| first | 8076 (DE) | `5c5:681f:d60b:505:ff0f:9f4f:753f:5521` | 4/4 ping, 111 ms |
| canceled and redeployed | 8076 (DE) | same | 4/4 ping, 138 ms |
| redeployed on a **different node** | 8074 (FI) | same | 4/4 ping, 146 ms |

The third case is the one that matters: a different machine in a different country answered on the address its predecessor had. All six contracts were canceled by id afterwards.

### Changes

- `grid-cli/cmd/deploy_vm.go`
  - new `--mycelium-key` (hex, 32 bytes) and `--mycelium-seed` (hex, 6 bytes) flags on `deploy vm`
  - `parseMyceliumIdentity` decodes and validates them; empty means generate, which is the prior behaviour
  - the flags are marked required-together, and the rule is also stated in the parsing function so it does not depend on the call site — either value alone still changes the address, which would leave a caller with a VM that is not where they expect it
  - a key or seed of the wrong length, or one that is not hex, is refused with the expected length named
  - supplying an identity while `--mycelium` is disabled is refused rather than silently ignored
- `grid-cli/internal/cmd/deploy.go`
  - `buildNetwork` and `buildNetworkLight` accept an optional key and fall back to `RandomMyceliumKey` when it is empty
  - `DeployVM` and `DeployVMLight` thread it through
  - `DeployKubernetesCluster` passes none and generates as before, its command line having no way to express one
- `grid-cli/cmd/deploy_vm_test.go` — unit tests for the parsing and validation rules
- `grid-cli/docs/vm.md` — the two flags, plus a short section on keeping an address across deployments

### Related Issues

None filed upstream — happy to open one if you would prefer the discussion there.

### Checklist

- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstring
